### PR TITLE
ci: disable UI tests on hosted runners + prefix iOS workflow names

### DIFF
--- a/.github/workflows/promote-preflight.yml
+++ b/.github/workflows/promote-preflight.yml
@@ -1,4 +1,4 @@
-name: Promote Beta → Pre-flight
+name: '[iOS] Promote Beta → Pre-flight'
 
 on:
   schedule:

--- a/.github/workflows/promote-production.yml
+++ b/.github/workflows/promote-production.yml
@@ -1,4 +1,4 @@
-name: Promote Beta → Production
+name: '[iOS] Promote Beta → Production'
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -1,4 +1,4 @@
-name: Release Pipeline
+name: '[iOS] Release Pipeline'
 
 on:
   push:

--- a/.github/workflows/swift-ci.yml
+++ b/.github/workflows/swift-ci.yml
@@ -71,15 +71,10 @@ jobs:
             -resultBundlePath TestResults.xcresult \
             | xcpretty
 
-      - name: Run UI tests
-        run: |
-          xcodebuild test \
-            -scheme LiftMark \
-            -project LiftMark.xcodeproj \
-            -only-testing:LiftMarkUITests \
-            -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=latest' \
-            -resultBundlePath TestResults-UI.xcresult \
-            | xcpretty
+      # UI tests (LiftMarkUITests) are disabled on hosted runners until we move
+      # them to a self-hosted Mac runner — they take ~20 min on macos-26, dominate
+      # PR feedback time, and have known flakes (issue #106). Re-enable once the
+      # self-hosted runner is up.
 
       - name: Upload unit test results
         uses: actions/upload-artifact@v7
@@ -87,12 +82,4 @@ jobs:
         with:
           name: test-results
           path: mobile-apps/ios/TestResults.xcresult
-          retention-days: 7
-
-      - name: Upload UI test results
-        uses: actions/upload-artifact@v7
-        if: always()
-        with:
-          name: test-results-ui
-          path: mobile-apps/ios/TestResults-UI.xcresult
           retention-days: 7

--- a/.github/workflows/swift-ci.yml
+++ b/.github/workflows/swift-ci.yml
@@ -1,4 +1,4 @@
-name: Swift CI
+name: '[iOS] CI'
 
 on:
   pull_request:

--- a/mobile-apps/ios/Makefile
+++ b/mobile-apps/ios/Makefile
@@ -44,5 +44,5 @@ clean:
 # Pushes to main also trigger it automatically; use this to re-run without an empty commit.
 release-alpha:
 	@echo "Triggering release pipeline..."
-	gh workflow run "Release Pipeline" --ref main
+	gh workflow run "[iOS] Release Pipeline" --ref main
 	@echo "Workflow triggered. Monitor at: https://github.com/$$(gh repo view --json nameWithOwner -q .nameWithOwner)/actions"


### PR DESCRIPTION
Re-pushed after these two commits got orphaned when #108 squash-merged.

## Changes
1. **Disable UI tests on hosted runners.** \`LiftMarkUITests\` takes ~20 min on \`macos-26\`, dominates PR feedback time, and has known flakes (#106). Re-enable when the self-hosted Mac runner is up.
2. **Prefix iOS workflow names with \`[iOS]\`** so they're easy to spot in the GH Actions UI:
   - \`Swift CI\` → \`[iOS] CI\`
   - \`Release Pipeline\` → \`[iOS] Release Pipeline\`
   - \`Promote Beta → Pre-flight\` → \`[iOS] Promote Beta → Pre-flight\`
   - \`Promote Beta → Production\` → \`[iOS] Promote Beta → Production\`
   - \`Validator CI\` left unprefixed (not iOS).
3. Updated \`mobile-apps/ios/Makefile\`'s \`release-alpha\` target for the renamed workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)