### PR TITLE
chore(ios): bump GRDB 6.29.3 → 7.10.0

### DIFF
--- a/mobile-apps/ios/LiftMark.xcodeproj/project.pbxproj
+++ b/mobile-apps/ios/LiftMark.xcodeproj/project.pbxproj
@@ -1431,7 +1431,7 @@
 			repositoryURL = "https://github.com/groue/GRDB.swift.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 6.24.0;
+				minimumVersion = 7.10.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/mobile-apps/ios/LiftMark.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/mobile-apps/ios/LiftMark.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/groue/GRDB.swift.git",
       "state" : {
-        "revision" : "2cf6c756e1e5ef6901ebae16576a7e4e4b834622",
-        "version" : "6.29.3"
+        "revision" : "36e30a6f1ef10e4194f6af0cff90888526f0c115",
+        "version" : "7.10.0"
       }
     }
   ],

--- a/mobile-apps/ios/project.yml
+++ b/mobile-apps/ios/project.yml
@@ -16,7 +16,7 @@ settings:
 packages:
   GRDB:
     url: https://github.com/groue/GRDB.swift.git
-    from: "6.24.0"
+    from: "7.10.0"
 
 targets:
   LiftMark:


### PR DESCRIPTION
## Summary
- Bumps GRDB.swift from 6.29.3 to 7.10.0 in the iOS app.
- Updates `project.yml` SemVer constraint (`from: \"6.24.0\"` → `from: \"7.10.0\"`), which is what xcodegen actually reads — dependabot's #48 only touched `Package.resolved`, which gets clobbered on every regen.

## Why this replaces #48
#48 was effectively a no-op: `xcodegen generate` (run on every build, including CI) resolves `project.yml`'s `from: \"6.24.0\"` constraint, overwriting the Package.resolved bump back to 6.29.3. The green Swift CI on #48 was testing against 6.29.3, not 7.10.0.

## Local validation (against 7.10.0)
- Build: clean
- Unit tests: **692/692 pass**
- UI tests: **15/15 pass**  (iPhone 17 Pro / iOS 26.0, ~19min)

## Breaking-change risk: low
GRDB 7 major changes don't apply to us — we don't use FTS5, SQLCipher, `DatabaseMigrator`, snapshots, UPSERT, or `ValueObservation`. Surface area is Row CRUD + raw SQL migrations. Swift 6.1+ requirement is satisfied by Xcode 26.

## Follow-up
Filed #79 to investigate whether we should migrate our hand-rolled schema-versioning to GRDB's `DatabaseMigrator`.

## Test plan
- [ ] Swift CI green (this time actually on 7.10.0)
- [ ] GitGuardian green

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)