### PR TITLE
fix(validator): derive inbox workout/summary on read from lmwf_text

### DIFF
--- a/spec/services/workout-inbox.md
+++ b/spec/services/workout-inbox.md
@@ -41,11 +41,23 @@ External client (PAT) ──POST /v1/workouts──► Server inbox (DDB)
 
 Each row stores:
 - `inbox_id` (ULID sort key, scoped by `user_id` partition key)
-- `lmwf_text` — original markdown
-- `parsed_json` — the full parsed `WorkoutPlan` (not just the summary projection)
+- `lmwf_text` — original markdown; **the single source of truth**
 - `status` — `pending` until iOS has fetched the detail; `ingested` after iOS's GET acknowledges receipt
 - `source_token_id` — PAT ULID or `"session"` for portal-pushed items
 - `created_at`, `ingested_at`
+
+The server does **not** persist the parsed result. Pushes are still validated
+on receipt (invalid LMWF is rejected with `422` and nothing is enqueued), but
+the parse output is discarded. The `workout` (full `WorkoutPlan`) and `summary`
+fields the read endpoints return are derived **on read** by re-parsing
+`lmwf_text` — so there is no stored pre-parse to drift away from the markdown.
+Inboxes are small (per-user, default 50), so parsing on read is cheap and needs
+no caching. If a row's markdown ever fails to parse on read, `workout`/`summary`
+degrade to `null` rather than failing the request.
+
+> DynamoDB is schemaless, so this needs no migration. Rows written before this
+> change may still carry a now-ignored `parsed_json` attribute; the server no
+> longer reads it, and new rows are written without it.
 
 ### Endpoints
 

--- a/validator/src/repositories/workout_inbox.ts
+++ b/validator/src/repositories/workout_inbox.ts
@@ -26,7 +26,6 @@ export interface InboxItem {
   user_id: string;
   source_token_id: string;
   lmwf_text: string;
-  parsed_json: unknown;
   status: InboxStatus;
   created_at: string;
   ingested_at?: string;
@@ -36,7 +35,6 @@ export interface CreateInboxItemInput {
   user_id: string;
   source_token_id: string;
   lmwf_text: string;
-  parsed_json: unknown;
   status: InboxStatus;
 }
 

--- a/validator/src/routes/workouts.ts
+++ b/validator/src/routes/workouts.ts
@@ -96,8 +96,22 @@ function summarize(
   return summarizePlan(result.data);
 }
 
+/// Parse stored markdown into a WorkoutPlan ON READ. `lmwf_text` is the single
+/// source of truth — we no longer persist the parse (`parsed_json` is gone),
+/// so the `workout`/`summary` fields the API returns are derived here from the
+/// raw markdown every time. Items were validated on push, so this normally
+/// succeeds; if a row's markdown somehow fails to parse we return null and let
+/// callers degrade gracefully rather than 500.
+function deriveWorkout(lmwf_text: string): WorkoutPlan | null {
+  try {
+    return parseWorkout(lmwf_text).data ?? null;
+  } catch {
+    return null;
+  }
+}
+
 /// Derive the summary projection from a stored WorkoutPlan. Used by the
-/// list/get endpoints since parsed_json now stores the full WorkoutPlan.
+/// list/get endpoints, which derive the plan on read from `lmwf_text`.
 function summarizePlan(plan: WorkoutPlan): WorkoutSummary {
   const exercises: ExerciseSummary[] = plan.exercises.map((ex) => ({
     name: ex.exerciseName,
@@ -116,21 +130,11 @@ function summarizePlan(plan: WorkoutPlan): WorkoutSummary {
   };
 }
 
-/// Best-effort summary from an unknown parsed_json blob — old rows persisted
-/// before the full-payload migration stored only the summary itself, so we
-/// fall back to returning whatever's there if the shape doesn't look like a
-/// WorkoutPlan. New rows always go through summarizePlan().
-function projectSummaryFromStored(parsed: unknown): WorkoutSummary | null {
-  if (parsed === null || parsed === undefined) return null;
-  if (typeof parsed !== 'object') return null;
-  const obj = parsed as Record<string, unknown>;
-  // Heuristic: WorkoutPlan shape carries `exercises` with `sets` arrays.
-  // Pre-migration rows have `workoutName`+`exercises[].setCount` instead.
-  if (Array.isArray(obj.exercises) && 'name' in obj && !('workoutName' in obj)) {
-    return summarizePlan(parsed as WorkoutPlan);
-  }
-  // Looks like an already-projected summary — pass through.
-  return parsed as WorkoutSummary;
+/// Project the lightweight summary from a row's stored markdown, deriving the
+/// plan on read. Returns null if the markdown won't parse (graceful degrade).
+function summaryFromText(lmwf_text: string): WorkoutSummary | null {
+  const plan = deriveWorkout(lmwf_text);
+  return plan ? summarizePlan(plan) : null;
 }
 
 function log(entry: Record<string, unknown>): void {
@@ -273,15 +277,14 @@ workoutsRouter.post('/', requireScope('workouts:write'), async (c) => {
   // source — distinguishes "pushed via PAT X" from "pushed via the web
   // portal" in the audit trail. PAT pushes record the token's ULID.
   const sourceTokenId = c.var.pat_token_id ?? 'session';
-  // Persist the FULL parser result, not just the summary projection. iOS
-  // rehydrates a complete WorkoutPlan from this on ingest, so it needs
-  // every exercise's full set list (weights, reps, modifiers, notes).
-  // The summary projection is derived on read for the list endpoint.
+  // Persist only the raw markdown — `lmwf_text` is the single source of
+  // truth. We validated the parse above (422 on invalid), but we do NOT
+  // store the parsed result: `workout`/`summary` are derived on read from
+  // `lmwf_text` so there is no stale pre-parse to diverge from the markdown.
   const item = await createInboxItem({
     user_id: c.var.user.user_id,
     source_token_id: sourceTokenId,
     lmwf_text: markdown,
-    parsed_json: result.data,
     status: 'pending',
   });
 
@@ -351,7 +354,7 @@ workoutsRouter.get('/', requireScope('workouts:read'), async (c) => {
       created_at: it.created_at,
       ingested_at: it.ingested_at,
       source_token_id: it.source_token_id,
-      summary: projectSummaryFromStored(it.parsed_json),
+      summary: summaryFromText(it.lmwf_text),
     })),
     next_cursor: nextCursor ?? null,
   });
@@ -363,9 +366,12 @@ workoutsRouter.get('/:inbox_id', requireScope('workouts:read'), async (c) => {
   if (!item) {
     return c.json({ error: 'Inbox item not found' }, 404);
   }
-  // `workout` exposes the full stored WorkoutPlan so iOS can rehydrate
-  // without re-parsing LMWF locally. `summary` stays for clients that
-  // only need the lightweight projection (and matches what list returns).
+  // `workout` is the full WorkoutPlan derived on read from `lmwf_text` (the
+  // single source of truth — no persisted pre-parse). `summary` is the
+  // lightweight projection for clients that only need name + counts, and
+  // matches what list returns. Both degrade to null if the markdown won't
+  // parse, rather than failing the request.
+  const plan = deriveWorkout(item.lmwf_text);
   return c.json({
     inbox_id: item.inbox_id,
     user_id: item.user_id,
@@ -373,8 +379,8 @@ workoutsRouter.get('/:inbox_id', requireScope('workouts:read'), async (c) => {
     created_at: item.created_at,
     ingested_at: item.ingested_at,
     source_token_id: item.source_token_id,
-    summary: projectSummaryFromStored(item.parsed_json),
-    workout: item.parsed_json,
+    summary: plan ? summarizePlan(plan) : null,
+    workout: plan,
     lmwf_text: item.lmwf_text,
   });
 });

--- a/validator/tests/repositories/workout_inbox.test.ts
+++ b/validator/tests/repositories/workout_inbox.test.ts
@@ -20,7 +20,6 @@ liveDdb('workout_inbox repository', () => {
       user_id,
       source_token_id: 'tok-1',
       lmwf_text: '# Push Day\n## Bench Press\n- 135 x 5',
-      parsed_json: { workoutName: 'Push Day' },
       status: 'pending',
     });
 
@@ -37,7 +36,6 @@ liveDdb('workout_inbox repository', () => {
       user_id,
       source_token_id: 'tok',
       lmwf_text: 'a',
-      parsed_json: {},
       status: 'pending',
     });
     // Spread the timestamps so the SK ordering is unambiguous.
@@ -46,7 +44,6 @@ liveDdb('workout_inbox repository', () => {
       user_id,
       source_token_id: 'tok',
       lmwf_text: 'b',
-      parsed_json: {},
       status: 'pending',
     });
 
@@ -63,14 +60,12 @@ liveDdb('workout_inbox repository', () => {
       user_id,
       source_token_id: 'tok',
       lmwf_text: 'p',
-      parsed_json: {},
       status: 'pending',
     });
     await createInboxItem({
       user_id,
       source_token_id: 'tok',
       lmwf_text: 'r',
-      parsed_json: {},
       status: 'rejected',
     });
 
@@ -88,7 +83,6 @@ liveDdb('workout_inbox repository', () => {
         user_id,
         source_token_id: 'tok',
         lmwf_text: `item-${i}`,
-        parsed_json: {},
         status: 'pending',
       });
       // Ensure distinct created_at values.
@@ -119,7 +113,6 @@ liveDdb('workout_inbox repository', () => {
       user_id,
       source_token_id: 'tok',
       lmwf_text: 'x',
-      parsed_json: {},
       status: 'pending',
     });
 

--- a/validator/tests/routes/workouts.test.ts
+++ b/validator/tests/routes/workouts.test.ts
@@ -17,6 +17,23 @@ const VALID_LMWF = `# Push Day
 
 const INVALID_LMWF = `Just some text with no header at all.`;
 
+// A superset block (## Superset header + two ### exercise children). On read
+// the server re-parses this from `lmwf_text` and must reproduce the grouping:
+// both children carry `parentExerciseId` pointing at the superset parent.
+const SUPERSET_LMWF = `# Arm Day
+@units: lbs
+
+## Superset: Arms
+
+### Bicep Curl
+- 30 x 12
+- 30 x 12
+
+### Tricep Pushdown
+- 40 x 12
+- 40 x 12
+`;
+
 live('Workout inbox routes (/v1/workouts)', () => {
   let originalSecret: string | undefined;
   let app: typeof import('../../src/app.js').app;
@@ -278,6 +295,78 @@ live('Workout inbox routes (/v1/workouts)', () => {
     expect(body.workout.tags).toEqual(['strength', 'upper']);
     expect(body.workout.exercises).toHaveLength(1);
     expect(body.workout.exercises[0].sets).toHaveLength(3);
+  });
+
+  it('GET /v1/workouts/:id derives `workout` from lmwf_text alone (no persisted parsed_json), grouping intact', async () => {
+    // The server no longer stores a parsed payload — it persists only
+    // `lmwf_text` and derives `workout`/`summary` by re-parsing on read.
+    // This guards the #161 root cause: a superset's children must carry
+    // `parentExerciseId` pointing at the superset parent. If derivation
+    // ever regressed to dropping grouping, this would catch it.
+    const { plaintext } = await mintUserAndPat('derive-superset');
+    const created = (await (
+      await app.request('/v1/workouts', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          authorization: `Bearer ${plaintext}`,
+        },
+        body: JSON.stringify({ lmwf: SUPERSET_LMWF }),
+      })
+    ).json()) as { inbox_id: string };
+
+    const res = await app.request(`/v1/workouts/${created.inbox_id}`, {
+      headers: { authorization: `Bearer ${plaintext}` },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      lmwf_text: string;
+      summary: {
+        exercises: Array<{
+          name: string;
+          groupType: string | null;
+          groupName: string | null;
+          parentExerciseId: string | null;
+        }>;
+      };
+      workout: {
+        exercises: Array<{
+          id: string;
+          exerciseName: string;
+          groupType: string | null;
+          groupName: string | null;
+          parentExerciseId: string | null;
+        }>;
+      };
+    };
+
+    // Raw markdown still round-trips.
+    expect(body.lmwf_text).toBe(SUPERSET_LMWF);
+
+    // Derived plan exposes the superset parent + its two children.
+    const exs = body.workout.exercises;
+    expect(exs).toHaveLength(3);
+
+    // The superset parent has no parent of its own and carries the grouping.
+    const parent = exs.find((e) => e.groupType === 'superset' && !e.parentExerciseId);
+    expect(parent).toBeDefined();
+    expect(parent?.groupName).toBe('Superset: Arms');
+
+    const children = exs.filter((e) => e.parentExerciseId);
+    expect(children).toHaveLength(2);
+    // Both children point at the superset parent — the grouping link the
+    // old hand-written bridge dropped (#161 / #145).
+    for (const child of children) {
+      expect(child.parentExerciseId).toBe(parent?.id);
+    }
+    expect(children.map((c) => c.exerciseName).sort()).toEqual([
+      'Bicep Curl',
+      'Tricep Pushdown',
+    ]);
+
+    // The lightweight summary projection carries the same grouping fields.
+    const sumChildren = body.summary.exercises.filter((e) => e.parentExerciseId);
+    expect(sumChildren).toHaveLength(2);
   });
 
   it('GET /v1/workouts/:id non-existent returns 404', async () => {


### PR DESCRIPTION
## Summary
- Stop persisting the server-side pre-parse (`parsed_json`) for workout-inbox items — it was a stale/divergence artifact. `lmwf_text` (the raw markdown) is now the single source of truth.
- Keep validate-on-push: invalid LMWF still returns `422` and nothing is enqueued; we just discard the parse output instead of writing it.
- Derive `workout` (full `WorkoutPlan`) and `summary` **on read** by re-parsing `lmwf_text` (new `deriveWorkout(lmwf_text)` → `parseWorkout(lmwf_text).data` helper). The API response shape is unchanged, so the website inbox (#147) needs no changes. If a row ever fails to parse on read, `workout`/`summary` degrade to `null` rather than 500.
- DynamoDB is schemaless → no migration. Old rows may still carry a now-ignored `parsed_json` attribute; new rows are written without it. Spec updated to reflect this.

This is PR 2/2 of #161 (PR 1 shipped the iOS client fix in #162). Scope is the inbox parse-persistence only — no changes to `mobile-apps/ios/` or `website/`.

## Test plan
- [x] `npm run typecheck` — clean.
- [x] `npm test` against local DynamoDB — 304 passed / 35 skipped, 0 failed.
- [x] Existing detail/list/round-trip assertions still pass unchanged (response shape preserved, now derived).
- [x] New test: POST a superset workout, then GET detail and assert the derived `workout` reproduces the superset parent + two children, with both children carrying `parentExerciseId` → the parent (guards the #161/#145 root cause). Proves derivation works from `lmwf_text` alone with no persisted `parsed_json`.
- [ ] Real verification of on-read derivation is the validator-ci pipeline (deploy-beta → deploy-prod + smoke/e2e) on merge to main.

Closes #161