### PR TITLE
ci: bump upload-artifact@v4 to v7 in validator-ci

### DIFF
--- a/.github/workflows/validator-ci.yml
+++ b/.github/workflows/validator-ci.yml
@@ -113,14 +113,14 @@ jobs:
         working-directory: website
         run: npm run build
       - name: Upload validator bundle
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: validator-bundle
           path: validator/dist
           if-no-files-found: error
           retention-days: 7
       - name: Upload website bundle
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: website-bundle
           path: website/dist
@@ -241,14 +241,14 @@ jobs:
             npx playwright test
       - name: Upload Playwright report on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report
           path: validator/e2e/playwright-report
           retention-days: 14
       - name: Upload validator log on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: validator-log
           path: /tmp/validator.log
@@ -400,7 +400,7 @@ jobs:
         run: npx playwright test
       - name: Upload Playwright report on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report-beta
           path: validator/e2e/playwright-report


### PR DESCRIPTION
## Summary
- Bumps all `actions/upload-artifact@v4` to `@v7` in `.github/workflows/validator-ci.yml` to clear the Node 20 deprecation (force-bump 2026-06-02). Matches the rest of the repo, which is already on v7.
- `download-artifact` is bumped separately in a follow-up PR (→ v8) so its post-merge deploy path can be verified in isolation, per the plan in #135.

Part of #135, #151.

## Test plan
- [ ] `build` job (which runs the upload step) passes in PR checks.