### PR TITLE
fix(cdk): allow 'unsafe-inline' in CSP style-src (unblocks deploy)

### DIFF
--- a/validator/cdk/stack.ts
+++ b/validator/cdk/stack.ts
@@ -415,17 +415,18 @@ function handler(event) {
     // HSTS, anti-clickjacking, nosniff, and Referrer-Policy controls the site
     // and authenticated /account portal were missing entirely.
     //
-    // CSP: `default-src 'self'` with no `'unsafe-inline'`. The website ships
-    // two inline <script> blocks (Base.astro); the website agent adds the
-    // matching CSP hashes via Astro's build so they load under `script-src
-    // 'self' <hash>`. We deliberately keep `'self'`-only here rather than
-    // weakening to `'unsafe-inline'` — coordinate hashes, do not relax this.
+    // CSP: `script-src 'self'` (no `'unsafe-inline'`) is the real XSS control —
+    // all site scripts are external ES modules, so no script hashes are needed.
+    // `style-src` DOES allow `'unsafe-inline'`: the site applies runtime inline
+    // styles (theme/color-scheme toggle sets element.style, Astro scoped
+    // <style>), which can't be practically hashed; inline *style* injection is
+    // far lower-risk than script injection, so this is the standard tradeoff.
     // `img-src 'self' data:` permits inlined icons/SVGs; everything else is
     // locked to same-origin.
     const csp = [
       "default-src 'self'",
       "script-src 'self'",
-      "style-src 'self'",
+      "style-src 'self' 'unsafe-inline'",
       "connect-src 'self'",
       "img-src 'self' data:",
       "font-src 'self'",


### PR DESCRIPTION
After #169 unblocked the CDK deploy, the redeploy got through **deploy-beta ✓** and **smoke-beta ✓** but failed **e2e-beta** on the homepage: the strict CSP from #166 (`style-src 'self'`) blocks the site's runtime inline styles (theme/color-scheme toggle setting `element.style`; Astro scoped `<style>`), producing a console CSP violation the homepage test rejects. The page content renders fine and the account-portal e2e specs passed against beta; only the no-console-errors assertion failed. Prod was not touched (deploy-prod gates on e2e-beta).

Fix: `style-src 'self' 'unsafe-inline'`. `script-src 'self'` (the real XSS control — all scripts are external ES modules) and `frame-ancestors 'none'` are unchanged. Inline *style* injection is far lower-risk than script injection, so this is the standard CSP tradeoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)