### PR TITLE
test(ai): e2e + unit coverage for AI prompt surface (GH #101 Phase 4 / #94)

### DIFF
--- a/e2e-spec/scenarios/ai-prompt-settings.yaml
+++ b/e2e-spec/scenarios/ai-prompt-settings.yaml
@@ -1,0 +1,109 @@
+name: "AI prompt settings"
+
+# Phase 4 verification for #101 / #94 — confirms the AI prompt surface in
+# Settings: the toggle controls and custom-prompt input are reachable, and
+# the custom prompt persists across relaunch. Block-composition behaviour
+# (which toggles control which prompt sections) and the persistence of the
+# four boolean toggle settings are covered by unit tests
+# (WorkoutGenerationServiceTests, StoreIntegrationTests).
+
+setup:
+  - action: launchApp
+    newInstance: true
+  - action: tryCatch
+    try:
+      - action: waitFor
+        target: "home-screen"
+        timeout: 30000
+    catch:
+      - action: waitFor
+        target: "max-lift-tile-0"
+        timeout: 5000
+  - action: tap
+    target: "tab-settings"
+  - action: waitFor
+    target: "settings-screen"
+    timeout: 5000
+  # AI section is below Appearance/Workout/Gym/Integrations — bring it on-screen.
+  # Two swipes lands the section in view; `expect toExist` has a scroll-search
+  # fallback that handles minor over/undershoot.
+  - action: scroll
+    target: "settings-screen"
+    direction: "up"
+  - action: delay
+    ms: 300
+  - action: scroll
+    target: "settings-screen"
+    direction: "up"
+  - action: delay
+    ms: 500
+  - action: expect
+    target: "toggle-ai-include-format-pointer"
+    assertion: "toExist"
+
+tests:
+  - name: "AI section toggles and custom prompt input are reachable"
+    steps:
+      - action: expect
+        target: "toggle-ai-include-format-pointer"
+        assertion: "toExist"
+      - action: expect
+        target: "toggle-ai-include-recent-workouts"
+        assertion: "toExist"
+      - action: expect
+        target: "toggle-ai-include-progression"
+        assertion: "toExist"
+      - action: expect
+        target: "toggle-ai-include-equipment"
+        assertion: "toExist"
+      - action: expect
+        target: "input-custom-prompt"
+        assertion: "toExist"
+
+  - name: "custom prompt persists across relaunch"
+    steps:
+      - action: expect
+        target: "input-custom-prompt"
+        assertion: "toExist"
+      - action: replaceText
+        target: "input-custom-prompt"
+        value: "Avoid overhead pressing"
+      - action: delay
+        ms: 300
+      - action: expect
+        target: "input-custom-prompt"
+        assertion: "toHaveText"
+        value: "Avoid overhead pressing"
+      - action: launchApp
+        newInstance: true
+      - action: tryCatch
+        try:
+          - action: waitFor
+            target: "home-screen"
+            timeout: 30000
+        catch:
+          - action: waitFor
+            target: "max-lift-tile-0"
+            timeout: 5000
+      - action: tap
+        target: "tab-settings"
+      - action: waitFor
+        target: "settings-screen"
+        timeout: 5000
+      - action: scroll
+        target: "settings-screen"
+        direction: "up"
+      - action: delay
+        ms: 300
+      - action: scroll
+        target: "settings-screen"
+        direction: "up"
+      - action: delay
+        ms: 500
+      - action: expect
+        target: "input-custom-prompt"
+        assertion: "toExist"
+      - action: expect
+        target: "input-custom-prompt"
+        assertion: "toHaveText"
+        value: "Avoid overhead pressing"

--- a/mobile-apps/ios/LiftMark/Views/Settings/SettingsAISection.swift
+++ b/mobile-apps/ios/LiftMark/Views/Settings/SettingsAISection.swift
@@ -34,8 +34,8 @@ struct SettingsAISection: View {
                     }
                 ), axis: .vertical)
                 .lineLimit(2...4)
+                .accessibilityIdentifier("input-custom-prompt")
             }
-            .accessibilityIdentifier("input-custom-prompt")
 
             VStack(alignment: .leading, spacing: LiftMarkTheme.spacingSM) {
                 Text("API Key")

--- a/mobile-apps/ios/LiftMarkTests/StoreIntegrationTests.swift
+++ b/mobile-apps/ios/LiftMarkTests/StoreIntegrationTests.swift
@@ -530,6 +530,39 @@ final class SettingsStoreTests: XCTestCase {
         settings.customPromptAddition = "I have a bad back"
         store.updateSettings(settings)
         XCTAssertEqual(store.settings?.customPromptAddition, "I have a bad back")
+
+        let store2 = SettingsStore()
+        store2.loadSettings()
+        XCTAssertEqual(store2.settings?.customPromptAddition, "I have a bad back")
+    }
+
+    func testUpdateSettingsCustomPromptMultiLine() {
+        store.loadSettings()
+        guard var settings = store.settings else { return }
+        let multiLine = "Line one\nLine two\nLine three"
+        settings.customPromptAddition = multiLine
+        store.updateSettings(settings)
+
+        let store2 = SettingsStore()
+        store2.loadSettings()
+        XCTAssertEqual(store2.settings?.customPromptAddition, multiLine)
+    }
+
+    func testUpdateSettingsAIPromptToggles() {
+        store.loadSettings()
+        guard var settings = store.settings else { return }
+        settings.aiPromptIncludeFormatPointer = false
+        settings.aiPromptIncludeRecentWorkouts = false
+        settings.aiPromptIncludeProgression = false
+        settings.aiPromptIncludeEquipment = false
+        store.updateSettings(settings)
+
+        let store2 = SettingsStore()
+        store2.loadSettings()
+        XCTAssertEqual(store2.settings?.aiPromptIncludeFormatPointer, false)
+        XCTAssertEqual(store2.settings?.aiPromptIncludeRecentWorkouts, false)
+        XCTAssertEqual(store2.settings?.aiPromptIncludeProgression, false)
+        XCTAssertEqual(store2.settings?.aiPromptIncludeEquipment, false)
     }
 
     func testUpdateSettingsHomeTiles() {

--- a/mobile-apps/ios/LiftMarkTests/WorkoutGenerationServiceTests.swift
+++ b/mobile-apps/ios/LiftMarkTests/WorkoutGenerationServiceTests.swift
@@ -84,6 +84,30 @@ final class WorkoutGenerationServiceTests: XCTestCase {
         XCTAssertTrue(prompt.contains("shoulder injury"))
     }
 
+    func testBuildPromptOmitsCustomNotesWhenNil() {
+        let context = makeContext(customPrompt: nil)
+        let params = WorkoutGenerationParams(intent: "Push day")
+        let prompt = WorkoutGenerationService.buildWorkoutGenerationPrompt(context: context, params: params)
+        XCTAssertFalse(prompt.contains("Custom notes"))
+    }
+
+    func testBuildPromptOmitsCustomNotesWhenWhitespaceOnly() {
+        let context = makeContext(customPrompt: "   \n\t  ")
+        let params = WorkoutGenerationParams(intent: "Push day")
+        let prompt = WorkoutGenerationService.buildWorkoutGenerationPrompt(context: context, params: params)
+        XCTAssertFalse(prompt.contains("Custom notes"))
+    }
+
+    func testBuildPromptPreservesMultiLineCustomNotes() {
+        let multiLine = "Line one\nLine two\nLine three"
+        let context = makeContext(customPrompt: multiLine)
+        let params = WorkoutGenerationParams(intent: "Push day")
+        let prompt = WorkoutGenerationService.buildWorkoutGenerationPrompt(context: context, params: params)
+        XCTAssertTrue(prompt.contains("Line one"))
+        XCTAssertTrue(prompt.contains("Line two"))
+        XCTAssertTrue(prompt.contains("Line three"))
+    }
+
     func testBuildPromptIncludesGymName() {
         let context = makeContext(gym: "Iron Paradise")
         let params = WorkoutGenerationParams(intent: "Workout")

--- a/mobile-apps/ios/LiftMarkUITests/LiftMarkUITests.swift
+++ b/mobile-apps/ios/LiftMarkUITests/LiftMarkUITests.swift
@@ -99,4 +99,8 @@ final class LiftMarkUITests: XCTestCase {
         runner.runScenario(named: "onboarding")
     }
 
+    func testAIPromptSettings() throws {
+        runner.runScenario(named: "ai-prompt-settings")
+    }
+
 }


### PR DESCRIPTION
## Summary
- Adds `e2e-spec/scenarios/ai-prompt-settings.yaml` covering the AI section toggles and custom-prompt input reachability, plus custom-prompt persistence across relaunch (the explicit verification ask from #94).
- New `WorkoutGenerationServiceTests` cases: nil and whitespace-only custom prompt no longer emit a stray `Custom notes` line; multi-line custom prompts round-trip into the prompt body.
- New `StoreIntegrationTests` cases: `customPromptAddition` (incl. multi-line) and the four `aiPromptInclude*` booleans round-trip through `SettingsStore` reload.
- Moves the `input-custom-prompt` accessibility identifier onto the `TextField` itself — the wrapper `VStack` didn't propagate it, so XCUITest couldn't locate it.

Toggle-state flipping inside the UI test is intentionally omitted: SwiftUI `Toggle` on iOS 26 doesn't reliably react to XCUITest `.tap()`, and the per-block behaviour is already covered by the existing toggle-off unit tests in `WorkoutGenerationServiceTests`.

## Test plan
- [x] `xcodebuild test -only-testing:LiftMarkTests` — 833 tests pass locally
- [x] `xcodebuild test -only-testing:LiftMarkUITests/LiftMarkUITests/testAIPromptSettings` — passes locally on iPhone 17 Pro / iOS 26
- [x] `swiftlint lint` — no new violations attributable to this change
- [ ] CI (unit tests + lint) green on hosted runner

Closes #94. Advances #101 (Phase 4 verification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)