### PR TITLE
fix(validator): kill e2e-beta cold-start flakes (sign-out await + Lambda warm-up)

### DIFF
--- a/.github/workflows/validator-ci.yml
+++ b/.github/workflows/validator-ci.yml
@@ -345,6 +345,24 @@ jobs:
           # Mask before exposing as an output so it never lands in logs.
           echo "::add-mask::$SECRET"
           echo "secret=$SECRET" >> "$GITHUB_OUTPUT"
+      # Warm the beta Lambda before the suite runs. deploy-beta ships a
+      # fresh function version and smoke-beta only makes a couple of
+      # sequential calls (one warm instance); Playwright then hits the API
+      # with 4 parallel workers, triggering concurrent cold starts that
+      # blew the action/navigation timeouts (sign-out redirect, first PAT
+      # create). Fire several concurrent rounds so Lambda scales out and
+      # the suite lands on warm instances.
+      - name: Warm beta Lambda
+        run: |
+          set -uo pipefail
+          echo "==> warming https://beta.liftmark.app"
+          for round in 1 2 3; do
+            for i in $(seq 1 8); do
+              curl -s -o /dev/null --max-time 30 https://beta.liftmark.app/version &
+            done
+            wait
+          done
+          echo "==> warm-up complete"
       - name: Run Playwright against beta
         working-directory: validator/e2e
         env:

--- a/website/src/pages/account/index.astro
+++ b/website/src/pages/account/index.astro
@@ -321,17 +321,22 @@ const exampleLmwf = `# Push Day
     }
 
     function bindHandlers() {
-      document.getElementById('signout-btn').addEventListener('click', async () => {
-        // Best-effort server-side revocation before clearing local state.
-        // We don't await/branch on the result — even if logout fails,
-        // clearing localStorage is the right user-visible outcome.
+      document.getElementById('signout-btn').addEventListener('click', () => {
+        // Best-effort server-side revocation. Fire-and-forget: we do NOT
+        // await it. `keepalive` lets the request outlive the redirect, so
+        // the token still gets revoked, but a cold-start round-trip can
+        // never stall the user on the dashboard. (Awaiting it here caused
+        // the e2e sign-out test to time out against a freshly-deployed,
+        // cold beta Lambda.) The fetch is dispatched synchronously below,
+        // capturing the current Authorization header before clearSession.
         const refresh_token = getRefreshToken();
         if (refresh_token) {
           try {
-            await api('/v1/auth/logout', {
+            api('/v1/auth/logout', {
               method: 'POST',
               body: { refresh_token },
-            });
+              keepalive: true,
+            }).catch(() => {});
           } catch {}
         }
         clearSession();


### PR DESCRIPTION
## Summary

The SES fix (#148) landed and `auth-signup-verify` now passes against beta. But that run exposed two **cold-start** casualties — the deploy ships a fresh Lambda version, `smoke-beta` warms only one instance, then Playwright's 4 parallel workers trigger concurrent cold starts (run was 44.8s vs 32.3s warm):

- **`auth-login-logout` (hard fail)** — `waitForURL('**/account/login')` timed out at 15s after sign-out.
- **`account-pats` (flaky)** — PAT-create `waitForResponse` timed out at 10s, passed on retry.

## Fixes

### 1. Sign-out is fire-and-forget (`website/src/pages/account/index.astro`)

The handler's comment already said *"we don't await/branch on the result"*, but the code actually `await`ed `POST /v1/auth/logout`, so a cold-start round-trip stalled the redirect past the 15s budget. Now it dispatches the logout with `keepalive: true` (request survives the navigation, token still gets revoked) and redirects immediately. The fetch is kicked off synchronously before `clearSession()`, so it still carries the `Authorization` header. Net: better UX (sign-out never blocks on network) and the test no longer depends on logout latency.

### 2. Warm-up step before Playwright (`validator-ci.yml`)

New `Warm beta Lambda` step: 3 rounds × 8 concurrent `GET /version` so Lambda scales out and the suite lands on warm instances.

I chose warm-up over bumping timeouts deliberately — per the suite's reliability budget, longer timeouts mask real regressions, whereas cold-start is a known, fixable infra characteristic.

## Test plan

- [x] `e2e-local.sh tests/auth-login-logout.spec.ts tests/account-pats.spec.ts` — 3/3 pass; sign-out still clears session + redirects.
- [x] Workflow YAML parses.
- [ ] After merge: `e2e-beta` runs warm and both tests pass against beta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)