### PR TITLE
fix(validator): make e2e-beta signup + PAT tests pass on SES sandbox + cold start

### DIFF
--- a/spec/services/validator-e2e.md
+++ b/spec/services/validator-e2e.md
@@ -88,6 +88,36 @@ Unit tests cover: secret missing → 404; secret wrong → 404 (not 401, to
 avoid disclosing existence); secret right + unknown email → 404; happy
 path → 200 with a JWT that verifies under `JWT_SECRET`.
 
+## Verified recipient for signup test
+
+SES on beta is in sandbox mode: outbound mail is rejected for any
+recipient that isn't explicitly verified. The signup test exercises the
+real `POST /v1/auth/password/signup` → `sendVerificationEmail` path, so
+the test recipient has to be verified or the endpoint 503s and the
+test sees a `waitForResponse` timeout.
+
+The remote E2E mode uses a single verified address
+(`crusted_staid_0k@icloud.com`) for that one test. SES sandbox
+verification is exact-match — plus-addressing variants count as
+different addresses — so re-using one verified address is the only
+viable option without graduating SES out of sandbox.
+
+To keep that single address re-runnable across CI invocations, the
+test calls a second test-only endpoint before signup:
+
+```
+POST /v1/__test__/delete-user-by-email
+X-Test-Secret: <shared secret>
+{ "email": "..." }
+→ 200 { "deleted": true | false, "user_id"?: "..." }
+```
+
+Hard-deletes the user identified by the (`password`, email) identity,
+along with every referencing row (identities, pat_tokens,
+refresh_tokens, entitlements, workout_inbox, workout_outbox).
+Idempotent — returns 200 with `deleted: false` when no such user
+exists. Same activation gate as `/v1/__test__/mint-token`.
+
 ## Local serving
 
 The validator gets one new affordance for E2E: when

--- a/validator/e2e/helpers/api.ts
+++ b/validator/e2e/helpers/api.ts
@@ -151,6 +151,27 @@ export async function login(opts: {
   };
 }
 
+/**
+ * Hard-delete any user matching this email (and all their related rows)
+ * via /v1/__test__/delete-user-by-email. No-op when the user doesn't
+ * exist. Used to make signup tests rerunnable when SES sandbox forces
+ * us to reuse a verified address.
+ */
+export async function deleteTestUser(email: string): Promise<void> {
+  const res = await fetch(`${getBaseUrl()}/v1/__test__/delete-user-by-email`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-test-secret': getTestSecret(),
+    },
+    body: JSON.stringify({ email }),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`delete-user-by-email failed (${res.status}): ${text}`);
+  }
+}
+
 export async function seedOutboxItem(opts: {
   userId: string;
   sessionName?: string;

--- a/validator/e2e/helpers/env.ts
+++ b/validator/e2e/helpers/env.ts
@@ -46,3 +46,23 @@ export function getMailpitUrl(): string {
 export function uniqueEmail(label: string): string {
   return `e2e-${label}-${Date.now()}-${Math.floor(Math.random() * 1e9)}@example.com`;
 }
+
+/**
+ * Address that's verified in SES sandbox for the target env. Used by
+ * the signup test in `remote` mode, where SES rejects any unverified
+ * recipient and `@example.com` would 503 the signup endpoint.
+ *
+ * SES sandbox compares the full recipient verbatim (no plus-addressing
+ * normalization), so re-using one verified address is the only viable
+ * option without leaving the sandbox. The test pairs this with
+ * /v1/__test__/delete-user-by-email pre-cleanup so successive runs
+ * don't trip the 409 dupe-check on signup.
+ *
+ * In `local` mode SES is replaced by Mailpit, so we still want unique
+ * addresses per run for parallel-worker safety.
+ */
+export function signupTestEmail(): string {
+  return getMode() === 'remote'
+    ? 'crusted_staid_0k@icloud.com'
+    : uniqueEmail('signup');
+}

--- a/validator/e2e/tests/account-pats.spec.ts
+++ b/validator/e2e/tests/account-pats.spec.ts
@@ -12,7 +12,16 @@ test('create + revoke a personal access token', async ({ page }) => {
   await page.locator('#new-token-btn').click();
   const tokenName = `e2e-pat-${Date.now()}`;
   await page.locator('#tok-name').fill(tokenName);
-  await page.locator('#new-token-form button[type=submit]').click();
+
+  // Wait for the server's response BEFORE asserting on DOM that's only
+  // populated after that response lands — beta cold-starts can blow the
+  // default 5s expect timeout and produce flakes.
+  await Promise.all([
+    page.waitForResponse(
+      (r) => r.url().endsWith('/v1/tokens') && r.request().method() === 'POST' && r.status() === 201,
+    ),
+    page.locator('#new-token-form button[type=submit]').click(),
+  ]);
 
   // Plaintext block surfaces once after create.
   await expect(page.locator('#token-plaintext')).toContainText(/lm_pat_/);

--- a/validator/e2e/tests/auth-signup-verify.spec.ts
+++ b/validator/e2e/tests/auth-signup-verify.spec.ts
@@ -1,10 +1,16 @@
 import { expect, test } from '@playwright/test';
-import { uniqueEmail } from '../helpers/env.js';
+import { deleteTestUser } from '../helpers/api.js';
+import { signupTestEmail, uniqueEmail } from '../helpers/env.js';
 import { getLatestToken } from '../helpers/tokens.js';
 
 test('full signup → email verify flow', async ({ page, request }) => {
-  const email = uniqueEmail('signup');
+  const email = signupTestEmail();
   const password = 'correct horse battery staple';
+
+  // In remote mode `email` is a single verified-in-SES address that
+  // gets reused across runs; wipe any leftover user from a prior run so
+  // the signup endpoint doesn't 409. No-op when the user doesn't exist.
+  await deleteTestUser(email);
 
   await page.goto('/account/signup');
 

--- a/validator/src/routes/__test__/index.ts
+++ b/validator/src/routes/__test__/index.ts
@@ -13,18 +13,22 @@
  *
  * See spec/services/validator-e2e.md → "Test-only token endpoint".
  */
+import { DeleteCommand, QueryCommand } from '@aws-sdk/lib-dynamodb';
 import { Hono } from 'hono';
 import { timingSafeEqual } from 'node:crypto';
 import type { MiddlewareHandler } from 'hono';
+import { ddb, tableName } from '../../infra/ddb.js';
 import { signJwt } from '../../infra/jwt.js';
 import { hashPassword } from '../../infra/password.js';
 import {
   createIdentity,
   getIdentityByProviderSub,
+  listIdentitiesByUserId,
   markEmailVerified,
 } from '../../repositories/identities.js';
 import {
   createUser,
+  deleteUser,
   updateUserTier,
   type UserTier,
 } from '../../repositories/users.js';
@@ -243,4 +247,115 @@ testRouter.post('/mint-token', async (c) => {
     type === 'email_verify' ? '24h' : '1h',
   );
   return c.json({ token }, 200);
+});
+
+interface DeleteUserBody {
+  email?: unknown;
+}
+
+/**
+ * Hard-delete a user and every row that references them, identified by
+ * the password-provider email. Idempotent — returns 200 even when no
+ * user exists for the email.
+ *
+ * Exists so the `remote` E2E suite can re-use a single verified
+ * recipient (SES sandbox is exact-match on the recipient address; see
+ * spec/services/validator-e2e.md → "Verified recipient for signup
+ * test"). Without this, the second test run hits the 409 dupe-check on
+ * /v1/auth/password/signup.
+ *
+ * Same gate as the rest of /v1/__test__: missing/wrong secret → 404,
+ * LMWF_ENV=prod → 404.
+ */
+testRouter.post('/delete-user-by-email', async (c) => {
+  let body: DeleteUserBody;
+  try {
+    body = await c.req.json<DeleteUserBody>();
+  } catch {
+    return c.json({ error: 'Invalid JSON body' }, 400);
+  }
+
+  const emailRaw = body.email;
+  if (typeof emailRaw !== 'string' || emailRaw.length === 0) {
+    return c.json({ error: 'email must be a string' }, 400);
+  }
+  const email = emailRaw.toLowerCase();
+
+  const identity = await getIdentityByProviderSub('password', email);
+  if (!identity) {
+    return c.json({ deleted: false, reason: 'no_such_user' }, 200);
+  }
+  const user_id = identity.user_id;
+
+  // identities — there may be more than one (linked accounts).
+  const identities = await listIdentitiesByUserId(user_id);
+  await Promise.all(
+    identities.map((i) =>
+      ddb.send(
+        new DeleteCommand({
+          TableName: tableName('identities'),
+          Key: { identity_id: i.identity_id },
+        }),
+      ),
+    ),
+  );
+
+  // Tables with PK=token_hash and a user_id GSI: pat_tokens, refresh_tokens.
+  for (const t of ['pat_tokens', 'refresh_tokens'] as const) {
+    const q = await ddb.send(
+      new QueryCommand({
+        TableName: tableName(t),
+        IndexName: 'user_id-index',
+        KeyConditionExpression: 'user_id = :uid',
+        ExpressionAttributeValues: { ':uid': user_id },
+      }),
+    );
+    await Promise.all(
+      (q.Items ?? []).map((item) =>
+        ddb.send(
+          new DeleteCommand({
+            TableName: tableName(t),
+            Key: { token_hash: (item as { token_hash: string }).token_hash },
+          }),
+        ),
+      ),
+    );
+  }
+
+  // entitlements: PK is user_id.
+  await ddb.send(
+    new DeleteCommand({
+      TableName: tableName('entitlements'),
+      Key: { user_id },
+    }),
+  );
+
+  // workout_inbox / workout_outbox: composite (user_id, <sk>).
+  for (const t of ['workout_inbox', 'workout_outbox'] as const) {
+    const skName = t === 'workout_inbox' ? 'inbox_id' : 'outbox_id';
+    const q = await ddb.send(
+      new QueryCommand({
+        TableName: tableName(t),
+        KeyConditionExpression: 'user_id = :uid',
+        ExpressionAttributeValues: { ':uid': user_id },
+      }),
+    );
+    await Promise.all(
+      (q.Items ?? []).map((item) =>
+        ddb.send(
+          new DeleteCommand({
+            TableName: tableName(t),
+            Key: {
+              user_id,
+              [skName]: (item as Record<string, string>)[skName],
+            },
+          }),
+        ),
+      ),
+    );
+  }
+
+  await deleteUser(user_id);
+
+  return c.json({ deleted: true, user_id }, 200);
 });


### PR DESCRIPTION
## Summary

The first end-to-end run of `e2e-beta` (after PRs #139/#141/#142 cleared the IAM path) surfaced two issues the local suite can't reproduce:

1. **`auth-signup-verify` failed every attempt.** The test does a real `/v1/auth/password/signup` against beta. Beta SES is in sandbox mode, so sends to any unverified recipient (the suite's default `e2e-signup-…@example.com`) are rejected — signup returns 503 after rolling back, and the Playwright predicate (`r.status() === 201`) just sees a 10s `waitForResponse` timeout.

2. **`account-pats` was flaky.** `#token-plaintext` stayed empty past the default 5s `expect.timeout`, then passed on retry. Lambda cold start on a fresh deploy beats the timeout for the very first PAT POST.

## Changes

### Test-only endpoint

`POST /v1/__test__/delete-user-by-email` — hard-deletes a user and every referencing row (identities, pat_tokens, refresh_tokens, entitlements, workout_inbox, workout_outbox). Idempotent. Same gate-middleware as the other test endpoints (`E2E_TEST_SECRET` + `LMWF_ENV != 'prod'` + matching `X-Test-Secret`).

### Signup test

- `signupTestEmail()` returns `crusted_staid_0k@icloud.com` (SES-verified inbox owned by the user) in remote mode and `uniqueEmail('signup')` in local mode.
- `deleteTestUser(email)` POSTs to the new endpoint.
- The test calls `deleteTestUser(email)` before opening the signup form so the verified address is re-runnable across CI invocations without tripping the 409 dupe-check.

### PAT test

- `Promise.all(page.waitForResponse(POST /v1/tokens, 201), click)` ensures the DOM assertion runs *after* the server replies — no cold-start race.

### Spec

- New "Verified recipient for signup test" section in `spec/services/validator-e2e.md` documents both the SES-sandbox rationale and the `delete-user-by-email` contract.

## Why exact-match SES verification (vs plus-addressing)

SES sandbox compares recipient addresses verbatim — `crusted_staid_0k+anything@icloud.com` is treated as a different address from `crusted_staid_0k@icloud.com`. Re-using one verified address with pre-test cleanup is the only viable path short of moving beta SES out of sandbox.

## Test plan

- [x] `tsc --noEmit` clean on `validator/` and `validator/e2e/`.
- [x] `scripts/e2e-local.sh` — all 11 tests pass in 1.9s.
- [ ] After merge: `e2e-beta` runs against beta and both `auth-signup-verify` + `account-pats` pass against the real SES + Lambda cold-start path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)