### PR TITLE
security(m4): deploy via GitHub OIDC role, drop static AWS keys [DRAFT — needs roles first]

### DIFF
--- a/.github/workflows/validator-ci.yml
+++ b/.github/workflows/validator-ci.yml
@@ -18,6 +18,7 @@ concurrency:
 permissions:
   contents: read
   deployments: write
+  id-token: write   # OIDC: assume the per-env AWS deploy role (no static keys)
 
 jobs:
   # ── Stage 0: changes ───────────────────────────────────────────────────
@@ -292,11 +293,13 @@ jobs:
         with:
           name: website-bundle
           path: website/dist
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
       - name: CDK deploy (beta)
         working-directory: validator/cdk
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
           set -euo pipefail
           BUILD_COMMIT="${{ github.sha }}"
@@ -360,11 +363,13 @@ jobs:
       - name: Install Playwright browser
         working-directory: validator/e2e
         run: npx playwright install --with-deps chromium
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
       - name: Fetch E2E test secret from beta Secrets Manager
         id: get-secret
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
           set -euo pipefail
           SECRET=$(aws secretsmanager get-secret-value \
@@ -445,11 +450,13 @@ jobs:
         with:
           name: website-bundle
           path: website/dist
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
       - name: CDK deploy (prod)
         working-directory: validator/cdk
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
           set -euo pipefail
           BUILD_COMMIT="${{ github.sha }}"


### PR DESCRIPTION
**Draft — do not merge until the OIDC roles + env vars exist** (#172 + `setup-oidc.sh` run per account). Phase A workflow half of #171.

## Change
The three AWS-auth jobs in `validator-ci.yml` — `deploy-beta`, `e2e-beta`, `deploy-prod` — now assume the per-environment `GitHubActionsDeploy` role via OIDC instead of long-lived static keys:
- top-level `permissions:` gains `id-token: write`
- each job gets a `Configure AWS credentials (OIDC)` step using `aws-actions/configure-aws-credentials@v4` with `role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}` and `aws-region: ${{ env.AWS_REGION }}`
- the `secrets.AWS_ACCESS_KEY_ID/SECRET` env blocks are removed

`vars.AWS_DEPLOY_ROLE_ARN` resolves per GitHub Environment (`beta` → beta-acct role, `production` → prod-acct role), so the same YAML works for both.

## Merge sequence (hard dependency)
1. Merge #172 (or run `validator/cdk/iam/setup-oidc.sh beta|prod` from that branch) → OIDC providers + `GitHubActionsDeploy` roles exist.
2. `gh variable set AWS_DEPLOY_ROLE_ARN` on both `beta` and `production` environments.
3. Mark this PR ready + merge → **or** test first via `gh workflow run Validator --ref main` while the old keys still exist as a fallback.
4. After a green OIDC deploy: delete the `AWS_ACCESS_KEY_ID/SECRET` env secrets + the `liftmark-ci-deploy-*` IAM users (Phase A cleanup) and proceed to Concourse retirement (Phase B).

If merged before step 1/2, the deploy jobs fail (no role to assume) — hence draft.

Tracking: #171.

🤖 Generated with [Claude Code](https://claude.com/claude-code)