### PR TITLE
ci: three-ring release pipeline (Beta → Pre-flight → App Store)

### DIFF
--- a/.github/scripts/asc-client.mjs
+++ b/.github/scripts/asc-client.mjs
@@ -1,0 +1,241 @@
+// App Store Connect API client. Shared by attach-to-group, promote-preflight, promote-production.
+//
+// Env required:
+//   ASC_KEY_ID        — 10-char key identifier from App Store Connect
+//   ASC_ISSUER_ID     — issuer UUID
+//   ASC_KEY_PATH      — path to the .p8 private key file
+//
+// Docs: https://developer.apple.com/documentation/appstoreconnectapi
+
+import { readFileSync } from 'node:fs';
+import { createSign } from 'node:crypto';
+import { homedir } from 'node:os';
+
+const API_BASE = 'https://api.appstoreconnect.apple.com/v1';
+
+function expandPath(p) {
+  return p.startsWith('~') ? p.replace('~', homedir()) : p;
+}
+
+function makeJwt() {
+  const keyId = required('ASC_KEY_ID');
+  const issuerId = required('ASC_ISSUER_ID');
+  const keyPath = expandPath(required('ASC_KEY_PATH'));
+  const privateKey = readFileSync(keyPath, 'utf8');
+
+  const header = { alg: 'ES256', kid: keyId, typ: 'JWT' };
+  const now = Math.floor(Date.now() / 1000);
+  const payload = {
+    iss: issuerId,
+    iat: now,
+    exp: now + 1200,
+    aud: 'appstoreconnect-v1',
+  };
+
+  const b64 = (obj) => Buffer.from(JSON.stringify(obj)).toString('base64url');
+  const signingInput = `${b64(header)}.${b64(payload)}`;
+  const signer = createSign('SHA256');
+  signer.update(signingInput);
+  const signature = signer.sign(privateKey).toString('base64url');
+  return `${signingInput}.${signature}`;
+}
+
+export function required(name) {
+  const v = process.env[name];
+  if (!v) throw new Error(`Missing required env: ${name}`);
+  return v;
+}
+
+export async function ascFetch(path, init = {}) {
+  const url = path.startsWith('http') ? path : `${API_BASE}${path}`;
+  const res = await fetch(url, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${makeJwt()}`,
+      'Content-Type': 'application/json',
+      ...(init.headers || {}),
+    },
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`ASC ${init.method || 'GET'} ${path} → ${res.status}: ${body}`);
+  }
+  return res.status === 204 ? null : res.json();
+}
+
+export async function getAppId(bundleId) {
+  const res = await ascFetch(`/apps?filter[bundleId]=${encodeURIComponent(bundleId)}`);
+  if (!res.data || res.data.length === 0) {
+    throw new Error(`No app found with bundleId ${bundleId}`);
+  }
+  return res.data[0].id;
+}
+
+export async function getGroupId(appId, groupName) {
+  const res = await ascFetch(`/apps/${appId}/betaGroups?filter[name]=${encodeURIComponent(groupName)}&limit=200`);
+  const match = (res.data || []).find((g) => g.attributes?.name === groupName);
+  if (!match) {
+    throw new Error(`No TestFlight group named "${groupName}" on app ${appId}`);
+  }
+  return match.id;
+}
+
+// Returns [{ id, buildNumber, version, uploadedAt, processingState }]
+export async function listBuildsInGroup(appId, groupName) {
+  const groupId = await getGroupId(appId, groupName);
+  const path = `/betaGroups/${groupId}/builds?include=preReleaseVersion&fields[builds]=version,uploadedDate,processingState,preReleaseVersion&fields[preReleaseVersions]=version&limit=200`;
+  const res = await ascFetch(path);
+  const versionById = new Map();
+  for (const inc of res.included || []) {
+    if (inc.type === 'preReleaseVersions') {
+      versionById.set(inc.id, inc.attributes?.version);
+    }
+  }
+  return (res.data || []).map((b) => {
+    const prvId = b.relationships?.preReleaseVersion?.data?.id;
+    return {
+      id: b.id,
+      buildNumber: b.attributes?.version,
+      version: prvId ? versionById.get(prvId) : undefined,
+      uploadedAt: b.attributes?.uploadedDate,
+      processingState: b.attributes?.processingState,
+    };
+  });
+}
+
+// Look up a build by buildNumber (and optionally marketing version) for the given app.
+export async function getBuild(appId, { version, buildNumber }) {
+  const params = new URLSearchParams({
+    'filter[app]': appId,
+    'filter[version]': String(buildNumber),
+    'include': 'preReleaseVersion',
+    'fields[builds]': 'version,uploadedDate,processingState,preReleaseVersion',
+    'fields[preReleaseVersions]': 'version',
+    'limit': '200',
+  });
+  if (version) params.set('filter[preReleaseVersion.version]', version);
+  const res = await ascFetch(`/builds?${params}`);
+  if (!res.data || res.data.length === 0) return null;
+  const build = res.data[0];
+  const prvId = build.relationships?.preReleaseVersion?.data?.id;
+  const prv = (res.included || []).find((i) => i.type === 'preReleaseVersions' && i.id === prvId);
+  return {
+    id: build.id,
+    buildNumber: build.attributes?.version,
+    version: prv?.attributes?.version,
+    uploadedAt: build.attributes?.uploadedDate,
+    processingState: build.attributes?.processingState,
+  };
+}
+
+export async function attachBuildToGroup(buildId, groupId) {
+  await ascFetch(`/betaGroups/${groupId}/relationships/builds`, {
+    method: 'POST',
+    body: JSON.stringify({ data: [{ type: 'builds', id: buildId }] }),
+  });
+}
+
+export async function submitForBetaReview(buildId) {
+  await ascFetch('/betaAppReviewSubmissions', {
+    method: 'POST',
+    body: JSON.stringify({
+      data: {
+        type: 'betaAppReviewSubmissions',
+        relationships: { build: { data: { type: 'builds', id: buildId } } },
+      },
+    }),
+  });
+}
+
+// Production submission: create-or-update appStoreVersion for the build's marketing
+// version, attach the build, set release strategy, write release notes, then submit.
+export async function submitForAppStoreReview(buildId, { autoRelease, phasedRelease, releaseNotes }) {
+  const build = await ascFetch(`/builds/${buildId}?include=app,preReleaseVersion&fields[apps]=bundleId&fields[preReleaseVersions]=version`);
+  const appId = build.data.relationships.app.data.id;
+  const prvId = build.data.relationships.preReleaseVersion.data.id;
+  const versionString = (build.included || []).find((i) => i.type === 'preReleaseVersions' && i.id === prvId)?.attributes?.version;
+  if (!versionString) throw new Error(`Could not resolve marketing version for build ${buildId}`);
+
+  // Find existing appStoreVersion for this versionString, or create one.
+  const existing = await ascFetch(`/apps/${appId}/appStoreVersions?filter[versionString]=${encodeURIComponent(versionString)}&filter[platform]=IOS&limit=10`);
+  let appStoreVersionId = (existing.data || [])[0]?.id;
+
+  const releaseType = autoRelease ? 'AFTER_APPROVAL' : 'MANUAL';
+
+  if (!appStoreVersionId) {
+    const created = await ascFetch('/appStoreVersions', {
+      method: 'POST',
+      body: JSON.stringify({
+        data: {
+          type: 'appStoreVersions',
+          attributes: { platform: 'IOS', versionString, releaseType },
+          relationships: {
+            app: { data: { type: 'apps', id: appId } },
+            build: { data: { type: 'builds', id: buildId } },
+          },
+        },
+      }),
+    });
+    appStoreVersionId = created.data.id;
+  } else {
+    await ascFetch(`/appStoreVersions/${appStoreVersionId}`, {
+      method: 'PATCH',
+      body: JSON.stringify({
+        data: {
+          type: 'appStoreVersions',
+          id: appStoreVersionId,
+          attributes: { releaseType },
+          relationships: { build: { data: { type: 'builds', id: buildId } } },
+        },
+      }),
+    });
+  }
+
+  // Phased release: create or update the phasedRelease record.
+  if (phasedRelease) {
+    try {
+      await ascFetch('/appStoreVersionPhasedReleases', {
+        method: 'POST',
+        body: JSON.stringify({
+          data: {
+            type: 'appStoreVersionPhasedReleases',
+            attributes: { phasedReleaseState: 'INACTIVE' },
+            relationships: { appStoreVersion: { data: { type: 'appStoreVersions', id: appStoreVersionId } } },
+          },
+        }),
+      });
+    } catch (err) {
+      // 409 if one already exists for this version — ignore
+      if (!String(err.message).includes('409')) throw err;
+    }
+  }
+
+  // Release notes (whatsNew) live on appStoreVersionLocalizations. Update en-US if notes given.
+  if (releaseNotes && releaseNotes.trim()) {
+    const locs = await ascFetch(`/appStoreVersions/${appStoreVersionId}/appStoreVersionLocalizations?fields[appStoreVersionLocalizations]=locale,whatsNew&limit=50`);
+    const enUS = (locs.data || []).find((l) => l.attributes?.locale === 'en-US');
+    if (enUS) {
+      await ascFetch(`/appStoreVersionLocalizations/${enUS.id}`, {
+        method: 'PATCH',
+        body: JSON.stringify({
+          data: {
+            type: 'appStoreVersionLocalizations',
+            id: enUS.id,
+            attributes: { whatsNew: releaseNotes },
+          },
+        }),
+      });
+    }
+  }
+
+  // Submit for review.
+  await ascFetch('/appStoreVersionSubmissions', {
+    method: 'POST',
+    body: JSON.stringify({
+      data: {
+        type: 'appStoreVersionSubmissions',
+        relationships: { appStoreVersion: { data: { type: 'appStoreVersions', id: appStoreVersionId } } },
+      },
+    }),
+  });
+}

--- a/.github/scripts/attach-to-group.mjs
+++ b/.github/scripts/attach-to-group.mjs
@@ -1,0 +1,45 @@
+// Attaches the just-uploaded build to a named TestFlight group.
+// Used by release-pipeline.yml immediately after xcodebuild -exportArchive upload.
+//
+// TestFlight processing is async — the build appears in the API in "PROCESSING" state
+// for a few minutes before becoming "VALID" and attachable to a group. We poll.
+//
+// Env:
+//   APP_BUNDLE_ID, MARKETING_VERSION, BUILD_NUMBER, TESTFLIGHT_GROUP_NAME
+//   ASC_* (via asc-client)
+
+import { required, getAppId, getBuild, getGroupId, attachBuildToGroup } from './asc-client.mjs';
+
+const TIMEOUT_MIN = 30;
+const POLL_INTERVAL_SEC = 30;
+
+async function main() {
+  const bundleId = required('APP_BUNDLE_ID');
+  const version = required('MARKETING_VERSION');
+  const buildNumber = required('BUILD_NUMBER');
+  const groupName = required('TESTFLIGHT_GROUP_NAME');
+
+  const appId = await getAppId(bundleId);
+  const groupId = await getGroupId(appId, groupName);
+
+  const deadline = Date.now() + TIMEOUT_MIN * 60_000;
+  let build;
+  while (Date.now() < deadline) {
+    build = await getBuild(appId, { version, buildNumber });
+    if (build && build.processingState === 'VALID') break;
+    console.log(`Build ${version} (${buildNumber}) state: ${build?.processingState ?? 'not yet visible'} — waiting ${POLL_INTERVAL_SEC}s`);
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL_SEC * 1000));
+  }
+
+  if (!build || build.processingState !== 'VALID') {
+    throw new Error(`Build did not reach VALID state within ${TIMEOUT_MIN} min; last state: ${build?.processingState}`);
+  }
+
+  await attachBuildToGroup(build.id, groupId);
+  console.log(`Attached build ${version} (${buildNumber}) to group "${groupName}"`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/.github/scripts/promote-preflight.mjs
+++ b/.github/scripts/promote-preflight.mjs
@@ -1,0 +1,145 @@
+// Evaluates Beta builds and promotes the latest eligible one to the Pre-flight external group.
+//
+// Groups:
+//   Beta       — internal, auto-populated by release-pipeline on every push
+//   Pre-flight — external, requires Apple Beta App Review
+//
+// Eligibility gate:
+//   1. In the Beta group, not yet in the Pre-flight group
+//   2. Build age ≥ SOAK_HOURS
+//   3. Build number not in BLOCKED_BUILDS (from block-promotion/build-N git tags)
+//   4. Sentry session count for the build's release ≥ MIN_SESSIONS
+//   5. Sentry crash-free session rate ≥ MIN_CRASH_FREE_RATE
+//
+// Picks the *newest* build passing all gates. Older eligible builds are skipped.
+// A build failing the minimum-sessions check is considered "still soaking," not rejected.
+//
+// Env:
+//   APP_BUNDLE_ID, SOURCE_GROUP_NAME, TARGET_GROUP_NAME
+//   SOAK_HOURS, MIN_SESSIONS, MIN_CRASH_FREE_RATE
+//   BLOCKED_BUILDS (comma-separated build numbers)
+//   SENTRY_AUTH_TOKEN, SENTRY_ORG, SENTRY_PROJECT
+//   DRY_RUN ('true' evaluates without promoting)
+//   ASC_* (via asc-client)
+
+import {
+  required,
+  getAppId,
+  getGroupId,
+  listBuildsInGroup,
+  attachBuildToGroup,
+  submitForBetaReview,
+} from './asc-client.mjs';
+
+let _sentryProjectId;
+async function sentryProjectId(org, projectSlug, token) {
+  if (_sentryProjectId) return _sentryProjectId;
+  const res = await fetch(`https://sentry.io/api/0/projects/${encodeURIComponent(org)}/${encodeURIComponent(projectSlug)}/`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error(`Sentry project lookup → ${res.status}: ${await res.text()}`);
+  _sentryProjectId = (await res.json()).id;
+  return _sentryProjectId;
+}
+
+async function sentryCrashFreeRate(release) {
+  const token = required('SENTRY_AUTH_TOKEN');
+  const org = required('SENTRY_ORG');
+  const project = required('SENTRY_PROJECT');
+  const projectId = await sentryProjectId(org, project, token);
+
+  const params = new URLSearchParams({
+    project: projectId,
+    field: 'sum(session)',
+    statsPeriod: '7d',
+    query: `release:${release}`,
+  });
+  params.append('field', 'crash_free_rate(session)');
+
+  const res = await fetch(`https://sentry.io/api/0/organizations/${encodeURIComponent(org)}/sessions/?${params}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) throw new Error(`Sentry sessions → ${res.status}: ${await res.text()}`);
+  const data = await res.json();
+
+  // Sessions API returns groups[0].totals when no groupBy is set.
+  const totals = data.groups?.[0]?.totals || {};
+  const sessions = Number(totals['sum(session)'] ?? 0);
+  const rate = totals['crash_free_rate(session)'];
+  // crash_free_rate returns null when there are no sessions; treat as 1.0 for gating
+  // (the sessions check will independently fail and mark "still soaking").
+  const crashFreeRate = rate == null ? 1 : Number(rate);
+  return { sessions, crashFreeRate };
+}
+
+function parseBlocked(csv) {
+  return new Set((csv || '').split(',').map((s) => s.trim()).filter(Boolean));
+}
+
+async function main() {
+  const bundleId = required('APP_BUNDLE_ID');
+  const sourceName = required('SOURCE_GROUP_NAME');
+  const targetName = required('TARGET_GROUP_NAME');
+  const soakHours = Number(required('SOAK_HOURS'));
+  const minSessions = Number(required('MIN_SESSIONS'));
+  const minCrashFree = Number(required('MIN_CRASH_FREE_RATE'));
+  const blocked = parseBlocked(process.env.BLOCKED_BUILDS);
+  const dryRun = process.env.DRY_RUN === 'true';
+
+  const appId = await getAppId(bundleId);
+  const targetGroupId = await getGroupId(appId, targetName);
+
+  const sourceBuilds = await listBuildsInGroup(appId, sourceName);
+  const targetBuilds = await listBuildsInGroup(appId, targetName);
+  const targetBuildIds = new Set(targetBuilds.map((b) => b.id));
+
+  sourceBuilds.sort((a, b) => new Date(b.uploadedAt) - new Date(a.uploadedAt));
+
+  const now = Date.now();
+  const results = [];
+
+  for (const build of sourceBuilds) {
+    const ageHours = (now - new Date(build.uploadedAt).getTime()) / 3_600_000;
+    const reasons = [];
+    if (targetBuildIds.has(build.id)) reasons.push(`already in ${targetName}`);
+    if (ageHours < soakHours) reasons.push(`soak ${ageHours.toFixed(1)}h < ${soakHours}h`);
+    if (blocked.has(String(build.buildNumber))) reasons.push('blocked by git tag');
+
+    let health;
+    if (reasons.length === 0) {
+      const release = `${bundleId}@${build.version}+${build.buildNumber}`;
+      health = await sentryCrashFreeRate(release);
+      if (health.sessions < minSessions) reasons.push(`sessions ${health.sessions} < ${minSessions} (still soaking)`);
+      else if (health.crashFreeRate < minCrashFree) reasons.push(`crash-free ${(health.crashFreeRate * 100).toFixed(2)}% < ${(minCrashFree * 100).toFixed(2)}%`);
+    }
+
+    results.push({ build, ageHours, reasons, health });
+    if (reasons.length === 0) break;
+  }
+
+  console.log('## Evaluation');
+  for (const r of results) {
+    const tag = r.reasons.length === 0 ? 'ELIGIBLE' : 'skip';
+    console.log(`- [${tag}] build ${r.build.buildNumber} (${r.build.version}), age ${r.ageHours.toFixed(1)}h${r.reasons.length ? ' — ' + r.reasons.join('; ') : ''}`);
+  }
+
+  const eligible = results.find((r) => r.reasons.length === 0);
+  if (!eligible) {
+    console.log('No eligible build to promote.');
+    return;
+  }
+
+  if (dryRun) {
+    console.log(`DRY RUN: would promote build ${eligible.build.buildNumber} to ${targetName}`);
+    return;
+  }
+
+  await attachBuildToGroup(eligible.build.id, targetGroupId);
+  await submitForBetaReview(eligible.build.id);
+  console.log(`Promoted build ${eligible.build.buildNumber} to ${targetName} and submitted for Beta App Review`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/.github/scripts/promote-production.mjs
+++ b/.github/scripts/promote-production.mjs
@@ -1,0 +1,37 @@
+// Submits an existing TestFlight build to App Store review.
+// No rebuild — ASC lets us take a build that's already processed and submit it.
+//
+// Env:
+//   APP_BUNDLE_ID, BUILD_NUMBER
+//   RELEASE_NOTES (optional, What's New in this version)
+//   AUTO_RELEASE ('true' = release on approval, 'false' = hold for manual)
+//   PHASED_RELEASE ('true' = 7-day gradual rollout)
+//   ASC_* (via asc-client)
+
+import { required, getAppId, getBuild, submitForAppStoreReview } from './asc-client.mjs';
+
+async function main() {
+  const bundleId = required('APP_BUNDLE_ID');
+  const buildNumber = required('BUILD_NUMBER');
+  const autoRelease = process.env.AUTO_RELEASE === 'true';
+  const phasedRelease = process.env.PHASED_RELEASE !== 'false';
+  const releaseNotes = process.env.RELEASE_NOTES || '';
+
+  const appId = await getAppId(bundleId);
+  // Look up by buildNumber alone — version is implicit per build.
+  const build = await getBuild(appId, { buildNumber });
+  if (!build) throw new Error(`Build ${buildNumber} not found in TestFlight`);
+  if (build.processingState !== 'VALID') {
+    throw new Error(`Build ${buildNumber} is in state ${build.processingState}; must be VALID before submission`);
+  }
+
+  await submitForAppStoreReview(build.id, { autoRelease, phasedRelease, releaseNotes });
+  console.log(`Submitted build ${buildNumber} (${build.version}) to App Store review`);
+  console.log(`  auto-release: ${autoRelease}`);
+  console.log(`  phased release: ${phasedRelease}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/.github/workflows/promote-preflight.yml
+++ b/.github/workflows/promote-preflight.yml
@@ -1,0 +1,70 @@
+name: Promote Beta → Pre-flight
+
+on:
+  schedule:
+    - cron: '0 */12 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Evaluate eligibility but do not promote'
+        required: false
+        default: 'false'
+        type: choice
+        options: ['true', 'false']
+
+concurrency:
+  group: promote-preflight
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  evaluate-and-promote:
+    name: Evaluate Beta builds and promote latest eligible to Pre-flight
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: Setup App Store Connect API key
+        env:
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_API_KEY_P8: ${{ secrets.ASC_API_KEY_P8 }}
+        run: |
+          mkdir -p ~/.private_keys
+          echo -n "$ASC_API_KEY_P8" > ~/.private_keys/AuthKey_${ASC_KEY_ID}.p8
+
+      - name: Fetch blocked build numbers from git tags
+        id: blocks
+        run: |
+          git fetch --tags --quiet
+          BLOCKED=$(git tag -l 'block-promotion/build-*' | sed 's|block-promotion/build-||' | tr '\n' ',' | sed 's/,$//')
+          echo "blocked=${BLOCKED}" >> "$GITHUB_OUTPUT"
+          echo "Blocked builds: ${BLOCKED:-(none)}"
+
+      - name: Evaluate and promote
+        env:
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_KEY_PATH: ~/.private_keys/AuthKey_${{ secrets.ASC_KEY_ID }}.p8
+          APP_BUNDLE_ID: ${{ secrets.APP_BUNDLE_ID }}
+          SOURCE_GROUP_NAME: Beta
+          TARGET_GROUP_NAME: Pre-flight
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+          SOAK_HOURS: '72'
+          MIN_SESSIONS: '5'
+          MIN_CRASH_FREE_RATE: '0.99'
+          BLOCKED_BUILDS: ${{ steps.blocks.outputs.blocked }}
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+        run: node .github/scripts/promote-preflight.mjs
+
+      - name: Cleanup
+        if: always()
+        run: rm -rf ~/.private_keys || true

--- a/.github/workflows/promote-production.yml
+++ b/.github/workflows/promote-production.yml
@@ -1,0 +1,76 @@
+name: Promote Beta → Production
+
+on:
+  workflow_dispatch:
+    inputs:
+      build_number:
+        description: 'TestFlight build number to submit for App Store review'
+        required: true
+        type: string
+      release_notes:
+        description: 'Release notes (What to Test → What Changed in App Store)'
+        required: false
+        type: string
+      auto_release:
+        description: 'Release automatically after approval (vs. manual release)'
+        required: false
+        default: 'false'
+        type: choice
+        options: ['true', 'false']
+      phased_release:
+        description: 'Use phased release (7-day gradual rollout)'
+        required: false
+        default: 'true'
+        type: choice
+        options: ['true', 'false']
+
+concurrency:
+  group: promote-production
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  submit:
+    name: Submit build to App Store review
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: Setup App Store Connect API key
+        env:
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_API_KEY_P8: ${{ secrets.ASC_API_KEY_P8 }}
+        run: |
+          mkdir -p ~/.private_keys
+          echo -n "$ASC_API_KEY_P8" > ~/.private_keys/AuthKey_${ASC_KEY_ID}.p8
+
+      - name: Submit to App Store review
+        env:
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_KEY_PATH: ~/.private_keys/AuthKey_${{ secrets.ASC_KEY_ID }}.p8
+          APP_BUNDLE_ID: ${{ secrets.APP_BUNDLE_ID }}
+          BUILD_NUMBER: ${{ github.event.inputs.build_number }}
+          RELEASE_NOTES: ${{ github.event.inputs.release_notes }}
+          AUTO_RELEASE: ${{ github.event.inputs.auto_release }}
+          PHASED_RELEASE: ${{ github.event.inputs.phased_release }}
+        run: node .github/scripts/promote-production.mjs
+
+      - name: Cleanup
+        if: always()
+        run: rm -rf ~/.private_keys || true
+
+      - name: Summary
+        run: |
+          echo "## Production Submission" >> $GITHUB_STEP_SUMMARY
+          echo "- **Build:** ${{ github.event.inputs.build_number }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Auto-release:** ${{ github.event.inputs.auto_release }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Phased release:** ${{ github.event.inputs.phased_release }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -1,38 +1,109 @@
-name: Deploy Swift to TestFlight
+name: Release Pipeline
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - 'mobile-apps/ios/**'
+      - '.github/workflows/release-pipeline.yml'
+      - '.github/scripts/**'
   workflow_dispatch:
-    inputs:
-      bump:
-        description: 'Version bump type'
-        required: true
-        default: 'build'
-        type: choice
-        options:
-          - build
-          - patch
-          - minor
 
 concurrency:
-  group: swift-deploy
+  group: release-pipeline
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
-  build-and-deploy:
+  test-unit:
+    name: Unit tests
     runs-on: macos-26
     defaults:
       run:
+        shell: bash --noprofile --norc -eo pipefail {0}
         working-directory: mobile-apps/ios
+    steps:
+      - uses: actions/checkout@v6
 
+      - name: SwiftLint
+        run: |
+          brew install swiftlint
+          swiftlint lint --reporter github-actions-logging
+
+      - name: Select Xcode 26
+        run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
+
+      - name: Install XcodeGen
+        run: |
+          brew install xcodegen
+          INSTALLED=$(xcodegen --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+          MINIMUM="2.45.3"
+          if [ "$(printf '%s\n' "$MINIMUM" "$INSTALLED" | sort -V | head -n1)" != "$MINIMUM" ]; then
+            echo "::error::XcodeGen version too old: need >= $MINIMUM, got $INSTALLED"
+            exit 1
+          fi
+
+      - name: Write placeholder Sentry xcconfig
+        run: |
+          cat > Config/Sentry.xcconfig <<'EOF'
+          SENTRY_DSN_REST =
+          EOF
+
+      - name: Generate Xcode project
+        run: xcodegen generate
+
+      - name: Resolve Swift packages
+        run: xcodebuild -resolvePackageDependencies -scheme LiftMark -project LiftMark.xcodeproj
+
+      - name: Run unit tests
+        run: |
+          xcodebuild test \
+            -scheme LiftMark \
+            -project LiftMark.xcodeproj \
+            -only-testing:LiftMarkTests \
+            -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=latest' \
+            -resultBundlePath TestResults.xcresult \
+            | xcpretty
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: unit-test-results
+          path: mobile-apps/ios/TestResults.xcresult
+          retention-days: 7
+
+  test-ui:
+    name: UI tests (placeholder)
+    needs: test-unit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Placeholder
+        run: |
+          echo "UI tests will run here once the self-hosted Mac runner is set up."
+          echo "Current plan: move LiftMarkUITests to a self-hosted macOS runner."
+
+  deploy-alpha:
+    name: Deploy to TestFlight Beta
+    needs: test-ui
+    runs-on: macos-26
+    permissions:
+      contents: write
+    defaults:
+      run:
+        working-directory: mobile-apps/ios
     env:
       SCHEME: LiftMark
       PROJECT: LiftMark.xcodeproj
       ARCHIVE_PATH: build/LiftMark.xcarchive
       EXPORT_PATH: build/export
-
+    outputs:
+      build_number: ${{ steps.version.outputs.build_number }}
+      marketing_version: ${{ steps.version.outputs.marketing_version }}
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
+      - uses: actions/checkout@v6
 
       - name: Select Xcode 26
         run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
@@ -55,18 +126,14 @@ jobs:
             echo "::error::SENTRY_DSN secret is empty — refusing to ship a build with no crash reporting"
             exit 1
           fi
-          # Strip the https:// prefix — xcconfig treats // as a comment start, so
-          # we store everything after the scheme and reassemble in the build phase.
           DSN_REST=${SENTRY_DSN#https://}
           if [ "$DSN_REST" = "$SENTRY_DSN" ]; then
-            echo "::error::SENTRY_DSN did not start with https:// — got: ${SENTRY_DSN:0:12}..."
+            echo "::error::SENTRY_DSN did not start with https://"
             exit 1
           fi
           cat > Config/Sentry.xcconfig <<EOF
-          // Written by CI from SENTRY_DSN secret. Do not commit.
           SENTRY_DSN_REST = ${DSN_REST}
           EOF
-          echo "Wrote Config/Sentry.xcconfig ($(wc -c < Config/Sentry.xcconfig) bytes)"
 
       - name: Generate Xcode project
         run: xcodegen generate
@@ -74,60 +141,32 @@ jobs:
       - name: Resolve Swift packages
         run: xcodebuild -resolvePackageDependencies -scheme $SCHEME -project $PROJECT
 
-      # Unit tests run in the Swift CI workflow on PRs.
-      # Skipping here to avoid simulator availability issues on deploy runners.
-
-      # --- Install signing certificate ---
       - name: Install certificate
         env:
           CERTIFICATE_P12: ${{ secrets.SWIFT_CERTIFICATE_P12 }}
           CERTIFICATE_PASSWORD: ${{ secrets.SWIFT_CERTIFICATE_PASSWORD }}
         run: |
-          # Create temporary keychain
           KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
           KEYCHAIN_PASSWORD=$(openssl rand -base64 32)
-
           security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
           security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-
-          # Import certificate
           CERT_PATH=$RUNNER_TEMP/certificate.p12
           echo -n "$CERTIFICATE_P12" | base64 --decode -o "$CERT_PATH"
-          security import "$CERT_PATH" \
-            -P "$CERTIFICATE_PASSWORD" \
-            -A \
-            -t cert \
-            -f pkcs12 \
-            -k "$KEYCHAIN_PATH"
-
-          # Allow codesign to access the keychain without prompting
+          security import "$CERT_PATH" -P "$CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-
-          # Set keychain search list
           security list-keychain -d user -s "$KEYCHAIN_PATH"
-
-          # Verify certificate was imported
           security find-identity -v -p codesigning "$KEYCHAIN_PATH"
 
-      # --- Install provisioning profiles ---
       - name: Install provisioning profile (main app)
         env:
           PROVISIONING_PROFILE: ${{ secrets.SWIFT_PROVISIONING_PROFILE }}
         run: |
           PROFILE_PATH=$RUNNER_TEMP/profile.mobileprovision
           echo -n "$PROVISIONING_PROFILE" | base64 --decode -o "$PROFILE_PATH"
-
-          # Extract UUID from provisioning profile and install with correct filename
           PROFILE_UUID=$(/usr/libexec/PlistBuddy -c "Print UUID" /dev/stdin <<< $(security cms -D -i "$PROFILE_PATH"))
-          echo "Profile UUID: $PROFILE_UUID"
-
           mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
           cp "$PROFILE_PATH" ~/Library/MobileDevice/Provisioning\ Profiles/${PROFILE_UUID}.mobileprovision
-
-          # Extract and display profile name for verification
-          PROFILE_NAME=$(/usr/libexec/PlistBuddy -c "Print Name" /dev/stdin <<< $(security cms -D -i "$PROFILE_PATH"))
-          echo "Profile Name: $PROFILE_NAME"
 
       - name: Install provisioning profile (LiveWorkouts extension)
         env:
@@ -135,32 +174,35 @@ jobs:
         run: |
           PROFILE_PATH=$RUNNER_TEMP/liveworkouts_profile.mobileprovision
           echo -n "$PROVISIONING_PROFILE" | base64 --decode -o "$PROFILE_PATH"
-
           PROFILE_UUID=$(/usr/libexec/PlistBuddy -c "Print UUID" /dev/stdin <<< $(security cms -D -i "$PROFILE_PATH"))
-          echo "Profile UUID: $PROFILE_UUID"
-
           mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
           cp "$PROFILE_PATH" ~/Library/MobileDevice/Provisioning\ Profiles/${PROFILE_UUID}.mobileprovision
 
-          PROFILE_NAME=$(/usr/libexec/PlistBuddy -c "Print Name" /dev/stdin <<< $(security cms -D -i "$PROFILE_PATH"))
-          echo "Profile Name: $PROFILE_NAME"
-
-      # --- Build archive ---
-      - name: Set version numbers
+      - name: Compute next build number (patch bump from latest deploy/* tag)
+        id: version
+        working-directory: ${{ github.workspace }}
         run: |
-          VERSION="1.0.${{ github.run_number }}"
-          BUILD="${{ github.run_number }}"
-          echo "APP_VERSION=$VERSION" >> $GITHUB_ENV
+          git fetch --tags --quiet
+          LATEST=$(git tag -l 'deploy/*' | sed 's|deploy/||' | sort -V | tail -n1)
+          if [ -z "$LATEST" ]; then
+            LATEST="1.0.102"
+          fi
+          MAJOR=$(echo "$LATEST" | cut -d. -f1)
+          MINOR=$(echo "$LATEST" | cut -d. -f2)
+          PATCH=$(echo "$LATEST" | cut -d. -f3)
+          NEXT_PATCH=$((PATCH + 1))
+          MARKETING="${MAJOR}.${MINOR}.${NEXT_PATCH}"
+          BUILD="${NEXT_PATCH}"
+          echo "Previous deploy: $LATEST → next: $MARKETING (build $BUILD)"
+          echo "marketing_version=$MARKETING" >> "$GITHUB_OUTPUT"
+          echo "build_number=$BUILD" >> "$GITHUB_OUTPUT"
+          echo "APP_VERSION=$MARKETING" >> $GITHUB_ENV
           echo "APP_BUILD=$BUILD" >> $GITHUB_ENV
-          echo "Setting version to $VERSION (build $BUILD)"
 
       - name: Build archive
         env:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
-          # Verify signing identity
-          security find-identity -v -p codesigning $RUNNER_TEMP/app-signing.keychain-db
-
           xcodebuild archive \
             -scheme $SCHEME \
             -project $PROJECT \
@@ -170,7 +212,6 @@ jobs:
             MARKETING_VERSION="$APP_VERSION" \
             CURRENT_PROJECT_VERSION="$APP_BUILD"
 
-      # --- Setup API key (needed for export and upload) ---
       - name: Setup App Store Connect API key
         env:
           ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
@@ -179,8 +220,6 @@ jobs:
           mkdir -p ~/.private_keys
           echo -n "$ASC_API_KEY_P8" > ~/.private_keys/AuthKey_${ASC_KEY_ID}.p8
 
-      # --- Export and upload to TestFlight ---
-      # exportArchive with app-store-connect method validates and uploads in one step
       - name: Export and upload to TestFlight
         env:
           ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
@@ -194,20 +233,43 @@ jobs:
             -authenticationKeyID "$ASC_KEY_ID" \
             -authenticationKeyIssuerID "$ASC_ISSUER_ID"
 
-      # --- Cleanup keychain ---
+      - name: Wait for TestFlight processing & attach to Alpha group
+        env:
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_KEY_PATH: ~/.private_keys/AuthKey_${{ secrets.ASC_KEY_ID }}.p8
+          APP_BUNDLE_ID: ${{ secrets.APP_BUNDLE_ID }}
+          TESTFLIGHT_GROUP_NAME: Beta
+          BUILD_NUMBER: ${{ steps.version.outputs.build_number }}
+          MARKETING_VERSION: ${{ steps.version.outputs.marketing_version }}
+        working-directory: ${{ github.workspace }}
+        run: node .github/scripts/attach-to-group.mjs
+
+      - name: Tag deploy
+        if: success()
+        working-directory: ${{ github.workspace }}
+        env:
+          MARKETING_VERSION: ${{ steps.version.outputs.marketing_version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag "deploy/${MARKETING_VERSION}" "${{ github.sha }}"
+          git push origin "deploy/${MARKETING_VERSION}"
+
       - name: Cleanup
         if: always()
         run: |
           security delete-keychain $RUNNER_TEMP/app-signing.keychain-db || true
           rm -f $RUNNER_TEMP/certificate.p12 || true
           rm -f $RUNNER_TEMP/profile.mobileprovision || true
+          rm -f $RUNNER_TEMP/liveworkouts_profile.mobileprovision || true
           rm -rf ~/.private_keys || true
 
       - name: Summary
         run: |
-          echo "## Swift Build Summary" >> $GITHUB_STEP_SUMMARY
-          echo "- **Version:** $APP_VERSION (build $APP_BUILD)" >> $GITHUB_STEP_SUMMARY
-          echo "- **Ref:** ${{ github.ref }}" >> $GITHUB_STEP_SUMMARY
+          echo "## Alpha Deploy" >> $GITHUB_STEP_SUMMARY
+          echo "- **Version:** ${{ steps.version.outputs.marketing_version }} (build ${{ steps.version.outputs.build_number }})" >> $GITHUB_STEP_SUMMARY
           echo "- **Commit:** ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Distributed to:** Beta (internal developer testing)" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Build submitted to TestFlight. Check App Store Connect for processing status." >> $GITHUB_STEP_SUMMARY
+          echo "Pre-flight promotion runs on a 12h schedule. Build becomes eligible 72h after upload if crash-free ≥ 99%." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/swift-ci.yml
+++ b/.github/workflows/swift-ci.yml
@@ -1,12 +1,6 @@
 name: Swift CI
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'mobile-apps/ios/**'
-      - 'e2e-spec/**'
-      - '.github/workflows/swift-ci.yml'
   pull_request:
     branches: [main]
     paths:

--- a/mobile-apps/ios/Makefile
+++ b/mobile-apps/ios/Makefile
@@ -40,8 +40,9 @@ clean:
 	xcodebuild clean -scheme $(SCHEME)
 	rm -rf .build build
 
-# Trigger TestFlight deploy via GitHub Actions
+# Manually re-trigger the release pipeline against current main.
+# Pushes to main also trigger it automatically; use this to re-run without an empty commit.
 release-alpha:
-	@echo "Triggering Swift TestFlight build..."
-	gh workflow run "Deploy Swift to TestFlight" --ref main --field bump=build
+	@echo "Triggering release pipeline..."
+	gh workflow run "Release Pipeline" --ref main
 	@echo "Workflow triggered. Monitor at: https://github.com/$$(gh repo view --json nameWithOwner -q .nameWithOwner)/actions"


### PR DESCRIPTION
## Summary
- Replace single \`deploy-swift-testflight.yml\` with three workflows that model alpha → beta → prod as TestFlight ring promotion (same binary, no rebuilds).
- Auto-deploy on push to main (was manual workflow_dispatch).
- Scheduled auto-promotion from Beta → Pre-flight gated by 72h soak + Sentry crash-free rate ≥ 99% + min 5 sessions.
- Manual production submission via workflow_dispatch with required-reviewer gate on the \`production\` environment.

## Pipeline

\`\`\`
push to main (mobile-apps/ios/**)
  └─ test-unit → test-ui (placeholder) → deploy
                                         ├─ build & sign
                                         ├─ upload to TestFlight
                                         ├─ attach to "Beta" internal group
                                         └─ tag deploy/1.0.N

cron */12h
  └─ promote-preflight: latest eligible Beta build → "Pre-flight" external group + Beta App Review

workflow_dispatch (manual, environment: production)
  └─ promote-production: existing build → App Store review
\`\`\`

## Versioning
- Each deploy = one patch bump from latest \`deploy/*\` git tag.
- Seeded at \`deploy/1.0.102\`; first auto-deploy from this branch becomes \`1.0.103\`.
- \`CFBundleVersion\` = patch component, so marketing version and build number stay aligned.

## Kill switch
- Tag \`block-promotion/build-N\` to skip a build during preflight promotion.

## Permissions
- Workflow-level default: \`contents: read\`.
- \`deploy\` job overrides to \`contents: write\` (needed to push \`deploy/*\` tags).
- \`production\` environment configured with required reviewers in repo settings.

## New secrets needed
- \`APP_BUNDLE_ID\`
- \`SENTRY_AUTH_TOKEN\`, \`SENTRY_ORG\`, \`SENTRY_PROJECT\`

## Test plan
- [ ] Dry-run \`promote-preflight\` via workflow_dispatch with \`dry_run=true\` — verify it lists Beta builds, evaluates them, doesn't promote
- [ ] Merge a trivial iOS-touching change to main — verify release-pipeline runs, build 1.0.103 lands in Beta group, \`deploy/1.0.103\` tag is pushed
- [ ] After 72h soak (or manual dispatch), verify promote-preflight attaches build 103 to Pre-flight and submits for Beta App Review
- [ ] Test \`promote-production\` with a build number — verify environment approval gate triggers and submission goes through

🤖 Generated with [Claude Code](https://claude.com/claude-code)