### PR TITLE
fix(ios): recover silently-failed inbox workout sync when signed out (#143)

### DIFF
--- a/mobile-apps/ios/LiftMark.xcodeproj/project.pbxproj
+++ b/mobile-apps/ios/LiftMark.xcodeproj/project.pbxproj
@@ -105,6 +105,7 @@
 		6D835E5584FD9C63A619EBFC /* DatabaseMigrationCrossCheckTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF1C774749F46282DA0627E6 /* DatabaseMigrationCrossCheckTests.swift */; };
 		6E470AECCA4B776FDD395E88 /* WorkoutPlanStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 183AA7541B9622B31C10CC50 /* WorkoutPlanStore.swift */; };
 		6EFA74E38221E7BD4E9BB291 /* TokenStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5F4306EFB81F0C2668F42D9 /* TokenStore.swift */; };
+		70481D0EAF2215976F676BC2 /* AuthSyncBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D49EC85640F289ECF7CB153 /* AuthSyncBannerView.swift */; };
 		70EB05BEF00C39E243663AB4 /* GymStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A19C073FB83621738F4CA3 /* GymStore.swift */; };
 		712B0C691B4ED8D1379D8774 /* AudioServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71CC4A4FDCEB486218739935 /* AudioServiceTests.swift */; };
 		73297C88CA6649D0C63AEB78 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 069E1FA9B7B710571D98821B /* Theme.swift */; };
@@ -200,6 +201,7 @@
 		DE179F500208338C247CC1D7 /* ScreenshotSeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FFC4B0E050FECBAB275D1E5 /* ScreenshotSeed.swift */; };
 		DE32D2B2D0BC36737819F32E /* SessionNotesSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4285B345A9C1B0810A967BD /* SessionNotesSheet.swift */; };
 		DE38D1DB725BDF730177A59C /* Yams in Frameworks */ = {isa = PBXBuildFile; productRef = 35C7774955CFDD8AC21B7740 /* Yams */; };
+		DE74148FDCE6F320FA2C3DD8 /* OutboxPusherServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 602B65899BCBD9026FEB621C /* OutboxPusherServiceTests.swift */; };
 		DF373888E7CD580855CE16A4 /* DatabaseBackupServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10878713306254945D8C4834 /* DatabaseBackupServiceTests.swift */; };
 		E668788C558E80F3E620BF5B /* WorkoutExportServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7B54090FD3C32CBDBBCA904 /* WorkoutExportServiceTests.swift */; };
 		E6750E3C596E80E2720795A9 /* ActionAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BBF08237635EFE610F8D173 /* ActionAdapter.swift */; };
@@ -339,6 +341,7 @@
 		598097ACA9731458C838AD5E /* SettingsAboutSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsAboutSection.swift; sourceTree = "<group>"; };
 		5A8B0A4526BD762457DD4ABF /* CloudKitSyncProtectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudKitSyncProtectionTests.swift; sourceTree = "<group>"; };
 		5AE9C7D51ED3CF2FC7D59030 /* DatabaseManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseManagerTests.swift; sourceTree = "<group>"; };
+		602B65899BCBD9026FEB621C /* OutboxPusherServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutboxPusherServiceTests.swift; sourceTree = "<group>"; };
 		62BC30CC7136FEBF11EFB81E /* DebugLogsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugLogsView.swift; sourceTree = "<group>"; };
 		64A76A2194E3AF636AD5C75F /* StoreIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreIntegrationTests.swift; sourceTree = "<group>"; };
 		661D15791C0AD1574A2334AB /* MigratorBridgeFailureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigratorBridgeFailureTests.swift; sourceTree = "<group>"; };
@@ -364,6 +367,7 @@
 		790A5CDE07EFFF281DAC47FA /* WorkoutExportIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutExportIntegrationTests.swift; sourceTree = "<group>"; };
 		790BF9E2E0D248724753225B /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		7B45DC7A3E8EAF0E19BE1083 /* MigratorBridgeAlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigratorBridgeAlertView.swift; sourceTree = "<group>"; };
+		7D49EC85640F289ECF7CB153 /* AuthSyncBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthSyncBannerView.swift; sourceTree = "<group>"; };
 		7FE81B205D52B24B526C4350 /* AppearancePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearancePicker.swift; sourceTree = "<group>"; };
 		81BB00D28805B71DB987185E /* SessionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionStore.swift; sourceTree = "<group>"; };
 		8225A50909E6337E1FA95E80 /* ActiveWorkoutViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveWorkoutViewModelTests.swift; sourceTree = "<group>"; };
@@ -842,6 +846,7 @@
 			isa = PBXGroup;
 			children = (
 				C38E018F88DC33EB2158C6AC /* AdaptiveSplitView.swift */,
+				7D49EC85640F289ECF7CB153 /* AuthSyncBannerView.swift */,
 				DF5E7925F25E5F7CFE3C109B /* DisclaimerText.swift */,
 				4EE0CDF79B2DFFE19F219027 /* ErrorBannerView.swift */,
 				F2EE730B57432DA41F655940 /* ExerciseCardView.swift */,
@@ -891,6 +896,7 @@
 				BE23FF382474D10663FDF662 /* MarkdownParserTests.swift */,
 				661D15791C0AD1574A2334AB /* MigratorBridgeFailureTests.swift */,
 				8237249141BCC8A29A52C430 /* MigratorBridgeTests.swift */,
+				602B65899BCBD9026FEB621C /* OutboxPusherServiceTests.swift */,
 				9017628E208B7ED9FDC9E047 /* ParserConformanceTests.swift */,
 				4406CB6F8705596A59036876 /* PlateCalculatorTests.swift */,
 				54DEB10F36ACE6291531A52C /* RestTimerTickTests.swift */,
@@ -1158,6 +1164,7 @@
 				046BDEE4D56EEF1A07640A9D /* AppearancePicker.swift in Sources */,
 				5FAF2240A9E665DC7B211254 /* AudioService.swift in Sources */,
 				422B47D9CA307C3BD13117A0 /* AuthError.swift in Sources */,
+				70481D0EAF2215976F676BC2 /* AuthSyncBannerView.swift in Sources */,
 				363B6816FAB41E9EE5BCCA41 /* AuthenticatedUser.swift in Sources */,
 				A3275CAEA4376A2F94A89A9B /* AuthenticationStore.swift in Sources */,
 				D76A9B26D9C1583D5A4E7C95 /* BuildInfo.swift in Sources */,
@@ -1333,6 +1340,7 @@
 				B32B1213805C0FDA52C6DE0F /* MigrationGoldenShapes.swift in Sources */,
 				2BF94A6E07D8F5BECF07F472 /* MigratorBridgeFailureTests.swift in Sources */,
 				15963F56C95DD902FAFF715E /* MigratorBridgeTests.swift in Sources */,
+				DE74148FDCE6F320FA2C3DD8 /* OutboxPusherServiceTests.swift in Sources */,
 				083A02957C5374F617C3B256 /* ParserConformanceTests.swift in Sources */,
 				A2994975FB6B2B6580CA34C5 /* PlateCalculatorTests.swift in Sources */,
 				06EE4DED95E7B9EE13AF33F1 /* RestTimerTickTests.swift in Sources */,

--- a/mobile-apps/ios/LiftMark/App/ContentView.swift
+++ b/mobile-apps/ios/LiftMark/App/ContentView.swift
@@ -18,6 +18,9 @@ struct ContentView: View {
     var body: some View {
         MigratorBridgeAlertContainer {
             mainContent
+                .safeAreaInset(edge: .top, spacing: 0) {
+                    AuthSyncBannerView()
+                }
         }
     }
 

--- a/mobile-apps/ios/LiftMark/App/LiftMarkApp.swift
+++ b/mobile-apps/ios/LiftMark/App/LiftMarkApp.swift
@@ -36,10 +36,20 @@ struct LiftMarkApp: App {
             apiClient: api,
             featureFlags: flags
         ))
-        _outboxPusher = State(initialValue: OutboxPusherService(
+        let pusher = OutboxPusherService(
             authStore: auth,
             apiClient: api
-        ))
+        )
+        _outboxPusher = State(initialValue: pusher)
+
+        // On a successful (re-)login, drain any completed-but-unsynced workouts
+        // immediately rather than waiting for the next foreground transition.
+        // This is the recovery half of GH #143. `auth` retains `pusher` via this
+        // closure, but `auth` lives for the whole app lifetime so there is no
+        // leak concern.
+        auth.onAuthenticated = { [weak pusher] in
+            Task { @MainActor in await pusher?.flushIfAuthenticated() }
+        }
 
         // Reset data before any views load (for test isolation)
         if ProcessInfo.processInfo.arguments.contains("--reset-data") {

--- a/mobile-apps/ios/LiftMark/Services/CrashReporter.swift
+++ b/mobile-apps/ios/LiftMark/Services/CrashReporter.swift
@@ -70,6 +70,12 @@ final class CrashReporter: @unchecked Sendable {
     /// regardless of whether Sentry is initialized. Only set from unit tests.
     nonisolated(unsafe) static var migratorEventRecorder: ((String, [String: String]) -> Void)?
 
+    /// Test seam — when set, every `captureError` invocation is recorded here
+    /// (with the allowlist-filtered metadata) regardless of whether Sentry is
+    /// initialized. Only set from unit tests. Lets us assert on capture sites
+    /// without standing up the real SentrySDK.
+    nonisolated(unsafe) static var captureErrorRecorder: ((Error, LogCategory, [String: String]) -> Void)?
+
     private init() {
         // Default master toggle to true on first launch.
         if UserDefaults.standard.object(forKey: Self.crashReportingEnabledKey) == nil {
@@ -149,8 +155,9 @@ final class CrashReporter: @unchecked Sendable {
 
     /// Report a sync-class non-fatal error. Only allowlisted metadata keys are forwarded.
     func captureError(_ error: Error, category: LogCategory, metadata: [String: String]? = nil) {
-        guard isStarted, Self.isCrashReportingEnabled else { return }
         let filtered = Self.filter(metadata: metadata, allowlist: Self.syncMetadataAllowlist)
+        Self.captureErrorRecorder?(error, category, filtered)
+        guard isStarted, Self.isCrashReportingEnabled else { return }
         SentrySDK.capture(error: error) { scope in
             scope.setTag(value: category.rawValue, key: "category")
             for (key, value) in filtered {

--- a/mobile-apps/ios/LiftMark/Services/OutboxPusherService.swift
+++ b/mobile-apps/ios/LiftMark/Services/OutboxPusherService.swift
@@ -81,10 +81,17 @@ final class OutboxPusherService {
         Task { await flushIfAuthenticated() }
     }
 
-    /// Drain the queue. Idempotent — silently returns if unauthenticated or a
-    /// flush is in flight.
+    /// Drain the queue. Idempotent — silently returns if a flush is in flight.
+    ///
+    /// If the device isn't authenticated but there ARE queued completions, the
+    /// queue is preserved and the failure is surfaced loudly (device log +
+    /// Sentry + observable `lastError`) so a silently-unsynced completed
+    /// workout can't go unnoticed (GH #143).
     func flushIfAuthenticated() async {
-        guard authStore.isAuthenticated else { return }
+        guard authStore.isAuthenticated else {
+            reportAuthFailure(reason: "not_authenticated")
+            return
+        }
         guard !isFlushing else { return }
         isFlushing = true
         lastError = nil
@@ -101,6 +108,7 @@ final class OutboxPusherService {
         var pushed = 0
         var retried = 0
         var failed = 0
+        var hitAuthFailure = false
 
         for item in items {
             let outcome = await pushOne(item)
@@ -109,8 +117,9 @@ final class OutboxPusherService {
             case .gaveUpClientError: failed += 1
             case .retryQueued: retried += 1
             case .authMissing:
-                // Lost auth mid-flush — bail; we'll resume next foreground.
-                break
+                // Lost auth mid-flush — the queue row is preserved (we never
+                // delete on auth failure). Bail; we'll resume after re-auth.
+                hitAuthFailure = true
             }
             if outcome == .authMissing { break }
         }
@@ -126,6 +135,50 @@ final class OutboxPusherService {
                 "retried": String(retried),
                 "failed": String(failed),
                 "queueSizeAfter": String(pendingCount),
+            ]
+        )
+
+        // Report once per flush cycle (not per item) to avoid Sentry spam.
+        if hitAuthFailure {
+            reportAuthFailure(reason: "push_401")
+        }
+    }
+
+    /// Loud, recoverable handling of an auth failure that leaves completed
+    /// workouts stranded in the queue. The rows are NEVER deleted here — the
+    /// caller guarantees the queue is untouched. Emits one device-log error and
+    /// one Sentry capture per flush cycle, and reflects the unsynced state in
+    /// the observable `lastError` / `pendingCount` so the app-level auth-sync
+    /// banner can render. See `spec/services/workout-outbox.md`.
+    private func reportAuthFailure(reason: String) {
+        let stranded = (try? queue.count()) ?? pendingCount
+        pendingCount = stranded
+        // Nothing queued → nothing was lost → stay quiet (e.g. a routine
+        // foreground flush while signed out with an empty queue).
+        guard stranded > 0 else { return }
+
+        lastError = "Sign in to sync \(stranded) completed workout\(stranded == 1 ? "" : "s")"
+
+        Logger.shared.error(
+            .sync,
+            "outbox flush blocked: authentication required",
+            metadata: [
+                "pendingCount": String(stranded),
+                "reason": reason,
+            ]
+        )
+
+        let err = NSError(
+            domain: "LiftMark.Outbox",
+            code: 401,
+            userInfo: [NSLocalizedDescriptionKey: "Outbox auth failure: \(stranded) completed workout(s) cannot sync"]
+        )
+        CrashReporter.shared.captureError(
+            err,
+            category: .sync,
+            metadata: [
+                "tag": "outbox_auth_failure",
+                "partialFailureCount": String(stranded),
             ]
         )
     }

--- a/mobile-apps/ios/LiftMark/Stores/AuthenticationStore.swift
+++ b/mobile-apps/ios/LiftMark/Stores/AuthenticationStore.swift
@@ -89,7 +89,21 @@ final class AuthenticationStore {
     var currentUser: AuthenticatedUser?
     var lastError: AuthError?
 
+    /// Set `true` when the refresh chain dies (refresh token rejected with
+    /// 401 in `refreshIfNeeded`). Distinguishes a *silently expired* session
+    /// from a *user-initiated* logout: the expired-session path drops the dead
+    /// tokens but must NOT wipe device-local session state (outbox/inbox) the
+    /// way `logout()` does, so completed-but-unsynced workouts survive until
+    /// the user signs back in (GH #143). Reset on a successful `login(...)`.
+    private(set) var sessionExpired: Bool = false
+
     var isAuthenticated: Bool { currentUser != nil }
+
+    /// Invoked on a successful login so queued outbox pushes drain immediately
+    /// rather than waiting for the next foreground transition. Wired up by
+    /// `LiftMarkApp` to call `OutboxPusherService.flushIfAuthenticated()`.
+    /// Left nil in tests that don't exercise the flush.
+    var onAuthenticated: (() -> Void)?
 
     init(api: APIClientProtocol, tokenStore: TokenStore) {
         self.api = api
@@ -117,6 +131,10 @@ final class AuthenticationStore {
             tokenStore.saveRefreshToken(response.refreshToken)
             currentUser = response.user
             lastError = nil
+            // A fresh session clears any prior "needs re-auth" state and drains
+            // any completed-but-unsynced workouts queued under the old session.
+            sessionExpired = false
+            onAuthenticated?()
             return response.user
         } catch let error as APIError {
             let mapped = Self.mapLoginError(error)
@@ -151,6 +169,8 @@ final class AuthenticationStore {
         tokenStore.clear()
         currentUser = nil
         lastError = nil
+        // A deliberate sign-out is a clean state, not a lapsed one.
+        sessionExpired = false
 
         // Inbox is treated as session-scoped device state — wipe on
         // sign-out. The server is the source of truth; signing back in
@@ -233,9 +253,18 @@ final class AuthenticationStore {
             return response.accessJwt
         } catch let error as APIError {
             if case .unauthorized = error {
-                // Refresh chain is dead — drop local session.
-                tokenStore.clear()
-                currentUser = nil
+                // Refresh chain is dead — the access/refresh pair is useless, so
+                // drop the dead tokens and the in-memory user. CRITICAL: this is
+                // an *expired session*, NOT a user-initiated logout. We must NOT
+                // call `logout()` (which wipes the outbox/inbox), or completed-
+                // but-unsynced workouts would be silently lost (GH #143). Surface
+                // `sessionExpired` so the UI can prompt re-auth and the queued
+                // pushes survive to drain after the next successful login.
+                markSessionExpired()
+                Logger.shared.warn(
+                    .network,
+                    "auth refresh failed (401) — session expired, prompting re-auth; outbox preserved"
+                )
             }
             throw error
         }
@@ -256,18 +285,35 @@ final class AuthenticationStore {
             // exp check would pass on our just-minted token. Bypass by
             // calling the refresh endpoint directly via the same path.
             guard let refresh = tokenStore.loadRefreshToken() else {
+                markSessionExpired()
                 throw APIError.unauthorized
             }
-            let response: RefreshResponse = try await api.send(
-                path: "/v1/auth/refresh",
-                method: "POST",
-                body: RefreshRequest(refreshToken: refresh),
-                accessToken: nil
-            )
-            tokenStore.saveAccessToken(response.accessJwt)
-            tokenStore.saveRefreshToken(response.refreshToken)
-            return try await block(response.accessJwt)
+            do {
+                let response: RefreshResponse = try await api.send(
+                    path: "/v1/auth/refresh",
+                    method: "POST",
+                    body: RefreshRequest(refreshToken: refresh),
+                    accessToken: nil
+                )
+                tokenStore.saveAccessToken(response.accessJwt)
+                tokenStore.saveRefreshToken(response.refreshToken)
+                return try await block(response.accessJwt)
+            } catch APIError.unauthorized {
+                // Refresh chain is dead even on the forced retry. Same handling
+                // as `refreshIfNeeded`: expired session, not a logout. Preserve
+                // device-local queues (GH #143).
+                markSessionExpired()
+                throw APIError.unauthorized
+            }
         }
+    }
+
+    /// Drop the dead session tokens and flag re-auth needed WITHOUT wiping the
+    /// outbox/inbox (that is `logout()`'s job, for deliberate sign-out only).
+    private func markSessionExpired() {
+        tokenStore.clear()
+        currentUser = nil
+        sessionExpired = true
     }
 
     // MARK: - Private

--- a/mobile-apps/ios/LiftMark/Views/Shared/AuthSyncBannerView.swift
+++ b/mobile-apps/ios/LiftMark/Views/Shared/AuthSyncBannerView.swift
@@ -1,0 +1,75 @@
+import SwiftUI
+
+/// App-level banner shown when there are completed workouts that can't sync
+/// because the device needs to (re-)authenticate. This is the user-facing half
+/// of the GH #143 fix: a completed workout must never silently fail to sync
+/// without a recovery affordance.
+///
+/// Visible when:
+///   `outboxPusher.pendingCount > 0 && (!authStore.isAuthenticated || authStore.sessionExpired)`
+///
+/// Tapping it presents `LoginView`. A successful login resets `sessionExpired`
+/// and flushes the outbox, which drains the queue and dismisses the banner.
+struct AuthSyncBannerView: View {
+    @Environment(AuthenticationStore.self) private var authStore
+    @Environment(OutboxPusherService.self) private var outboxPusher
+
+    @State private var showingLogin = false
+
+    private var shouldShow: Bool {
+        outboxPusher.pendingCount > 0
+            && (!authStore.isAuthenticated || authStore.sessionExpired)
+    }
+
+    private var message: String {
+        let count = outboxPusher.pendingCount
+        let noun = count == 1 ? "workout" : "workouts"
+        return "\(count) \(noun) waiting to sync — sign in to upload."
+    }
+
+    var body: some View {
+        if shouldShow {
+            Button {
+                showingLogin = true
+            } label: {
+                HStack(spacing: LiftMarkTheme.spacingSM) {
+                    Image(systemName: "exclamationmark.icloud.fill")
+                        .foregroundStyle(.white)
+                    Text(message)
+                        .font(.subheadline.weight(.medium))
+                        .foregroundStyle(.white)
+                        .multilineTextAlignment(.leading)
+                        .lineLimit(2)
+                    Spacer(minLength: LiftMarkTheme.spacingSM)
+                    Text("Sign in")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(.white)
+                    Image(systemName: "chevron.right")
+                        .font(.caption.weight(.bold))
+                        .foregroundStyle(.white.opacity(0.8))
+                }
+                .padding(.horizontal, LiftMarkTheme.spacingMD)
+                .padding(.vertical, LiftMarkTheme.spacingSM + 2)
+                .frame(maxWidth: .infinity)
+                .background(LiftMarkTheme.warning)
+            }
+            .buttonStyle(.plain)
+            .transition(.move(edge: .top).combined(with: .opacity))
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(message)
+            .accessibilityHint("Opens sign-in to upload your completed workouts")
+            .accessibilityIdentifier("auth-sync-banner")
+            .sheet(isPresented: $showingLogin) {
+                LoginView()
+            }
+        }
+    }
+}
+
+#Preview {
+    let auth = AuthenticationStore(api: APIClient(baseURL: nil), tokenStore: TokenStore())
+    let pusher = OutboxPusherService(authStore: auth, apiClient: APIClient(baseURL: nil))
+    return AuthSyncBannerView()
+        .environment(auth)
+        .environment(pusher)
+}

--- a/mobile-apps/ios/LiftMarkTests/AuthenticationStoreTests.swift
+++ b/mobile-apps/ios/LiftMarkTests/AuthenticationStoreTests.swift
@@ -80,6 +80,75 @@ final class AuthenticationStoreTests: XCTestCase {
         XCTAssertEqual(mockAPI.sentPaths.count, 0, "Should not have hit the network for a valid token")
     }
 
+    // MARK: - sessionExpired (GH #143)
+
+    func testRefreshUnauthorizedSetsSessionExpiredAndClearsTokens() async {
+        let store = AuthenticationStore(api: mockAPI, tokenStore: tokenStore)
+
+        let expiredToken = Self.makeJWT(expSecondsFromNow: -60)
+        tokenStore.saveAccessToken(expiredToken)
+        tokenStore.saveRefreshToken("lm_refresh_dead")
+
+        mockAPI.nextError = APIError.unauthorized
+
+        XCTAssertFalse(store.sessionExpired)
+
+        do {
+            _ = try await store.refreshIfNeeded()
+            XCTFail("Expected unauthorized to propagate")
+        } catch {
+            // expected
+        }
+
+        XCTAssertTrue(store.sessionExpired, "Refresh 401 must flag the session as expired")
+        XCTAssertFalse(store.isAuthenticated)
+        XCTAssertNil(tokenStore.loadAccessToken(), "Dead access token should be cleared")
+        XCTAssertNil(tokenStore.loadRefreshToken(), "Dead refresh token should be cleared")
+        // The expired-session path must NOT have touched the user-initiated
+        // logout codepath. We assert it hit ONLY the refresh endpoint — never
+        // /v1/auth/logout (which is what clears the outbox/inbox).
+        XCTAssertEqual(mockAPI.sentPaths, ["/v1/auth/refresh"])
+        XCTAssertFalse(
+            mockAPI.sentPaths.contains("/v1/auth/logout"),
+            "Expired session must not invoke the logout (outbox-clearing) codepath"
+        )
+    }
+
+    func testSuccessfulLoginResetsSessionExpiredAndTriggersFlush() async throws {
+        let store = AuthenticationStore(api: mockAPI, tokenStore: tokenStore)
+
+        // Force the store into the expired state via a failed refresh.
+        let expiredToken = Self.makeJWT(expSecondsFromNow: -60)
+        tokenStore.saveAccessToken(expiredToken)
+        tokenStore.saveRefreshToken("lm_refresh_dead")
+        mockAPI.nextError = APIError.unauthorized
+        _ = try? await store.refreshIfNeeded()
+        XCTAssertTrue(store.sessionExpired)
+
+        // A successful login must clear the flag and fire onAuthenticated so
+        // the queued outbox pushes drain.
+        var flushed = false
+        store.onAuthenticated = { flushed = true }
+
+        let newAccess = Self.makeJWT(expSecondsFromNow: 3600)
+        mockAPI.nextDecodableResponse = [
+            "access_jwt": newAccess,
+            "refresh_token": "lm_refresh_new",
+            "user": [
+                "user_id": "user-test",
+                "email": "a@b.co",
+                "display_name": "Tester",
+                "tier": "free",
+            ],
+        ]
+
+        _ = try await store.login(email: "a@b.co", password: "pw")
+
+        XCTAssertFalse(store.sessionExpired, "Successful login must reset sessionExpired")
+        XCTAssertTrue(store.isAuthenticated)
+        XCTAssertTrue(flushed, "Successful login must trigger the outbox flush hook")
+    }
+
     func testRefreshIfNeededCallsRefreshEndpointWhenExpired() async throws {
         // Construct the store before the keychain has any tokens so the
         // init-time rehydrate doesn't fire its own background refresh

--- a/mobile-apps/ios/LiftMarkTests/OutboxPusherServiceTests.swift
+++ b/mobile-apps/ios/LiftMarkTests/OutboxPusherServiceTests.swift
@@ -1,0 +1,132 @@
+import XCTest
+import GRDB
+@testable import LiftMark
+
+/// Tests for the GH #143 loud-failure + recovery behavior of the outbox
+/// pusher: an auth failure must log to the device log, capture to Sentry once
+/// per flush cycle, surface an observable `lastError`, and — critically —
+/// leave the queued completions in place so they can drain after re-auth.
+@MainActor
+final class OutboxPusherServiceTests: XCTestCase {
+
+    private var tokenStore: TokenStore!
+    private var mockAPI: MockAPIClient!
+    private var queue: OutboxPendingQueueRepository!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        DatabaseManager.shared.deleteDatabase()
+        _ = Logger.shared
+        // deleteDatabase() drops the file; Logger's singleton won't re-create
+        // app_logs on its own, and the LogStore schema flag may be stale from a
+        // prior suite. Re-create it so device-log assertions are reliable.
+        ensureAppLogsTableExists()
+        tokenStore = TokenStore(service: "app.liftmark.outbox.tests.\(UUID().uuidString)")
+        tokenStore.clear()
+        mockAPI = MockAPIClient()
+        queue = OutboxPendingQueueRepository()
+    }
+
+    private func ensureAppLogsTableExists() {
+        guard let db = try? DatabaseManager.shared.database() else { return }
+        try? db.write { db in
+            try db.execute(sql: """
+                CREATE TABLE IF NOT EXISTS app_logs (
+                    id TEXT PRIMARY KEY,
+                    timestamp TEXT NOT NULL,
+                    level TEXT NOT NULL,
+                    category TEXT NOT NULL,
+                    message TEXT NOT NULL,
+                    metadata TEXT,
+                    stack_trace TEXT,
+                    device_info TEXT,
+                    created_at TEXT DEFAULT CURRENT_TIMESTAMP
+                )
+            """)
+        }
+    }
+
+    override func tearDown() async throws {
+        CrashReporter.captureErrorRecorder = nil
+        tokenStore.clear()
+        DatabaseManager.shared.deleteDatabase()
+        tokenStore = nil
+        mockAPI = nil
+        queue = nil
+        try await super.tearDown()
+    }
+
+    // MARK: - Helpers
+
+    private func makeUnauthenticatedStore() -> AuthenticationStore {
+        // No tokens → currentUser nil → !isAuthenticated.
+        AuthenticationStore(api: mockAPI, tokenStore: tokenStore)
+    }
+
+    // MARK: - Auth failure: unauthenticated flush
+
+    func testFlushWhileSignedOutKeepsQueueAndReportsLoudly() async throws {
+        try queue.enqueue(clientSessionId: "sess-1")
+        try queue.enqueue(clientSessionId: "sess-2")
+
+        var captures: [(LogCategory, [String: String])] = []
+        CrashReporter.captureErrorRecorder = { _, category, metadata in
+            captures.append((category, metadata))
+        }
+
+        let auth = makeUnauthenticatedStore()
+        XCTAssertFalse(auth.isAuthenticated)
+        let pusher = OutboxPusherService(
+            authStore: auth,
+            apiClient: mockAPI,
+            queue: queue
+        )
+
+        await pusher.flushIfAuthenticated()
+
+        // Queue is preserved — completed workouts must NOT be lost.
+        XCTAssertEqual(try queue.count(), 2, "Auth failure must not delete queued completions")
+        XCTAssertEqual(pusher.pendingCount, 2)
+        XCTAssertNotNil(pusher.lastError, "lastError must reflect the unsynced state")
+
+        // Exactly one Sentry capture per flush cycle, tagged + carrying count.
+        XCTAssertEqual(captures.count, 1, "Auth failure should capture once per cycle, not per item")
+        XCTAssertEqual(captures.first?.0, .sync)
+        XCTAssertEqual(captures.first?.1["tag"], "outbox_auth_failure")
+        XCTAssertEqual(captures.first?.1["partialFailureCount"], "2")
+
+        // Device log error must be written. The SQLite write is dispatched to a
+        // background serial queue, so poll briefly for it to land rather than
+        // asserting synchronously (which would race the write).
+        let logged = await waitForSyncErrorLog(containing: "authentication required")
+        XCTAssertTrue(logged, "Auth failure must write a device-log error entry")
+    }
+
+    /// Polls the SQLite log store for up to ~2s for a `.sync` error whose
+    /// message contains `needle`. Logger writes are async (background queue).
+    private func waitForSyncErrorLog(containing needle: String) async -> Bool {
+        for _ in 0..<40 {
+            let logs = Logger.shared.getLogs(limit: 200, level: .error, category: .sync)
+            if logs.contains(where: { $0.message.contains(needle) }) { return true }
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+        return false
+    }
+
+    func testFlushWhileSignedOutWithEmptyQueueStaysQuiet() async throws {
+        XCTAssertEqual(try queue.count(), 0)
+
+        var captureCount = 0
+        CrashReporter.captureErrorRecorder = { _, _, _ in captureCount += 1 }
+
+        let auth = makeUnauthenticatedStore()
+        let pusher = OutboxPusherService(authStore: auth, apiClient: mockAPI, queue: queue)
+
+        await pusher.flushIfAuthenticated()
+
+        // Nothing queued → nothing lost → no Sentry noise, no lastError.
+        XCTAssertEqual(captureCount, 0)
+        XCTAssertNil(pusher.lastError)
+        XCTAssertEqual(pusher.pendingCount, 0)
+    }
+}

--- a/spec/services/sentry.md
+++ b/spec/services/sentry.md
@@ -91,7 +91,8 @@ When toggled off mid-session, `CrashReporter.setEnabled(false)` calls `SentrySDK
 - `zoneName` — CloudKit zone name (e.g. `LiftMarkData`)
 - `fieldName` — CloudKit field name implicated in `invalidArguments`
 - `fkTable` — FK target table for merge errors (e.g. `session_sets`)
-- `partialFailureCount` — integer
+- `partialFailureCount` — integer (also used by `OutboxPusherService` to carry the count of completed workouts stranded by an auth failure)
+- `tag` — short stable event-category marker (e.g. `"data_loss"`, `"outbox_auth_failure"`); enables single-rule Sentry alerts
 - `sdkVersion`, `osVersion`, `buildType` — already on every event via Sentry defaults
 
 Record IDs (UUIDs) are allowed in breadcrumbs but **not** in captured error metadata, because Sentry's search makes high-cardinality UUIDs noisy without being useful.
@@ -126,6 +127,7 @@ Tags attached to captured events:
 | Tag | Values | Purpose |
 |-----|--------|---------|
 | `tag: "data_loss"` | set on `SyncSessionGuard` data-loss-detected / restore-failed paths, and on `migrator_bridge_restore_failed` | Target for a single alert rule |
+| `tag: "outbox_auth_failure"` | set on `OutboxPusherService` flush cycles that cannot push completed workouts because the session is missing/expired (GH #143) | Target an alert: a user has completed workouts that silently aren't syncing |
 | `data_integrity_risk` | `"true"` on every migrator failure event except `skipped_already_done`, `skipped_fresh_install`, `build_number_changed` | Target for a single migrator-failure alert rule. See [`migrator.md`](migrator.md) §5.4. |
 
 ### `beforeSend` hook

--- a/spec/services/workout-outbox.md
+++ b/spec/services/workout-outbox.md
@@ -197,7 +197,40 @@ No outbox-browsing UI — the surface for "my completed workouts" remains the Hi
 
 ### Sign-out behavior
 
-Local `outbox_pending_queue` table is wiped on logout — the queue is session-scoped device state, matching the inbox convention. Server-side outbox rows stay (they outlive any single device install).
+Local `outbox_pending_queue` table is wiped on **user-initiated logout** — the queue is session-scoped device state, matching the inbox convention. Server-side outbox rows stay (they outlive any single device install).
+
+**Critical distinction — expired session vs. logout:** a *user-initiated* logout (Settings → Sign out) wipes the queue. A *silently expired session* (refresh token rejected with 401 during `refreshIfNeeded`) must **not** wipe the queue. The completed workouts in the queue still belong to the same user and the same server account; they just couldn't be pushed because the access/refresh chain lapsed. Dropping them here is exactly the data-loss bug this service must prevent (see GH #143). Tokens may be cleared in the expired-session path (an expired refresh token is useless), but the outbox queue survives so that re-authentication can drain it. See [AuthenticationStore re-auth state](#re-authentication-state) below.
+
+### Auth-failure handling during flush
+
+When a flush cannot push because the device is effectively signed out — either `!authStore.isAuthenticated` at the top of `flushIfAuthenticated()`, or a `POST` returns 401 even after `withAuthorizedRequest` tried to refresh — the service must fail **loudly and recoverably**:
+
+1. **Keep the queued items.** Auth failure is never a reason to delete a row. The completed workouts stay enqueued and become eligible to push the moment the user re-authenticates.
+2. **Log to the device log.** `Logger.shared.error(.sync, "outbox flush blocked: authentication required", metadata: [...])` so the on-device debug log records the unsynced state (this is the authoritative on-device record per [logger.md](logger.md)).
+3. **Capture to Sentry once per flush cycle** (not per item — avoid event-quota spam) via `CrashReporter.shared.captureError(_:category:metadata:)` with `category: .sync` and `metadata["tag"] = "outbox_auth_failure"`. The `pendingCount` of stranded items is attached under the allowlisted `partialFailureCount` key. See [sentry.md](sentry.md) for the tag/allowlist.
+4. **Reflect the unsynced state observably.** `lastError` is set to a user-facing "Sign in to sync" message and `pendingCount` continues to reflect the stranded rows so the app-level [auth-sync banner](#auth-sync-banner-ui) can render.
+
+This is the one normal-operation path (alongside the giveup-4xx case) that *does* emit a Sentry capture: a user who completed a workout that silently never synced is a real, actionable failure, not a transient network blip.
+
+### Auth-sync banner (UI)
+
+An app-level banner is shown at the root (`ContentView`) when there are completed workouts that cannot sync because the device needs sign-in:
+
+```
+outboxPusher.pendingCount > 0 && (!authStore.isAuthenticated || authStore.sessionExpired)
+```
+
+- Copy: "N workout(s) waiting to sync — sign in to upload." Tapping it presents `LoginView`.
+- Accessibility identifier `auth-sync-banner` for UI tests.
+- A successful login resets `sessionExpired` and triggers `flushIfAuthenticated()`, which drains the queue and clears the banner.
+
+### Re-authentication state
+
+`AuthenticationStore` exposes an observable `private(set) var sessionExpired: Bool` (default `false`):
+
+- Set to `true` when `refreshIfNeeded()` receives `APIError.unauthorized` — the refresh chain is dead and the user must sign in again. The store clears the dead tokens and `currentUser` in this path (an expired refresh token is useless), but **does not** invoke the user-initiated `logout()` codepath and therefore **does not** wipe the `outbox_pending_queue` or inbox. This is the load-bearing distinction that makes a silently-completed workout recoverable (GH #143).
+- Reset to `false` on a successful `login(...)`. A successful login also kicks `OutboxPusherService.flushIfAuthenticated()` so queued completions sync immediately rather than waiting for the next foreground transition.
+- `isAuthenticated` remains `currentUser != nil`; `sessionExpired` is an orthogonal signal that the *last known* session lapsed and re-auth is needed. The banner condition treats either `!isAuthenticated` or `sessionExpired` as "needs sign-in".
 
 ### Conflict + dedup rules
 
@@ -233,8 +266,9 @@ Astro builds static and the site upload is via S3 + CloudFront. A truly dynamic 
 - `outbox_push_success` — `{client_session_id, outbox_id}`
 - `outbox_push_giveup_4xx` — `{client_session_id, status, body_snippet}` (logged via `Logger.shared.error`)
 - `outbox_flush_complete` — `{pushed, retried, failed, queue_size_after}`
+- `outbox flush blocked: authentication required` — `{pendingCount}` (logged via `Logger.shared.error(.sync, …)`; also a single Sentry capture per flush cycle with `tag: "outbox_auth_failure"`)
 
-No Sentry error captures for normal flows (network blips are not bugs). 4xx-other-than-429 is a real bug; log via Sentry.
+No Sentry error captures for normal flows (network blips are not bugs). 4xx-other-than-429 is a real bug; log via Sentry. **Auth failure with a non-empty queue is also a real, user-impacting bug** (a completed workout silently never synced — GH #143); it captures once per flush cycle.
 
 ## Out of scope (v1)
 


### PR DESCRIPTION
## Summary
Fixes the GH #143 data-loss bug: a workout completed (from the inbox) while the session had silently expired never synced, surfaced no error, logged nothing to the device log or Sentry, and offered no recovery.

- **(A) No silent sign-out.** `AuthenticationStore` now exposes `sessionExpired`, set when `refreshIfNeeded()` (and the `withAuthorizedRequest` retry) hits a refresh-chain 401. The expired-session path clears the dead tokens but **does not** invoke the user-initiated `logout()` codepath, so the durable outbox/inbox survive. The flag resets on a successful login, which also fires `onAuthenticated` to immediately flush queued completions.
- **(B) Recovery.** Queued completions are never deleted on auth failure; they stay in `outbox_pending_queue` and drain after re-auth.
- **(C) Loud failure + UI.** `OutboxPusherService` now writes a `.sync` device-log error and captures to Sentry **once per flush cycle** (`tag: "outbox_auth_failure"`, `partialFailureCount`) when a flush is blocked by missing/expired auth, and sets an observable `lastError`. A new app-level `AuthSyncBannerView` (accessibility id `auth-sync-banner`) appears when `pendingCount > 0 && (!isAuthenticated || sessionExpired)` and routes to `LoginView`.

Specs updated first per the spec-based workflow: `spec/services/workout-outbox.md` (auth-failure logging/recovery, banner, re-auth state) and `spec/services/sentry.md` (new tag + allowlist note). No new Sentry metadata keys beyond the already-allowlisted `tag` and `partialFailureCount`.

## Test plan
- [x] `make build` — BUILD SUCCEEDED
- [x] `make test-unit` — 868 + 33 tests, 0 failures
- [x] New unit tests: `AuthenticationStoreTests` (sessionExpired set on refresh-401 without hitting logout/outbox-clear; login resets flag + triggers flush) and `OutboxPusherServiceTests` (auth-failure keeps queue, captures Sentry once, sets lastError, writes device log; empty queue stays quiet)
- [ ] Manual: complete an inbox workout while signed out → confirm banner appears, sign in → confirm queue drains

Closes #143