### PR TITLE
fix(database): close shared queue before import to avoid vnode invalidation (#104)

### DIFF
--- a/mobile-apps/ios/LiftMark/Database/DatabaseManager.swift
+++ b/mobile-apps/ios/LiftMark/Database/DatabaseManager.swift
@@ -89,9 +89,19 @@ final class DatabaseManager: @unchecked Sendable {
     }
 
     /// Close the database connection.
+    ///
+    /// Deterministically tears down the underlying SQLite connection (and its
+    /// vnode-watcher dispatch source) before releasing the queue reference, so
+    /// callers that intend to mutate the backing file (rename / replace / delete)
+    /// don't trip Apple's `SQLITE_IOERR_VNODE` check on a still-open connection.
+    /// See GH #104.
     func close() {
         dbLock.lock()
         defer { dbLock.unlock() }
+        // Synchronously close the SQLite handle. `try?` because GRDB will throw
+        // if statements are still in-flight; in that case ARC will tear the
+        // connection down on deinit, which is the same behavior as before.
+        try? dbQueue?.close()
         dbQueue = nil
     }
 

--- a/mobile-apps/ios/LiftMark/Database/DatabaseManager.swift
+++ b/mobile-apps/ios/LiftMark/Database/DatabaseManager.swift
@@ -98,10 +98,18 @@ final class DatabaseManager: @unchecked Sendable {
     func close() {
         dbLock.lock()
         defer { dbLock.unlock() }
-        // Synchronously close the SQLite handle. `try?` because GRDB will throw
-        // if statements are still in-flight; in that case ARC will tear the
-        // connection down on deinit, which is the same behavior as before.
-        try? dbQueue?.close()
+        // Synchronously close the SQLite handle. If GRDB throws (typically
+        // because statements are still in-flight) we fall back to ARC teardown
+        // on deinit — same behavior as before this fix, which is the flake-prone
+        // path. Log so we can tell from telemetry whether this fallback ever
+        // fires in production.
+        if let queue = dbQueue {
+            do {
+                try queue.close()
+            } catch {
+                Logger.shared.error(.database, "DatabaseQueue.close() failed; falling back to ARC teardown", error: error)
+            }
+        }
         dbQueue = nil
     }
 

--- a/mobile-apps/ios/LiftMark/Services/DatabaseBackupService.swift
+++ b/mobile-apps/ios/LiftMark/Services/DatabaseBackupService.swift
@@ -130,13 +130,17 @@ enum DatabaseBackupService {
         }
 
         do {
-            // Close current database connection
+            // Close current database connection. This synchronously tears down
+            // the SQLite handle (and its vnode-watcher dispatch source) so the
+            // file replacement below doesn't trigger `SQLITE_IOERR_VNODE` on a
+            // still-open connection. See GH #104.
             DatabaseManager.shared.close()
 
-            // Delete current database
-            if fileManager.fileExists(atPath: dbPath.path) {
-                try fileManager.removeItem(at: dbPath)
-            }
+            // Delete current database AND any SQLite sidecar files. Leftover
+            // -wal / -shm / -journal files from the old DB would otherwise be
+            // picked up by SQLite when it opens the freshly-imported file and
+            // could corrupt its view of the data.
+            try removeDatabaseFiles(at: dbPath, fileManager: fileManager)
 
             // Copy imported file to database location
             try fileManager.copyItem(at: fileURL, to: dbPath)
@@ -150,9 +154,10 @@ enum DatabaseBackupService {
             // Attempt to restore from safety backup
             if fileManager.fileExists(atPath: backupURL.path) {
                 do {
-                    if fileManager.fileExists(atPath: dbPath.path) {
-                        try fileManager.removeItem(at: dbPath)
-                    }
+                    // Close again in case `database()` reopened on the partially-
+                    // copied file before we got here.
+                    DatabaseManager.shared.close()
+                    try removeDatabaseFiles(at: dbPath, fileManager: fileManager)
                     try fileManager.copyItem(at: backupURL, to: dbPath)
                     _ = try DatabaseManager.shared.database()
                 } catch {
@@ -161,6 +166,20 @@ enum DatabaseBackupService {
             }
 
             throw BackupError.importFailed(error.localizedDescription)
+        }
+    }
+
+    /// Remove the SQLite database file and any associated sidecar files
+    /// (`-wal`, `-shm`, `-journal`). The connection MUST already be closed.
+    private static func removeDatabaseFiles(at dbPath: URL, fileManager: FileManager) throws {
+        let suffixes = ["", "-wal", "-shm", "-journal"]
+        for suffix in suffixes {
+            let url = suffix.isEmpty
+                ? dbPath
+                : dbPath.deletingLastPathComponent().appendingPathComponent(dbPath.lastPathComponent + suffix)
+            if fileManager.fileExists(atPath: url.path) {
+                try fileManager.removeItem(at: url)
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
Fixes the ~50% flake of `DatabaseBackupServiceTests.testImportReplacesData` on `macos-26` GitHub Actions runners (`SQLite error 10: disk I/O error`). Root cause is Apple's `SQLITE_IOERR_VNODE` check: the shared `DatabaseQueue` was holding a connection open on the SQLite file while `DatabaseBackupService.importDatabase(from:)` unlinked and replaced that file underneath it.

Closes #104.

## Approach: close-then-reopen (with synchronous close)

Of the two approaches suggested in the issue (close-then-reopen vs. truncate-and-copy), close-then-reopen is the cleaner fit for this codebase:

- `DatabaseManager.close()` already exists and is the documented teardown mechanism, used by `deleteDatabase()` and the migrator bridge.
- The lazy reopen via `database()` already works correctly; nothing else needs to change.
- Keeping the main DB file lifecycle as "delete then copy" preserves clear ownership semantics and avoids new edge cases around sidecar files written by the previous schema.

The previous `close()` only nilled the `dbQueue` property and relied on ARC to tear the SQLite handle down. That isn't guaranteed to be synchronous, so on busy CI the file removal in `importDatabase` raced the connection teardown and the still-live vnode dispatch source fired.

## Changes

1. **`DatabaseManager.close()`** now calls GRDB's `DatabaseQueue.close()` on the live queue before releasing the reference. GRDB's `close()` is `writer.sync { try $0.close() }` — synchronous, so the SQLite handle and its vnode dispatch source are torn down before the caller mutates the file.

2. **`DatabaseBackupService.importDatabase(from:)`** now removes the SQLite sidecar files (`-wal`, `-shm`, `-journal`) alongside the main DB file. Otherwise SQLite would pick them up against the freshly-imported file and produce an inconsistent view. The rollback path received the same treatment plus a defensive second `close()` in case `database()` was reopened during a partial copy.

Both changes are surgical — no behavioral change for happy-path callers, no API changes.

## Test plan

- [x] `xcodebuild test -only-testing:LiftMarkTests/DatabaseBackupServiceTests` passes locally (9/9)
- [x] `xcodebuild test -only-testing:LiftMarkTests/DatabaseManagerTests` passes locally (19/19) — exercises `close()` + reopen pattern
- [ ] swift-ci will be re-run **5 consecutive times** on this PR to gain flake confidence. The failure was ~50% on CI; 5 consecutive greens places the residual flake probability at ~3%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)