### PR TITLE
ci: bump Node 20 actions to Node 24 majors (closes #174)

### DIFF
--- a/.github/workflows/swift-ci.yml
+++ b/.github/workflows/swift-ci.yml
@@ -17,7 +17,7 @@ jobs:
       ios: ${{ steps.filter.outputs.ios }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |

--- a/.github/workflows/validator-ci.yml
+++ b/.github/workflows/validator-ci.yml
@@ -35,7 +35,7 @@ jobs:
       validator: ${{ steps.filter.outputs.validator }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -294,7 +294,7 @@ jobs:
           name: website-bundle
           path: website/dist
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
@@ -364,7 +364,7 @@ jobs:
         working-directory: validator/e2e
         run: npx playwright install --with-deps chromium
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
@@ -451,7 +451,7 @@ jobs:
           name: website-bundle
           path: website/dist
       - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}


### PR DESCRIPTION
Clears the Node 20 deprecation warnings (forced to Node 24 on **2026-06-02**, runtime removed **2026-09-16**) by bumping the two flagged actions to their node24 majors:

| action | was | now | runtime verified |
|---|---|---|---|
| `dorny/paths-filter` | v3 | **v4** | `using: node24` |
| `aws-actions/configure-aws-credentials` | v4 | **v6** | `using: node24` |

Confirmed each new major actually runs on node24 (checked `action.yml` at the tag), and both are stable major tags matching the repo's `@vN` convention.

`paths-filter@v4` is exercised by this PR's own `changes` job. `configure-aws-credentials@v6` is only used by the push-gated deploy jobs (OIDC `role-to-assume` + `aws-region`, both stable across v4→v6), so it's validated by the post-merge deploy — which I'll watch.

Closes #174.

🤖 Generated with [Claude Code](https://claude.com/claude-code)