### PR TITLE
fix(website,e2e): hold access JWT in sessionStorage; repair e2e login helper

### DIFF
--- a/validator/e2e/helpers/api.ts
+++ b/validator/e2e/helpers/api.ts
@@ -195,25 +195,24 @@ export async function seedOutboxItem(opts: {
 }
 
 /**
- * Inject the seeded user's tokens into localStorage on the active page
- * so the dashboard treats it as a returning logged-in session — no UI
- * login required. The page must already be on the same origin as the
- * validator (i.e. baseURL).
+ * Establish a logged-in dashboard session for the seeded user.
+ *
+ * The dashboard no longer stores tokens in localStorage — the access JWT
+ * lives in memory and the refresh token is an httpOnly cookie the API sets
+ * on login (see website/src/scripts/api.js). There is therefore no token to
+ * inject; we drive the real login form once. The httpOnly refresh cookie it
+ * sets is what lets subsequent navigations re-mint the access JWT via the
+ * page's ensureSession() bootstrap.
  */
 export async function setBrowserSession(
   page: import('@playwright/test').Page,
   user: SeededUser,
 ): Promise<void> {
-  // Must be on the target origin before localStorage writes apply to it.
-  await page.goto('/');
-  await page.evaluate(
-    ({ jwt, userId, email }) => {
-      localStorage.setItem('lmwf_access_jwt', jwt);
-      localStorage.setItem(
-        'lmwf_user',
-        JSON.stringify({ user_id: userId, email, display_name: email }),
-      );
-    },
-    { jwt: user.sessionJwt, userId: user.userId, email: user.email },
-  );
+  await page.goto('/account/login');
+  await page.locator('#email').fill(user.email);
+  await page.locator('#password').fill(user.password);
+  await Promise.all([
+    page.waitForURL('**/account/'),
+    page.locator('#submit-btn').click(),
+  ]);
 }

--- a/website/src/scripts/api.js
+++ b/website/src/scripts/api.js
@@ -12,9 +12,16 @@
 //     website deliberately ignores it.
 //
 //   - access JWT: short-lived (~1h), sent as `Authorization: Bearer <jwt>` on
-//     every API call. Held ONLY in a module-scope in-memory variable (never
-//     localStorage). Because it lives in memory it is gone after a reload —
-//     pages bootstrap a fresh one from the refresh cookie via ensureSession().
+//     every API call. Held in sessionStorage (per-tab, cleared when the tab
+//     closes) with an in-memory cache. sessionStorage — not a bare module
+//     variable — because the /account portal is a multi-page app: a bare
+//     variable is lost on every full-page navigation, which would force a
+//     refresh-token rotation on each page load and race the server's
+//     reuse-detection (concurrent rotations / multi-tab → spurious logout).
+//     sessionStorage survives same-tab navigation, so we only refresh when the
+//     token actually expires. It is XSS-readable, but it is the SHORT-LIVED
+//     token, not the 1-year refresh token (which stays httpOnly), and the
+//     CloudFront CSP is the XSS backstop.
 //
 //   - USER_KEY: non-sensitive display data (name/email/tier). Kept in
 //     localStorage purely so the dashboard can paint a name before the first
@@ -25,12 +32,21 @@
 // reads the cookie, rotates it, and returns a new access JWT.
 
 export const USER_KEY = 'lmwf_user';
+// Access JWT lives in sessionStorage (NOT localStorage): short-lived, per-tab.
+const ACCESS_KEY = 'lmwf_access_jwt';
 
-// Short-lived access JWT — in memory only, never persisted.
+// In-memory cache mirrored to sessionStorage so reads are cheap and a tab that
+// blocks storage still works within its lifetime.
 let accessJwt = null;
 
-export function getJwt() {
+function readStoredJwt() {
+  if (accessJwt) return accessJwt;
+  try { accessJwt = sessionStorage.getItem(ACCESS_KEY); } catch {}
   return accessJwt;
+}
+
+export function getJwt() {
+  return readStoredJwt();
 }
 
 export function getUser() {
@@ -40,10 +56,14 @@ export function getUser() {
   } catch { return null; }
 }
 
-// Store the access JWT in memory. The refresh token is intentionally NOT a
-// parameter — it lives only in the httpOnly cookie the server set.
+// Store the access JWT (sessionStorage + cache). The refresh token is
+// intentionally NOT a parameter — it lives only in the httpOnly cookie.
 export function setSession(accessJwtValue, user) {
   accessJwt = accessJwtValue || null;
+  try {
+    if (accessJwt) sessionStorage.setItem(ACCESS_KEY, accessJwt);
+    else sessionStorage.removeItem(ACCESS_KEY);
+  } catch {}
   try {
     if (user) localStorage.setItem(USER_KEY, JSON.stringify(user));
   } catch {}
@@ -51,13 +71,13 @@ export function setSession(accessJwtValue, user) {
 
 export function clearSession() {
   accessJwt = null;
-  try {
-    localStorage.removeItem(USER_KEY);
-  } catch {}
+  try { sessionStorage.removeItem(ACCESS_KEY); } catch {}
+  try { localStorage.removeItem(USER_KEY); } catch {}
 }
 
 function sessionHeader() {
-  return accessJwt ? { Authorization: `Bearer ${accessJwt}` } : {};
+  const jwt = readStoredJwt();
+  return jwt ? { Authorization: `Bearer ${jwt}` } : {};
 }
 
 // Internal: mint a fresh access JWT from the httpOnly refresh cookie.
@@ -98,7 +118,7 @@ async function tryRefreshTokens() {
 // cookie if needed (e.g. on first page load after a reload, when the in-memory
 // JWT is gone). Returns true if a session is available, false otherwise.
 export async function ensureSession() {
-  if (accessJwt) return true;
+  if (readStoredJwt()) return true;
   return tryRefreshTokens();
 }
 


### PR DESCRIPTION
Fixes the post-#166 `e2e-local` regression that is blocking the validator/website deploy on `main`.

## Root cause
#166 moved the dashboard access JWT to a **memory-only** variable. In a multi-page app that variable is lost on every full-page navigation, so each page load minted a new access JWT — i.e. a **refresh-token rotation per navigation**. Rapid navigation (and real-world multi-tab / fast clicks) races the server's refresh-token reuse-detection, killing the session. The e2e `account-outbox` / `account-pats` specs surfaced this as a redirect to `/account/login`.

## Fix
- **`website/src/scripts/api.js`** — store the short-lived access JWT in **`sessionStorage`** (per-tab, survives same-tab navigation) instead of a bare module variable. We now refresh only when the token actually expires, eliminating the per-navigation rotation race. The **1-year refresh token stays in the httpOnly cookie**, so M2's actual security goal (long-lived secret out of JS-readable storage) is preserved; sessionStorage holds only the ~1h token, with the CloudFront CSP as the XSS backstop.
- **`validator/e2e/helpers/api.ts`** — `setBrowserSession` injected a `localStorage` access token (the pre-#166 model the new auth ignores). It now drives the real login form, establishing the httpOnly refresh cookie the real way — which also makes the tests exercise the genuine cookie re-mint-on-navigation path.

## Verification
`e2e-local`: **11/11 pass** locally (were 2 failing post-#166: `account-outbox`, `account-pats`). Real login → dashboard → reload → sign-out all verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)