### PR TITLE
fix(validator): add Resource:* to e2e secret resource policy

### DIFF
--- a/validator/cdk/stack.ts
+++ b/validator/cdk/stack.ts
@@ -195,6 +195,11 @@ export class LmwfValidatorStack extends cdk.Stack {
               `arn:aws:iam::${cdk.Stack.of(this).account}:user/liftmark-ci-deploy-beta`,
             ),
           ],
+          // Secrets Manager resource policies require an explicit Resource
+          // element; '*' resolves to the secret this policy is attached to.
+          // Without this, CFN returns "A required element is missing from
+          // the policy."
+          resources: ['*'],
         }),
       );
     }


### PR DESCRIPTION
## Summary

Follow-up to #141. `deploy-beta` rolled back with:

> A required element is missing from the policy. (Service: SecretsManager, Status Code: 400)

CDK's `secret.addToResourcePolicy(new iam.PolicyStatement({...}))` passes the statement through verbatim, and `PolicyStatement` defaults to no `Resource` element. Secrets Manager's `PutResourcePolicy` validates that `Resource` is present (it can be `*` or the secret ARN, both resolve to "this secret" in a resource policy context).

Adds `resources: ['*']` to the statement. Verified via `cdk synth` — `Resource: "*"` is now emitted.

## Test plan

- [x] `tsc --noEmit` on `validator/cdk/` clean.
- [x] `cdk synth LmwfBetaValidatorStack` shows `Resource: "*"` under the `AWS::SecretsManager::ResourcePolicy` statement.
- [ ] After merge: `deploy-beta` completes (CFN rolls forward from the previous `UPDATE_ROLLBACK_COMPLETE` state) and `e2e-beta` reaches Playwright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)