### PR TITLE
fix: load equipment for default gym in workouts screen

### DIFF
--- a/app/(tabs)/workouts.tsx
+++ b/app/(tabs)/workouts.tsx
@@ -12,6 +12,7 @@ import {
 import { useRouter } from 'expo-router';
 import { useWorkoutStore } from '@/stores/workoutStore';
 import { useEquipmentStore } from '@/stores/equipmentStore';
+import { useGymStore } from '@/stores/gymStore';
 import { useTheme } from '@/theme';
 import type { WorkoutTemplate } from '@/types';
 
@@ -21,13 +22,21 @@ export default function WorkoutsScreen() {
   const { workouts, loadWorkouts, removeWorkout, searchWorkouts, error, clearError } =
     useWorkoutStore();
   const { equipment, loadEquipment, getAvailableEquipmentNames } = useEquipmentStore();
+  const { defaultGym, loadGyms } = useGymStore();
   const [searchQuery, setSearchQuery] = useState('');
   const [filterByEquipment, setFilterByEquipment] = useState(false);
 
   useEffect(() => {
     loadWorkouts();
-    loadEquipment();
+    loadGyms();
   }, []);
+
+  // Load equipment when default gym changes
+  useEffect(() => {
+    if (defaultGym) {
+      loadEquipment(defaultGym.id);
+    }
+  }, [defaultGym?.id]);
 
   useEffect(() => {
     if (error) {


### PR DESCRIPTION
## Summary

This PR fixes a TypeScript type error in the workouts screen that was preventing the build from passing.

**Note:** The requirements for li-9qf (multi-gym support with preset equipment lists) were already fully implemented in commit b390aa0. This PR addresses a type error discovered during verification.

## Changes

- Fix `loadEquipment()` call in `app/(tabs)/workouts.tsx` to pass required `gymId` parameter
- Import and use `gymStore` to access default gym
- Load equipment when default gym changes using proper `useEffect` pattern
- Follows same pattern as `app/modal/import.tsx` for consistency

## Type Error Fixed

```
app/(tabs)/workouts.tsx(29,5): error TS2554: Expected 1 arguments, but got 0.
```

The `loadEquipment` function requires a `gymId` parameter, but was being called without one.

## Verification

- ✅ All 506 tests pass
- ✅ TypeScript typecheck passes
- ✅ Equipment filtering works correctly with multi-gym system

## Related Work

Requirements for li-9qf:
1. ✅ Multiple gym locations - Implemented in b390aa0
2. ✅ Preset equipment checklist - Implemented in b390aa0
3. ✅ Default gym selection & AI integration - Implemented in b390aa0

🤖 Generated with [Claude Code](https://claude.com/claude-code)