### PR TITLE
security(m4): shrink deploy-policy under IAM's 6144-char managed-policy limit

### DIFF
--- a/validator/cdk/deploy-policy.json
+++ b/validator/cdk/deploy-policy.json
@@ -156,21 +156,7 @@
     {
       "Sid": "S3CDKAssets",
       "Effect": "Allow",
-      "Action": [
-        "s3:CreateBucket",
-        "s3:GetBucketLocation",
-        "s3:ListBucket",
-        "s3:GetObject",
-        "s3:PutObject",
-        "s3:DeleteObject",
-        "s3:GetBucketPolicy",
-        "s3:PutBucketPolicy",
-        "s3:PutBucketVersioning",
-        "s3:PutEncryptionConfiguration",
-        "s3:PutLifecycleConfiguration",
-        "s3:PutBucketPublicAccessBlock",
-        "s3:GetEncryptionConfiguration"
-      ],
+      "Action": "s3:*",
       "Resource": [
         "arn:aws:s3:::cdk-lmwf-*",
         "arn:aws:s3:::cdk-lmwf-*/*"
@@ -179,27 +165,7 @@
     {
       "Sid": "S3SiteBucket",
       "Effect": "Allow",
-      "Action": [
-        "s3:CreateBucket",
-        "s3:DeleteBucket",
-        "s3:GetBucketLocation",
-        "s3:ListBucket",
-        "s3:GetBucketPolicy",
-        "s3:PutBucketPolicy",
-        "s3:DeleteBucketPolicy",
-        "s3:PutBucketVersioning",
-        "s3:GetBucketVersioning",
-        "s3:PutEncryptionConfiguration",
-        "s3:GetEncryptionConfiguration",
-        "s3:PutBucketPublicAccessBlock",
-        "s3:GetBucketPublicAccessBlock",
-        "s3:PutBucketTagging",
-        "s3:GetBucketTagging",
-        "s3:PutLifecycleConfiguration",
-        "s3:GetObject",
-        "s3:PutObject",
-        "s3:DeleteObject"
-      ],
+      "Action": "s3:*",
       "Resource": [
         "arn:aws:s3:::liftmark-workoutformat-*",
         "arn:aws:s3:::liftmark-workoutformat-*/*"

--- a/validator/cdk/iam/README.md
+++ b/validator/cdk/iam/README.md
@@ -71,6 +71,8 @@ Not added in code, but recommended: a **permissions boundary on `CreateRole`** (
 
 The `CloudFrontDistribution` statement keeps `Resource: "*"`: `cloudfront:CreateDistribution` (and the OAC/Function/Invalidation actions) do not support resource-level ARNs — the distribution ARN does not exist until creation — so `*` is genuinely required by the CloudFront API. The actions are account-scoped and the policy is only reachable post-assume-role, so this is acceptable.
 
+The two S3 statements use `Action: "s3:*"` **scoped to specific bucket ARNs** (`cdk-lmwf-*` assets and `liftmark-workoutformat-*` site) rather than an explicit action list. This is a deliberate trade: enumerating every S3 action pushed the policy past IAM's 6,144-char managed-policy limit (whitespace excluded), so `LmwfCdkDeployPolicy` could not be created at all. `s3:*` bounded by resource grants the deploy role nothing beyond full control of buckets it already owns end-to-end, and it does not touch the IAM/`PassRole`/`AttachRolePolicy` guardrails above (the actual escalation surface). Keep new statements terse — the policy must stay under 6,144 non-whitespace characters or `aws iam create-policy` fails with `LimitExceeded`.
+
 ## Applying
 
 AWS Console → IAM → Users → `liftmark-deploy` → Permissions → Create inline policy → paste the JSON → name it `CdkAssumeBootstrapRoles`.


### PR DESCRIPTION
Blocker found while running Phase C (`refresh-deploy-policy.sh beta`): `aws iam create-policy` failed with **`LimitExceeded: Cannot exceed quota for PolicySize: 6144`**.

The L11-hardened `deploy-policy.json` was **6,558 non-whitespace chars** — over IAM's 6,144 managed-policy limit — so `LmwfCdkDeployPolicy` **was never created**. Which means the bootstrap couldn't have referenced it: **L11 was never actually live**, and the `cdk-lmwf-deploy-role` is still `AdministratorAccess`. (This is exactly what Phase C exists to catch.)

## Fix
Collapse the two S3 statements to `Action: "s3:*"` **scoped to their bucket ARNs** (`cdk-lmwf-*` assets, `liftmark-workoutformat-*` site). Resource-bounded → the deploy role gains nothing beyond buckets it already owns end-to-end, and the IAM/`PassRole`/`AttachRolePolicy` escalation guardrails (the actual L11 surface) are untouched. Now **5,827 chars** (~300 under the limit). README documents the trade + the limit.

## Next (you, after this merges or from this branch)
Re-run Phase C — it'll now create the policy, then report bootstrap scoping:
```bash
cd validator/cdk/iam
./refresh-deploy-policy.sh beta
./refresh-deploy-policy.sh prod
```
Expect both to create the policy ✓ then report **NOT scoped** (since it never existed) and print the `cdk bootstrap … --cloudformation-execution-policies …` to run — that re-bootstrap is what finally makes L11 live.

Tracking: #171 (Phase C).

🤖 Generated with [Claude Code](https://claude.com/claude-code)