### PR TITLE
feat(validator): warn on single-member supersets

### DIFF
--- a/liftmark-workout-format/LIFTMARK_WORKOUT_FORMAT_SPEC.md
+++ b/liftmark-workout-format/LIFTMARK_WORKOUT_FORMAT_SPEC.md
@@ -781,6 +781,7 @@ Short sprints with full recovery.
 - ⚠️ Mixed section levels — exercises and sections (groups with nested headers) at the same heading level. This is valid but may indicate structural issues (e.g., `## Warmup` as a section alongside `## Bench Press` as a standalone exercise).
 - ⚠️ `EXERCISE_ALIAS_SUGGESTION` — alias used in place of canonical name (e.g., `Bench` → `Bench Press`)
 - ⚠️ `EXERCISE_NAME_SUGGESTION` — fuzzy "did you mean?" hint for likely typos near a canonical name
+- ⚠️ `SINGLE_MEMBER_SUPERSET` — a superset block that contains only one exercise. A superset pairs two or more exercises performed back-to-back, so a one-member superset is almost always an authoring mistake that is otherwise invisible in the source markdown. The warning points at the superset block line and names the lone member. The file still parses (it is a warning, not an error); the fix is to add another exercise to the superset or convert it to a regular exercise/section.
 
 ### Error Examples
 

--- a/validator/src/parser/index.ts
+++ b/validator/src/parser/index.ts
@@ -672,6 +672,21 @@ function parseGroupedExercises(
     }
   }
 
+  // Warn on a superset that contains only a single member. A superset pairs two or
+  // more exercises performed back-to-back, so a one-member superset is almost always
+  // an authoring mistake that is invisible in the source markdown.
+  if (isSuperset && childExercises.length === 1) {
+    context.warnings.push({
+      line: headerLine.lineNumber,
+      message:
+        `Superset '${groupName}' contains only one exercise ` +
+        `('${childExercises[0].exerciseName}'). A superset pairs two or more exercises ` +
+        `performed back-to-back — add another exercise to this superset, or convert it ` +
+        `to a regular exercise or section if it was not meant to be a superset.`,
+      code: 'SINGLE_MEMBER_SUPERSET',
+    });
+  }
+
   return [parentExercise, ...childExercises];
 }
 

--- a/validator/tests/parser.test.ts
+++ b/validator/tests/parser.test.ts
@@ -329,6 +329,41 @@ describe('Supersets', () => {
     // data is null when success is false
     expect(result.data).toBeNull();
   });
+
+  it('warns when a superset contains only one member', () => {
+    const markdown = `# Workout
+
+## Superset
+### Bicep Curls
+- 20 x 10`;
+    const result = parseWorkout(markdown);
+
+    // Still a valid file — single-member superset is a warning, not an error.
+    expect(result.success).toBe(true);
+
+    const singleMemberWarnings = result.warnings.filter((w) =>
+      w.includes('contains only one exercise')
+    );
+    expect(singleMemberWarnings.length).toBe(1);
+    // Warning points at the superset block line (## Superset is line 3) and names the lone member.
+    expect(singleMemberWarnings[0]).toContain('Line 3:');
+    expect(singleMemberWarnings[0]).toContain("Superset");
+    expect(singleMemberWarnings[0]).toContain("Bicep Curls");
+  });
+
+  it('does NOT warn when a superset contains two or more members', () => {
+    const markdown = `# Workout
+
+## Superset
+### Bicep Curls
+- 20 x 10
+### Tricep Extensions
+- 20 x 10`;
+    const result = parseWorkout(markdown);
+
+    expect(result.success).toBe(true);
+    expect(result.warnings.some((w) => w.includes('contains only one exercise'))).toBe(false);
+  });
 });
 
 // MARK: - Sections


### PR DESCRIPTION
## Summary
- Adds a non-blocking `SINGLE_MEMBER_SUPERSET` validator warning for supersets that contain only one exercise. A superset of one is almost always an authoring mistake that is invisible in the source markdown.
- The warning points at the superset block line and names the lone member. The file still parses (warning, not error).
- Updates the LMWF spec Warnings (non-blocking) section to document the new warning.

## Implementation
- `validator/src/parser/index.ts`: in `parseGroupedExercises`, when `isSuperset && childExercises.length === 1`, push a `SINGLE_MEMBER_SUPERSET` warning following the existing `context.warnings.push({ line, message, code })` pattern.
- Spec: `liftmark-workout-format/LIFTMARK_WORKOUT_FORMAT_SPEC.md`.

## Test plan
- [x] New parser test: single-member superset emits exactly one warning containing the superset name + lone member, at the correct line; `success` stays `true`.
- [x] New parser test: multi-member superset emits no such warning.
- [x] `npm run typecheck` clean.
- [x] Full validator suite: 174 passed (164 skipped DDB integration tests).

Part of #145