### PR TITLE
fix(ios): render single-member supersets as standalone (no SUPERSET badge)

### DIFF
--- a/mobile-apps/ios/LiftMark/Models/Enums.swift
+++ b/mobile-apps/ios/LiftMark/Models/Enums.swift
@@ -50,6 +50,27 @@ enum GroupType: String, Codable, Hashable, CaseIterable {
     case section
 }
 
+/// Shared rules for grouping exercises into supersets.
+///
+/// A superset only means something when it has two or more members to
+/// alternate between. A "single-member superset" (a superset block that
+/// happens to contain exactly one exercise — almost always an authoring
+/// mistake) is not a real superset: there is nothing to alternate with.
+/// Both the plan (pre-start) view and the active (in-progress) view use
+/// this predicate so they render single-member supersets identically — as
+/// a standalone exercise with no SUPERSET badge or grouped card.
+enum SupersetGrouping {
+    /// Minimum number of child exercises required for a superset to be
+    /// rendered as a grouped superset.
+    static let minimumMembers = 2
+
+    /// True when a collection of superset children is large enough to be
+    /// treated as a real (grouped) superset.
+    static func isRealSuperset(childCount: Int) -> Bool {
+        childCount >= minimumMembers
+    }
+}
+
 // MARK: - Theme
 
 enum AppTheme: String, Codable, Hashable, CaseIterable {

--- a/mobile-apps/ios/LiftMark/Views/Workout/ActiveWorkoutViewModel.swift
+++ b/mobile-apps/ios/LiftMark/Views/Workout/ActiveWorkoutViewModel.swift
@@ -74,8 +74,14 @@ enum ActiveWorkoutViewModel {
                     }
                 }
                 processedIds.insert(exercise.id)
-                if !children.isEmpty {
+                if SupersetGrouping.isRealSuperset(childCount: children.count) {
                     items.append(.superset(parent: exercise, children: children))
+                } else {
+                    // Single-member superset is not a real superset — render the
+                    // lone child as a standalone exercise, matching the plan view.
+                    for child in children {
+                        items.append(.single(exercise: child.exercise, exerciseIndex: child.exerciseIndex, displayNumber: child.displayNumber))
+                    }
                 }
             } else if exercise.parentExerciseId != nil {
                 // Skip orphan children (already handled by superset parent)
@@ -103,8 +109,14 @@ enum ActiveWorkoutViewModel {
                             }
                         }
                         processedIds.insert(child.id)
-                        if !grandchildren.isEmpty {
+                        if SupersetGrouping.isRealSuperset(childCount: grandchildren.count) {
                             items.append(.superset(parent: child, children: grandchildren))
+                        } else {
+                            // Single-member superset inside a section — render the
+                            // lone grandchild standalone, matching the plan view.
+                            for grandchild in grandchildren {
+                                items.append(.single(exercise: grandchild.exercise, exerciseIndex: grandchild.exerciseIndex, displayNumber: grandchild.displayNumber))
+                            }
                         }
                     } else {
                         items.append(.single(exercise: child, exerciseIndex: childIndex, displayNumber: displayNumber))

--- a/mobile-apps/ios/LiftMark/Views/Workouts/WorkoutDetailSubviews.swift
+++ b/mobile-apps/ios/LiftMark/Views/Workouts/WorkoutDetailSubviews.swift
@@ -131,7 +131,6 @@ struct PlanExerciseCard: View {
     let exercise: PlannedExercise
     let sectionName: String?
     let exerciseIndex: Int
-    let supersetIndex: Int
     let onEdit: () -> Void
 
     var body: some View {
@@ -146,18 +145,12 @@ struct PlanExerciseCard: View {
                     .frame(minWidth: 20)
 
                 VStack(alignment: .leading, spacing: 2) {
-                    // Superset badge
-                    if exercise.groupType == .superset {
-                        Text("SUPERSET")
-                            .font(.caption2)
-                            .fontWeight(.bold)
-                            .foregroundStyle(.purple)
-                            .padding(.horizontal, 8)
-                            .padding(.vertical, 2)
-                            .background(Color.purple.opacity(0.1))
-                            .clipShape(RoundedRectangle(cornerRadius: 4))
-                            .accessibilityIdentifier("superset-\(supersetIndex)")
-                    }
+                    // No SUPERSET badge here: a standalone card is only used for
+                    // real (non-grouped) exercises and single-member supersets.
+                    // A single-member superset is not a real superset (nothing to
+                    // alternate with), so it renders as a plain exercise — matching
+                    // the active workout view. Real supersets (2+ members) render
+                    // via PlanSupersetCard, which carries the badge.
 
                     // Exercise name
                     Text(exercise.exerciseName)

--- a/mobile-apps/ios/LiftMark/Views/Workouts/WorkoutDetailView.swift
+++ b/mobile-apps/ios/LiftMark/Views/Workouts/WorkoutDetailView.swift
@@ -76,8 +76,15 @@ struct WorkoutDetailView: View {
                     }
                 }
                 processedIds.insert(exercise.id)
-                if !children.isEmpty {
+                if SupersetGrouping.isRealSuperset(childCount: children.count) {
                     items.append(.superset(parent: exercise, children: children))
+                } else {
+                    // Single-member superset is not a real superset — render the
+                    // lone child as a standalone exercise (no SUPERSET badge),
+                    // matching the active workout view.
+                    for child in children {
+                        items.append(.single(exercise: child))
+                    }
                 }
             } else if exercise.parentExerciseId != nil {
                 // Skip orphan children already handled
@@ -99,8 +106,14 @@ struct WorkoutDetailView: View {
                             }
                         }
                         processedIds.insert(child.id)
-                        if !grandchildren.isEmpty {
+                        if SupersetGrouping.isRealSuperset(childCount: grandchildren.count) {
                             items.append(.superset(parent: child, children: grandchildren))
+                        } else {
+                            // Single-member superset inside a section — render the
+                            // lone grandchild standalone, matching the active view.
+                            for grandchild in grandchildren {
+                                items.append(.single(exercise: grandchild))
+                            }
                         }
                     } else {
                         items.append(.single(exercise: child))
@@ -189,7 +202,6 @@ struct WorkoutDetailView: View {
                                                 exercise: exercise,
                                                 sectionName: section.name,
                                                 exerciseIndex: globalExerciseIndex(for: exercise),
-                                                supersetIndex: supersetIndexFor(exercise),
                                                 onEdit: { editingPlanExercise = exercise }
                                             )
                                         case .superset(let parent, let children):
@@ -448,24 +460,6 @@ struct WorkoutDetailView: View {
     private func reprocessPlan() {
         guard let plan, let markdown = plan.sourceMarkdown else { return }
         planStore.reprocessPlan(id: plan.id, fromMarkdown: markdown)
-    }
-
-    private func supersetIndexFor(_ exercise: PlannedExercise) -> Int {
-        guard let plan else { return 0 }
-        var seen: [String: Int] = [:]
-        var index = 0
-        for ex in plan.exercises {
-            if ex.groupType == .superset, let name = ex.groupName {
-                if seen[name] == nil {
-                    seen[name] = index
-                    index += 1
-                }
-                if ex.id == exercise.id {
-                    return seen[name] ?? 0
-                }
-            }
-        }
-        return 0
     }
 
     // MARK: - Regenerate Markdown

--- a/mobile-apps/ios/LiftMarkTests/ActiveWorkoutViewModelTests.swift
+++ b/mobile-apps/ios/LiftMarkTests/ActiveWorkoutViewModelTests.swift
@@ -334,6 +334,33 @@ final class ActiveWorkoutViewModelTests: XCTestCase {
         }
     }
 
+    func testBuildDisplayItemsSingleMemberSupersetRendersStandalone() {
+        // A superset block that contains only one exercise is not a real
+        // superset (nothing to alternate with). It should render as a plain
+        // standalone exercise, matching the plan view — not as a 1-member
+        // superset group.
+        let parentId = "parent1"
+        let parent = makeExercise(id: parentId, name: "Superset", groupType: .superset, sets: [])
+        let onlyChild = makeExercise(id: "c1", name: "Cable Tricep Pushdown", orderIndex: 1, parentExerciseId: parentId, sets: [makeSet()])
+
+        let items = ActiveWorkoutViewModel.buildDisplayItems(from: [parent, onlyChild])
+        XCTAssertEqual(items.count, 1)
+
+        if case .single(let ex, _, let num) = items[0] {
+            XCTAssertEqual(ex.exerciseName, "Cable Tricep Pushdown")
+            XCTAssertEqual(num, 1)
+        } else {
+            XCTFail("Expected .single for a single-member superset, got \(items[0])")
+        }
+    }
+
+    func testSupersetGroupingPredicate() {
+        XCTAssertFalse(SupersetGrouping.isRealSuperset(childCount: 0))
+        XCTAssertFalse(SupersetGrouping.isRealSuperset(childCount: 1))
+        XCTAssertTrue(SupersetGrouping.isRealSuperset(childCount: 2))
+        XCTAssertTrue(SupersetGrouping.isRealSuperset(childCount: 5))
+    }
+
     // MARK: - Display Items: Section Divider
 
     func testBuildDisplayItemsSection() {

--- a/spec/screens/active-workout.md
+++ b/spec/screens/active-workout.md
@@ -188,6 +188,7 @@ Primary workout execution screen. Displays all exercises and sets for the active
 - Sets are displayed **interleaved round-robin**: child A set 1, child B set 1, child A set 2, child B set 2, etc.
 - Each set row shows the exercise name label to identify which exercise it belongs to
 - The superset parent and its children are NOT rendered as separate standalone cards
+- **Single-member supersets**: a superset parent with only one child is not a real superset (nothing to alternate with). The lone child is rendered as a standalone exercise card, not a grouped superset card. A superset is grouped only when it has 2 or more members (`SupersetGrouping.isRealSuperset`). The plan (pre-start) view applies the same rule, so both views render single-member supersets identically.
 - **Exercise numbering**: Superset parents and section headers are excluded from the numbered badge index. Only exercises with sets (regular exercises and superset children) receive a sequential number. A superset with 2 children counts as 2 exercises in the numbering sequence.
 - **Session creation**: When creating a session from a plan, `parentExerciseId` must be mapped from plan exercise IDs to the corresponding session exercise IDs so superset grouping is preserved
 

--- a/spec/screens/workout-detail.md
+++ b/spec/screens/workout-detail.md
@@ -106,3 +106,4 @@ Each set row MUST display all data that was parsed from the workout plan. The fo
 - Purple "SUPERSET" badge
 - Multiple exercise names joined with "&"
 - Interleaved set display across exercises
+- **Single-member supersets**: a superset block that resolves to only one exercise is not a real superset (there is nothing to alternate with). It is rendered as a plain standalone exercise — no SUPERSET badge, no grouped card — exactly as the active workout view renders it. A superset is treated as a real (grouped) superset only when it has 2 or more members (`SupersetGrouping.isRealSuperset`). The validator emits a `SINGLE_MEMBER_SUPERSET` warning so the authoring error is visible in the source.


### PR DESCRIPTION
## Summary
The plan (pre-start) view showed a purple **SUPERSET** badge on exercises in a single-member superset, while the active workout view rendered those same exercises as standalone — the two views disagreed (reported in #145).

A superset of one is not a real superset (nothing to alternate with). This PR makes both views agree:
- Adds a shared `SupersetGrouping.isRealSuperset(childCount:)` predicate (a real superset has 2+ members) in `Models/Enums.swift`.
- `WorkoutDetailView` (plan) and `ActiveWorkoutViewModel` (active) both use it: single-member supersets render as a standalone exercise, never a grouped card.
- Removes the dead per-exercise SUPERSET badge and `supersetIndex` plumbing from `PlanExerciseCard`. Real (2+) supersets still render via `PlanSupersetCard` with the badge.
- Spec updated first (`spec/screens/workout-detail.md`, `spec/screens/active-workout.md`).

The validator half of #145 (a `SINGLE_MEMBER_SUPERSET` warning so the authoring error is visible in source) landed separately in #156.

## Test plan
- [x] `make build` — BUILD SUCCEEDED
- [x] `make test-unit` — TEST SUCCEEDED (added `testBuildDisplayItemsSingleMemberSupersetRendersStandalone` + `testSupersetGroupingPredicate`)
- [ ] CI checks green

Closes #145.