### PR TITLE
chore(ios): bump Sentry 9.14.0, Yams 6.2.2, swift-log 1.13.0

### DIFF
--- a/mobile-apps/ios/LiftMark.xcodeproj/project.pbxproj
+++ b/mobile-apps/ios/LiftMark.xcodeproj/project.pbxproj
@@ -1759,7 +1759,7 @@
 			repositoryURL = "https://github.com/jpsim/Yams.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 5.1.0;
+				minimumVersion = 6.2.2;
 			};
 		};
 		C21050608BE79B97D9DAA152 /* XCRemoteSwiftPackageReference "swift-log" */ = {
@@ -1767,7 +1767,7 @@
 			repositoryURL = "https://github.com/apple/swift-log.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.5.0;
+				minimumVersion = 1.13.0;
 			};
 		};
 		E5A0C4B28CC82C9E0A371F5A /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {
@@ -1775,7 +1775,7 @@
 			repositoryURL = "https://github.com/getsentry/sentry-cocoa.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 9.10.0;
+				minimumVersion = 9.14.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/mobile-apps/ios/LiftMark.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/mobile-apps/ios/LiftMark.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa.git",
       "state" : {
-        "revision" : "0baded16c4bd1f2471949e89bf36289ca2b93080",
-        "version" : "9.12.0"
+        "revision" : "193d313fbfd9affaf2be1692a0284a3b6574c515",
+        "version" : "9.14.0"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "5073617dac96330a486245e4c0179cb0a6fd2256",
-        "version" : "1.12.0"
+        "revision" : "7dc6101ae4dbe95cd3bc9cebad3b7cf8e49a7a63",
+        "version" : "1.13.0"
       }
     },
     {
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jpsim/Yams.git",
       "state" : {
-        "revision" : "3d6871d5b4a5cd519adf233fbb576e0a2af71c17",
-        "version" : "5.4.0"
+        "revision" : "a27b21e0c81c5bf42049b897a62aaf387e80f279",
+        "version" : "6.2.2"
       }
     }
   ],

--- a/mobile-apps/ios/project.yml
+++ b/mobile-apps/ios/project.yml
@@ -19,13 +19,13 @@ packages:
     from: "7.10.0"
   Sentry:
     url: https://github.com/getsentry/sentry-cocoa.git
-    from: "9.10.0"
+    from: "9.14.0"
   Yams:
     url: https://github.com/jpsim/Yams.git
-    from: "5.1.0"
+    from: "6.2.2"
   swift-log:
     url: https://github.com/apple/swift-log.git
-    from: "1.5.0"
+    from: "1.13.0"
 
 targets:
   LiftMark:


### PR DESCRIPTION
## Summary
- Bumps three Swift packages to versions dependabot proposed in #127, #128, #129
- Updates `mobile-apps/ios/project.yml` (the source of truth) so the bumps actually take effect — dependabot only modified `pbxproj`/`Package.resolved`, which `xcodegen` wipes on every regen
- Supersedes #127, #128, #129

| Package | Old | New | Dependabot PR |
|---|---|---|---|
| sentry-cocoa | 9.10.0 | 9.14.0 | #128 |
| Yams | 5.1.0 | 6.2.2 | #127 |
| swift-log | 1.5.0 | 1.13.0 | #129 |

## Test plan
- [x] \`make build\` succeeds locally on iPhone 17 Pro (iOS 26.0)
- [x] Full \`LiftMarkUITests\` suite passes locally: 19/19, 0 failures (26 min)
- [ ] CI \`build-and-test\` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)