### PR TITLE
ci(validator): manage e2e secret access via CDK (supersedes #139)

### DIFF
--- a/validator/cdk/iam/ci-deploy-beta-policy.json
+++ b/validator/cdk/iam/ci-deploy-beta-policy.json
@@ -15,12 +15,6 @@
         "arn:aws:iam::323146837100:role/cdk-lmwf-image-publishing-role-323146837100-us-east-1",
         "arn:aws:iam::323146837100:role/cdk-lmwf-lookup-role-323146837100-us-east-1"
       ]
-    },
-    {
-      "Sid": "ReadE2ETestSecret",
-      "Effect": "Allow",
-      "Action": "secretsmanager:GetSecretValue",
-      "Resource": "arn:aws:secretsmanager:us-west-2:323146837100:secret:lmwf-beta-e2e-test-secret-*"
     }
   ]
 }

--- a/validator/cdk/stack.ts
+++ b/validator/cdk/stack.ts
@@ -6,6 +6,7 @@ import * as cloudfront from 'aws-cdk-lib/aws-cloudfront';
 import * as origins from 'aws-cdk-lib/aws-cloudfront-origins';
 import * as cloudwatch from 'aws-cdk-lib/aws-cloudwatch';
 import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import * as iam from 'aws-cdk-lib/aws-iam';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as logs from 'aws-cdk-lib/aws-logs';
 import * as route53 from 'aws-cdk-lib/aws-route53';
@@ -178,6 +179,25 @@ export class LmwfValidatorStack extends cdk.Stack {
             },
           })
         : undefined;
+
+    // Grant the CI deploy user read access to the e2e secret so the
+    // e2e-beta workflow step can `aws secretsmanager get-secret-value`
+    // before invoking Playwright. Lives on the secret's resource policy
+    // (not the user's inline policy under iam/) so the grant is created
+    // and torn down alongside the secret — no manual put-user-policy
+    // and no risk of the iam/ JSON drifting from what's on AWS.
+    if (e2eTestSecret) {
+      e2eTestSecret.addToResourcePolicy(
+        new iam.PolicyStatement({
+          actions: ['secretsmanager:GetSecretValue'],
+          principals: [
+            new iam.ArnPrincipal(
+              `arn:aws:iam::${cdk.Stack.of(this).account}:user/liftmark-ci-deploy-beta`,
+            ),
+          ],
+        }),
+      );
+    }
 
     // ── SMTP credentials (manually managed) ──
     // SES SMTP requires an IAM user converted to SMTP credentials —


### PR DESCRIPTION
## Summary

Supersedes the inline-policy approach merged in #139. Moves the `secretsmanager:GetSecretValue` grant for `liftmark-ci-deploy-beta` from the hand-applied JSON under `validator/cdk/iam/` into CDK as an `AWS::SecretsManager::ResourcePolicy` on the e2e secret itself.

## Why the swap

`ci-deploy-beta-policy.json` is documented as applied manually with `aws iam put-user-policy`. #139 updated that JSON, but the policy on AWS was never re-applied — `e2e-beta` continued to fail with `AccessDeniedException` after merge. The pattern is exactly the kind of drift the `feedback_use_cdk_for_iac` rule was meant to prevent.

A CDK-managed resource policy:
- runs on every `cdk deploy LmwfBetaValidatorStack`, so the next push lands the grant automatically;
- tears down with the secret;
- is scoped to the single principal that needs read access;
- requires no AWS-side perms beyond what CDK already has to create the secret.

## How it lands

1. Merge.
2. The next push to `main` triggers `deploy-beta`, which runs `cdk deploy` and creates the `AWS::SecretsManager::ResourcePolicy`.
3. `e2e-beta` runs next; `aws secretsmanager get-secret-value` succeeds with the deploy user's existing creds.
4. (Optional cleanup) Re-apply `ci-deploy-beta-policy.json` to drop the now-stale `ReadE2ETestSecret` inline statement from the IAM user:

    ```bash
    aws --profile liftmark-beta iam put-user-policy \
      --user-name liftmark-ci-deploy-beta \
      --policy-name CdkAssumeBootstrapRolesBeta \
      --policy-document file://validator/cdk/iam/ci-deploy-beta-policy.json
    ```

   Functionally unnecessary (the resource policy on the secret is additive), but keeps the inline policy on AWS aligned with what's in git.

## Synth excerpt (for review)

```yaml
E2ETestSecretPolicyE38A8F1E:
  Type: AWS::SecretsManager::ResourcePolicy
  Properties:
    ResourcePolicy:
      Statement:
        - Action: secretsmanager:GetSecretValue
          Effect: Allow
          Principal:
            AWS: arn:aws:iam::323146837100:user/liftmark-ci-deploy-beta
    SecretId: { Ref: E2ETestSecret928763AB }
```

## Test plan

- [x] `tsc --noEmit` on `validator/cdk/` clean.
- [x] `cdk synth LmwfBetaValidatorStack` includes the resource policy with the correct ARN.
- [ ] After merge: confirm `deploy-beta` creates the resource policy and `e2e-beta` reaches `npx playwright test` without `AccessDeniedException`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)