### PR TITLE
fix(m4): include --profile in refresh-deploy-policy.sh bootstrap hint

### DIFF
--- a/validator/cdk/iam/refresh-deploy-policy.sh
+++ b/validator/cdk/iam/refresh-deploy-policy.sh
@@ -82,6 +82,7 @@ for region in "${REGIONS[@]}"; do
     echo "  [$region] ✗ NOT scoped (CloudFormationExecutionPolicies='${VAL:-<empty = AdministratorAccess>}')"
     echo "            deploy role is still AdministratorAccess — re-bootstrap to fix:"
     echo "            npx cdk bootstrap aws://${ACCT}/${region} \\"
+    echo "              --profile ${PROFILE} \\"
     echo "              --qualifier ${QUALIFIER} --toolkit-stack-name ${TOOLKIT} \\"
     echo "              --cloudformation-execution-policies ${POLICY_ARN}"
     NEEDS_FIX=1


### PR DESCRIPTION
The Phase C script's printed `cdk bootstrap` hint omitted `--profile`, so running it in a fresh shell (the script's exported `AWS_PROFILE` doesn't persist to the interactive shell) fails with `no credentials have been configured`. Emit `--profile ${PROFILE}` so the hint is copy-paste-correct. Tracking: #171.

🤖 Generated with [Claude Code](https://claude.com/claude-code)