### PR TITLE
ci: bump download-artifact@v4 to v8 in validator-ci

### DIFF
--- a/.github/workflows/validator-ci.yml
+++ b/.github/workflows/validator-ci.yml
@@ -169,7 +169,7 @@ jobs:
         working-directory: validator/e2e
         run: npx playwright install --with-deps chromium
       - name: Download website bundle
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: website-bundle
           path: website/dist
@@ -283,12 +283,12 @@ jobs:
         working-directory: validator/cdk
         run: npm ci --no-audit --no-fund
       - name: Download validator bundle
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: validator-bundle
           path: validator/dist
       - name: Download website bundle
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: website-bundle
           path: website/dist
@@ -436,12 +436,12 @@ jobs:
         working-directory: validator/cdk
         run: npm ci --no-audit --no-fund
       - name: Download validator bundle
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: validator-bundle
           path: validator/dist
       - name: Download website bundle
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: website-bundle
           path: website/dist


### PR DESCRIPTION
## Summary
- Bumps all `actions/download-artifact@v4` to `@v8` in `.github/workflows/validator-ci.yml`, clearing the remaining Node 20 deprecation ahead of the 2026-06-02 force-bump.
- Follow-up to the `upload-artifact@v7` PR. Within a single run, upload v7 + download v8 are compatible.
- The download steps run only in `deploy-beta`/`deploy-prod`, which fire on `push`, so this is verified by the post-merge run on `main` (the `CDK deploy` step prints artifact paths; a mis-extracted download would surface as a `BucketDeployment` failure).

Closes #135, #151.

## Test plan
- [ ] PR checks (build/validate) pass.
- [ ] Post-merge `deploy-beta` and `deploy-prod` succeed on `main`.