### PR TITLE
fix(website): bind dashboard handlers before the inbox fetch (e2e-beta sign-out)

### DIFF
--- a/website/src/pages/account/index.astro
+++ b/website/src/pages/account/index.astro
@@ -163,10 +163,15 @@ const exampleLmwf = `# Push Day
       document.getElementById('loading').hidden = true;
       document.getElementById('dash').hidden = false;
 
+      // Wire up handlers as soon as the dashboard is visible — they only
+      // touch static DOM (sign-out, create-token), not inbox data. Doing
+      // this BEFORE the inbox fetch closes a race where a user (or the
+      // E2E suite) clicks sign-out while `await refreshInbox()` is still
+      // pending against a cold backend, hitting an unbound button.
+      bindHandlers();
+
       // Inbox is reachable directly via the session JWT — no PAT needed.
       await refreshInbox();
-
-      bindHandlers();
     }
 
     function renderHeader(body) {


### PR DESCRIPTION
## Summary

Root cause of the persistent `auth-login-logout` hard failure on `e2e-beta`. It is **not** cold-start — it's a real ordering bug in the account dashboard.

`init()` in `account/index.astro` did:

1. `await api('/v1/tokens')`
2. `renderHeader()` → populates `#user-email`, makes sign-out button visible
3. show dashboard
4. `await refreshInbox()` → second API call to `/v1/workouts`
5. `bindHandlers()` → finally attaches the sign-out click listener

The test waits for `#user-email` (step 2), then clicks sign-out — but the listener isn't attached until step 5, *after* the inbox fetch. The Playwright trace confirms it: dashboard loads, `GET /v1/tokens` + `GET /v1/workouts` fire, then **total silence** — no logout request, no navigation — and `waitForURL('**/account/login')` times out at 15s. Locally the inbox fetch is instant so the race window is invisible; against a beta backend it loses every time.

A real user clicking sign-out quickly on a slow connection hits the same dead button.

## Fix

Move `bindHandlers()` ahead of `await refreshInbox()`. The handlers only touch static dashboard markup (sign-out, create-token, inbox filter/refresh, push form) — verified none are created by `refreshInbox` — so binding them as soon as `#dash` is visible is safe and closes the race for real users too.

## Relationship to #149

#149's fire-and-forget sign-out + Lambda warm-up were treating symptoms (and stand on their own — sign-out shouldn't block on logout latency, and warm-up fixed the `account-pats` flake, which passed in the latest run). This ordering bug was the actual cause of the login-logout failure.

## Test plan

- [x] `e2e-local.sh` for auth-login-logout + account-pats + account-outbox — 4/4 pass.
- [ ] After merge: `e2e-beta` runs fully green against beta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)