### PR TITLE
ci: fix matrix-skip check names (validate job)

### DIFF
--- a/.github/workflows/validator-ci.yml
+++ b/.github/workflows/validator-ci.yml
@@ -52,7 +52,13 @@ jobs:
   validate:
     name: validate (${{ matrix.check }})
     needs: changes
-    if: needs.changes.outputs.validator == 'true'
+    # Gate at the STEP level, not the job level. A skipped *matrix* job
+    # reports a single check named literally `validate (${{ matrix.check }})`
+    # — the matrix never expands — so the required contexts `validate (test)`
+    # / `validate (typecheck)` would never report and would block iOS PRs
+    # forever. Letting the job run but skipping its steps preserves matrix
+    # expansion (correct check names, reported green) while doing no work on
+    # non-validator PRs.
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -63,13 +69,17 @@ jobs:
         working-directory: validator
     steps:
       - uses: actions/checkout@v6
+        if: needs.changes.outputs.validator == 'true'
       - uses: actions/setup-node@v6
+        if: needs.changes.outputs.validator == 'true'
         with:
           node-version: '20'
           cache: 'npm'
           cache-dependency-path: validator/package-lock.json
-      - run: npm ci
+      - if: needs.changes.outputs.validator == 'true'
+        run: npm ci
       - name: ${{ matrix.check }}
+        if: needs.changes.outputs.validator == 'true'
         run: npm run ${{ matrix.check }}
 
   # ── Stage 2: build ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem
Follow-up to #152. PR #140's check run revealed a gap: the validator `validate` job is a **matrix** job. When a matrix job is skipped by a job-level `if:`, GitHub reports it under the *unexpanded* template name `validate (${{ matrix.check }})` — the matrix never fans out. So the required contexts `validate (test)` / `validate (typecheck)` never report on iOS-only PRs and would keep them blocked despite #152.

Non-matrix jobs (`build`, `build-and-test`) are unaffected — they skip with correct names.

## Fix
Gate the `validate` job at the **step** level instead of the job level. The job always runs (so the matrix expands → correct check names, reported green), but every step is `if: needs.changes.outputs.validator == 'true'`, so it does no real work on non-validator PRs.

## Test plan
- [ ] This PR touches `validator-ci.yml` → `validate (test)` / `validate (typecheck)` run with steps and pass (proves the running path + correct names).
- [ ] After merge, #140 (iOS-only) re-runs → `validate (test)` / `validate (typecheck)` report **green (skipped steps)** instead of the template name → #140 unblocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)