### PR TITLE
fix(cdk): WAFv2 web ACL description must be ASCII (unblocks deploy)

### DIFF
--- a/validator/cdk/edge-stack.ts
+++ b/validator/cdk/edge-stack.ts
@@ -55,7 +55,8 @@ export class LmwfEdgeStack extends cdk.Stack {
       name: `${namePrefix}-cloudfront`,
       scope: 'CLOUDFRONT',
       defaultAction: { allow: {} },
-      description: `LMWF ${envConfig.name} CloudFront WAF — managed rules + rate limits`,
+      // WAFv2 description is regex-constrained (no em-dash / non-ASCII punctuation).
+      description: `LMWF ${envConfig.name} CloudFront WAF - managed rules and rate limits`,
       visibilityConfig: {
         cloudWatchMetricsEnabled: true,
         metricName: `${namePrefix}-cloudfront-acl`,


### PR DESCRIPTION
The beta CDK deploy (from #166) failed: `EdgeWebAcl` CREATE_FAILED because the WAFv2 web ACL `description` contained an em-dash, and WAFv2 constrains the description to `^[\w+=:#@/\-,\.][\w+=:#@/\-,\.\s]+[\w+=:#@/\-,\.]$` (ASCII only). The beta edge stack rolled back cleanly; prod was untouched.

Fix: use an ASCII hyphen in the description. (Lambda/API/CloudFront/Route53 descriptions accept em-dashes, so only the WAF string needed changing.)

Verified: `cdk synth`/`tsc` clean. Deploy re-runs on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)