### PR TITLE
security(m4): GitHub Actions OIDC bootstrap (provider + deploy roles)

### DIFF
--- a/validator/cdk/iam/README.md
+++ b/validator/cdk/iam/README.md
@@ -8,6 +8,53 @@ Two inline policies for two IAM users:
 
 Both grant `sts:AssumeRole` on the LiftMark-namespaced CDK bootstrap roles (`cdk-lmwf-*`) in both `us-west-2` (Lambda + API Gateway origin + S3 + CloudFront) and `us-east-1` (CloudFront cert + WAF). All real permissions live in the bootstrap roles themselves, scoped by `../deploy-policy.json`, which CDK maintains.
 
+> The `ci-deploy-*` users are being retired in favour of GitHub Actions OIDC — see below. They are removed once OIDC is live (issue #171).
+
+## GitHub Actions OIDC (deploy auth) — replaces the static-key CI users
+
+The GitHub Actions deploy jobs (`.github/workflows/validator-ci.yml`) authenticate to AWS via **OIDC**, not long-lived access keys (security finding **M4**, issue #171). Per stage account there is:
+
+- a GitHub OIDC identity provider (`token.actions.githubusercontent.com`), and
+- a role `GitHubActionsDeploy` whose trust is scoped to a single GitHub Environment `sub`
+  (`repo:vfilby/liftmark:environment:beta` / `…:environment:production`) and whose only
+  permissions are to `sts:AssumeRole` the `cdk-lmwf-*` bootstrap roles (plus the e2e secret
+  read in beta).
+
+These files are the reviewable record; they are **bootstrap tier** — applied once per account
+from a privileged SSO session, NOT part of the CDK app and NOT run by the pipeline (the role is
+what the pipeline assumes, so the pipeline can't create it; a deploy identity must not manage
+itself — same tier as `cdk bootstrap` and the `ci-deploy-*`/`deploy-user` policies here).
+
+- `github-oidc-trust-beta.json` / `github-oidc-trust-prod.json` — role trust policies
+- `github-oidc-perms-beta.json` / `github-oidc-perms-prod.json` — role permission policies
+- `setup-oidc.sh` — applies the above for one stage (SSO login → provider → role → policy)
+
+### Apply
+
+```bash
+# from validator/cdk/iam/ — uses your SSO profile (default liftmark-beta / liftmark-prod;
+# override with PROFILE=...). Re-runnable: updates the role in place if it already exists.
+./setup-oidc.sh beta
+./setup-oidc.sh prod
+```
+
+The script prints the role ARN and the `gh variable set` command to publish it to the
+matching GitHub Environment, e.g.:
+
+```bash
+gh variable set AWS_DEPLOY_ROLE_ARN --repo vfilby/liftmark --env beta \
+  --body "arn:aws:iam::323146837100:role/GitHubActionsDeploy"
+gh variable set AWS_DEPLOY_ROLE_ARN --repo vfilby/liftmark --env production \
+  --body "arn:aws:iam::825347768149:role/GitHubActionsDeploy"
+```
+
+Also restrict each GitHub Environment (Settings → Environments → beta / production) with a
+**deployment branch policy** of `main`, so only `main` can claim the environment `sub`.
+
+Once OIDC is confirmed working (test via `gh workflow run Validator --ref main`), delete the
+`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` environment secrets and the `liftmark-ci-deploy-*`
+IAM users + policies.
+
 ## `../deploy-policy.json` privilege-escalation hardening (L11)
 
 The scoped CFN execution policy is the blast radius once `cdk-lmwf-deploy-role` is assumed. Three guardrails close the classic "create a role, attach AdministratorAccess, PassRole it to a Lambda" escalation primitive:

--- a/validator/cdk/iam/github-oidc-perms-beta.json
+++ b/validator/cdk/iam/github-oidc-perms-beta.json
@@ -1,0 +1,17 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AssumeCDKBootstrapRoles",
+      "Effect": "Allow",
+      "Action": "sts:AssumeRole",
+      "Resource": "arn:aws:iam::323146837100:role/cdk-lmwf-*"
+    },
+    {
+      "Sid": "E2ESecretRead",
+      "Effect": "Allow",
+      "Action": "secretsmanager:GetSecretValue",
+      "Resource": "arn:aws:secretsmanager:us-west-2:323146837100:secret:lmwf-beta-e2e-test-secret-*"
+    }
+  ]
+}

--- a/validator/cdk/iam/github-oidc-perms-prod.json
+++ b/validator/cdk/iam/github-oidc-perms-prod.json
@@ -1,0 +1,11 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AssumeCDKBootstrapRoles",
+      "Effect": "Allow",
+      "Action": "sts:AssumeRole",
+      "Resource": "arn:aws:iam::825347768149:role/cdk-lmwf-*"
+    }
+  ]
+}

--- a/validator/cdk/iam/github-oidc-trust-beta.json
+++ b/validator/cdk/iam/github-oidc-trust-beta.json
@@ -1,0 +1,19 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "GitHubActionsBetaEnvironment",
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::323146837100:oidc-provider/token.actions.githubusercontent.com"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+          "token.actions.githubusercontent.com:sub": "repo:vfilby/liftmark:environment:beta"
+        }
+      }
+    }
+  ]
+}

--- a/validator/cdk/iam/github-oidc-trust-prod.json
+++ b/validator/cdk/iam/github-oidc-trust-prod.json
@@ -1,0 +1,19 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "GitHubActionsProductionEnvironment",
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::825347768149:oidc-provider/token.actions.githubusercontent.com"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+          "token.actions.githubusercontent.com:sub": "repo:vfilby/liftmark:environment:production"
+        }
+      }
+    }
+  ]
+}

--- a/validator/cdk/iam/setup-oidc.sh
+++ b/validator/cdk/iam/setup-oidc.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# Bootstrap the GitHub Actions OIDC deploy role for one stage account.
+#
+# BOOTSTRAP TIER — run ONCE per account from a privileged SSO session. This is
+# deliberately NOT part of the CDK app and NOT run by the pipeline: the role
+# created here is what the pipeline authenticates as, so a pipeline-run deploy
+# can't create it (chicken-and-egg), and a deploy identity must not manage
+# itself. Lives alongside the other hand-applied IAM here (ci-deploy-*,
+# deploy-user). See README "GitHub Actions OIDC (deploy auth)" and issue #171.
+#
+# Usage:
+#   ./setup-oidc.sh beta
+#   ./setup-oidc.sh prod
+#   PROFILE=my-sso-profile ./setup-oidc.sh beta    # override the SSO profile
+#
+set -euo pipefail
+
+STAGE="${1:-}"
+REPO="vfilby/liftmark"
+ROLE_NAME="GitHubActionsDeploy"
+# Thumbprint is no longer security-critical for the GitHub provider (AWS
+# validates the token against its own trust store) but the create API still
+# requires the field.
+GH_THUMBPRINT="6938fd4d98bab03faadb97b34396831e3780aea1"
+
+case "$STAGE" in
+  beta) ACCT=323146837100; GH_ENV=beta;       PROFILE="${PROFILE:-liftmark-beta}" ;;
+  prod) ACCT=825347768149; GH_ENV=production; PROFILE="${PROFILE:-liftmark-prod}" ;;
+  *)    echo "usage: $0 <beta|prod>   (set PROFILE=... to override the SSO profile)"; exit 2 ;;
+esac
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TRUST="$DIR/github-oidc-trust-$STAGE.json"
+PERMS="$DIR/github-oidc-perms-$STAGE.json"
+
+echo "==> SSO login (profile: $PROFILE)"
+aws sso login --profile "$PROFILE"
+export AWS_PROFILE="$PROFILE"
+
+echo "==> verifying we are in account $ACCT"
+GOT="$(aws sts get-caller-identity --query Account --output text)"
+if [ "$GOT" != "$ACCT" ]; then
+  echo "WRONG ACCOUNT: got $GOT, expected $ACCT ($STAGE) — aborting" >&2
+  exit 1
+fi
+
+PROVIDER_ARN="arn:aws:iam::${ACCT}:oidc-provider/token.actions.githubusercontent.com"
+echo "==> ensuring GitHub OIDC provider exists"
+if aws iam get-open-id-connect-provider --open-id-connect-provider-arn "$PROVIDER_ARN" >/dev/null 2>&1; then
+  echo "    provider already present"
+else
+  aws iam create-open-id-connect-provider \
+    --url https://token.actions.githubusercontent.com \
+    --client-id-list sts.amazonaws.com \
+    --thumbprint-list "$GH_THUMBPRINT"
+  echo "    provider created"
+fi
+
+echo "==> creating/updating role $ROLE_NAME (trust: $(basename "$TRUST"))"
+if aws iam get-role --role-name "$ROLE_NAME" >/dev/null 2>&1; then
+  aws iam update-assume-role-policy --role-name "$ROLE_NAME" --policy-document "file://$TRUST"
+else
+  aws iam create-role --role-name "$ROLE_NAME" \
+    --assume-role-policy-document "file://$TRUST" \
+    --description "GitHub Actions OIDC deploy role (security M4, issue #171)"
+fi
+
+echo "==> attaching permissions (policy: $(basename "$PERMS"))"
+aws iam put-role-policy --role-name "$ROLE_NAME" --policy-name deploy --policy-document "file://$PERMS"
+
+ROLE_ARN="$(aws iam get-role --role-name "$ROLE_NAME" --query Role.Arn --output text)"
+echo ""
+echo "==> done. Role ARN: $ROLE_ARN"
+echo ""
+echo "Next, publish it to the GitHub environment (run locally, with gh authed to the repo):"
+echo "  gh variable set AWS_DEPLOY_ROLE_ARN --repo $REPO --env $GH_ENV --body \"$ROLE_ARN\""


### PR DESCRIPTION
Phase A of #171 — the reviewable bootstrap-tier record for replacing static CI deploy keys with per-account GitHub Actions OIDC roles.

**What's here (no behaviour change on merge):**
- `validator/cdk/iam/github-oidc-trust-{beta,prod}.json` — role trust, scoped to the `beta` / `production` GitHub Environment `sub`.
- `validator/cdk/iam/github-oidc-perms-{beta,prod}.json` — `sts:AssumeRole` on `cdk-lmwf-*` (+ the e2e secret read in beta only).
- `validator/cdk/iam/setup-oidc.sh` — applies them per stage from an SSO session (sso login → provider → role → policy), prints the role ARN and the `gh variable set` command.
- README section documenting it as **bootstrap tier** (applied once per account by an admin; not in the CDK app, not run by the pipeline).

**How to run (you, from this branch):**
```bash
cd validator/cdk/iam
./setup-oidc.sh beta      # PROFILE=... to override the SSO profile
./setup-oidc.sh prod
# then run the printed `gh variable set …` for each environment
```
Also set a deployment-branch policy of `main` on both GitHub Environments.

**Sequencing:** this PR is safe to merge anytime (it only adds reference files + a script — the `iam/` dir is not part of the deployed CDK app). The workflow change that actually *consumes* these roles is a separate PR (#TBD) and must land **only after** the roles + `AWS_DEPLOY_ROLE_ARN` env vars exist.

Tracking: #171.

🤖 Generated with [Claude Code](https://claude.com/claude-code)