### PR TITLE
fix(live-activities): advance past skipped exercise (#144)

### DIFF
--- a/mobile-apps/ios/LiftMark/Services/LiveActivityService.swift
+++ b/mobile-apps/ios/LiftMark/Services/LiveActivityService.swift
@@ -19,6 +19,28 @@ final class LiveActivityService: @unchecked Sendable {
     private var lastUpdateTime: Date?
     private static let updateThrottleInterval: TimeInterval = 1.0
 
+    /// Default title/subtitle shown when a workout is complete. Shared by the
+    /// in-place finishing state (skip-to-finish) and the dismissal message in
+    /// `endWorkoutActivity` so both paths read identically.
+    static let completeTitle = "Workout Complete"
+    static let completeSubtitle = "Great job!"
+
+    #if os(iOS)
+    /// Content state shown when no exercise has pending sets remaining — every
+    /// set is completed or skipped. Visually matches the completion message but
+    /// keeps the activity alive (it is dismissed only by `endWorkoutActivity`).
+    @available(iOS 16.2, *)
+    static var finishingState: WorkoutActivityAttributes.ContentState {
+        WorkoutActivityAttributes.ContentState(
+            isRestTimer: false,
+            exerciseName: completeTitle,
+            setInfo: "",
+            weightReps: completeSubtitle,
+            progress: 1.0
+        )
+    }
+    #endif
+
     private init() {}
 
     // MARK: - Availability
@@ -101,26 +123,29 @@ final class LiveActivityService: @unchecked Sendable {
         if #available(iOS 16.2, *) {
             guard let activity = currentActivity else { return }
 
-            // Throttle updates to avoid excessive Live Activity refreshes
-            if let lastUpdate = lastUpdateTime, Date().timeIntervalSince(lastUpdate) < Self.updateThrottleInterval {
+            // A nil exercise with no active rest timer means every set is now
+            // completed or skipped — the workout is effectively done. This
+            // transition into the finishing state (e.g. after skipping the last
+            // pending set) must NOT be dropped by the throttle, or the activity
+            // would stay stuck on the just-skipped exercise (#144).
+            let isFinishingTransition = (restTimer == nil || restTimer?.remainingSeconds == 0) && exercise == nil
+
+            // Throttle ordinary content refreshes; always let the finishing
+            // transition through.
+            if !isFinishingTransition,
+               let lastUpdate = lastUpdateTime,
+               Date().timeIntervalSince(lastUpdate) < Self.updateThrottleInterval {
                 return
             }
             lastUpdateTime = Date()
 
-            let state: WorkoutActivityAttributes.ContentState
-
-            if let restTimer, restTimer.remainingSeconds > 0 {
-                state = buildRestState(
-                    session: session,
-                    remainingSeconds: restTimer.remainingSeconds,
-                    nextExercise: restTimer.nextExercise,
-                    progress: progress
-                )
-            } else if let exercise {
-                state = buildActiveSetState(session: session, exercise: exercise, setIndex: setIndex, progress: progress)
-            } else {
-                return
-            }
+            let state = resolveContentState(
+                session: session,
+                exercise: exercise,
+                setIndex: setIndex,
+                progress: progress,
+                restTimer: restTimer
+            )
 
             let content = ActivityContent(state: state, staleDate: nil)
             Task {
@@ -129,6 +154,36 @@ final class LiveActivityService: @unchecked Sendable {
         }
         #endif
     }
+
+    #if os(iOS)
+    /// Pure resolution of which content state to display for the given inputs.
+    /// Extracted so the cursor-advance / finishing-state logic (#144) is
+    /// testable without a live `Activity` instance.
+    @available(iOS 16.2, *)
+    func resolveContentState(
+        session: WorkoutSession,
+        exercise: SessionExercise?,
+        setIndex: Int,
+        progress: (completed: Int, total: Int),
+        restTimer: (remainingSeconds: Int, nextExercise: SessionExercise?)? = nil
+    ) -> WorkoutActivityAttributes.ContentState {
+        if let restTimer, restTimer.remainingSeconds > 0 {
+            return buildRestState(
+                session: session,
+                remainingSeconds: restTimer.remainingSeconds,
+                nextExercise: restTimer.nextExercise,
+                progress: progress
+            )
+        } else if let exercise {
+            return buildActiveSetState(session: session, exercise: exercise, setIndex: setIndex, progress: progress)
+        } else {
+            // No exercise has pending sets remaining: show the finishing
+            // state (kept alive — the activity is only dismissed by
+            // endWorkoutActivity when the user formally finishes).
+            return Self.finishingState
+        }
+    }
+    #endif
 
     // MARK: - End
 
@@ -143,9 +198,9 @@ final class LiveActivityService: @unchecked Sendable {
 
             let finalState = WorkoutActivityAttributes.ContentState(
                 isRestTimer: false,
-                exerciseName: message ?? "Workout Complete",
+                exerciseName: message ?? Self.completeTitle,
                 setInfo: "",
-                weightReps: subtitle ?? "Great job!",
+                weightReps: subtitle ?? Self.completeSubtitle,
                 progress: 1.0
             )
 

--- a/mobile-apps/ios/LiftMarkTests/LiveActivityServiceTests.swift
+++ b/mobile-apps/ios/LiftMarkTests/LiveActivityServiceTests.swift
@@ -183,6 +183,101 @@ final class LiveActivityServiceTests: XCTestCase {
         XCTAssertEqual(detail, "BW \u{00D7} 60s")
     }
 
+    // MARK: - resolveContentState: cursor advance on skip (#144)
+
+    /// Mirrors ActiveWorkoutViewModel.updateLiveActivity's derivation of the
+    /// current exercise/set so the tests exercise the same handoff that the app
+    /// uses after a skip.
+    private func currentCursor(in session: WorkoutSession) -> (exercise: SessionExercise?, setIndex: Int) {
+        let current = session.exercises.first { ex in ex.sets.contains { $0.status == .pending } }
+        let idx = current?.sets.firstIndex { $0.status == .pending } ?? 0
+        return (current, idx)
+    }
+
+    func testResolveAdvancesToNextExerciseWhenCurrentSkipped() throws {
+        guard #available(iOS 16.2, *) else { throw XCTSkip("Requires iOS 16.2") }
+        // ex1's only set is skipped → cursor advances to ex2.
+        let ex1 = makeExercise(name: "Bench Press", sets: [
+            makeSet(targetWeight: 185, targetWeightUnit: .lbs, targetReps: 5, status: .skipped)
+        ])
+        let ex2 = makeExercise(name: "Squat", sets: [
+            makeSet(targetWeight: 225, targetWeightUnit: .lbs, targetReps: 5, status: .pending)
+        ])
+        let session = makeSession(exercises: [ex1, ex2])
+
+        let cursor = currentCursor(in: session)
+        XCTAssertEqual(cursor.exercise?.exerciseName, "Squat")
+
+        let state = service.resolveContentState(
+            session: session,
+            exercise: cursor.exercise,
+            setIndex: cursor.setIndex,
+            progress: (completed: 0, total: 2)
+        )
+        XCTAssertFalse(state.isRestTimer)
+        XCTAssertEqual(state.exerciseName, "Squat")
+        XCTAssertEqual(state.weightReps, "225 lbs \u{00D7} 5")
+    }
+
+    func testResolveAdvancesPastSkippedLastSetWithinExercise() throws {
+        guard #available(iOS 16.2, *) else { throw XCTSkip("Requires iOS 16.2") }
+        // First set completed, last set skipped on ex1 → advance to ex2.
+        let ex1 = makeExercise(name: "Bench Press", sets: [
+            makeSet(targetWeight: 135, targetWeightUnit: .lbs, targetReps: 5, status: .completed),
+            makeSet(targetWeight: 155, targetWeightUnit: .lbs, targetReps: 5, status: .skipped)
+        ])
+        let ex2 = makeExercise(name: "Squat", sets: [
+            makeSet(targetWeight: 225, targetWeightUnit: .lbs, targetReps: 5, status: .pending)
+        ])
+        let session = makeSession(exercises: [ex1, ex2])
+
+        let cursor = currentCursor(in: session)
+        let state = service.resolveContentState(
+            session: session,
+            exercise: cursor.exercise,
+            setIndex: cursor.setIndex,
+            progress: (completed: 1, total: 3)
+        )
+        XCTAssertEqual(state.exerciseName, "Squat")
+    }
+
+    func testResolveShowsFinishingStateWhenLastExerciseSkipped() throws {
+        guard #available(iOS 16.2, *) else { throw XCTSkip("Requires iOS 16.2") }
+        // Every set across the session is completed or skipped → finishing state.
+        let ex1 = makeExercise(name: "Bench Press", sets: [
+            makeSet(status: .completed)
+        ], status: .completed)
+        let ex2 = makeExercise(name: "Squat", sets: [
+            makeSet(status: .skipped)
+        ], status: .skipped)
+        let session = makeSession(exercises: [ex1, ex2])
+
+        let cursor = currentCursor(in: session)
+        XCTAssertNil(cursor.exercise, "No pending sets should resolve current exercise to nil")
+
+        let state = service.resolveContentState(
+            session: session,
+            exercise: cursor.exercise,
+            setIndex: cursor.setIndex,
+            progress: (completed: 1, total: 2)
+        )
+        XCTAssertEqual(state.exerciseName, LiveActivityService.completeTitle)
+        XCTAssertEqual(state.weightReps, LiveActivityService.completeSubtitle)
+        XCTAssertEqual(state.progress, 1.0)
+        XCTAssertFalse(state.isRestTimer)
+    }
+
+    func testResolveFinishingStateMatchesEndCompletionMessage() throws {
+        guard #available(iOS 16.2, *) else { throw XCTSkip("Requires iOS 16.2") }
+        // The in-place finishing state must read identically to the explicit
+        // end-of-workout completion message so skip-to-finish and tap-Finish
+        // look the same.
+        let finishing = LiveActivityService.finishingState
+        XCTAssertEqual(finishing.exerciseName, "Workout Complete")
+        XCTAssertEqual(finishing.weightReps, "Great job!")
+        XCTAssertEqual(finishing.progress, 1.0)
+    }
+
     // MARK: - Cleanup (Graceful in Test Environment)
 
     func testCleanupOrphanedActivitiesDoesNotCrash() {

--- a/spec/services/live-activities.md
+++ b/spec/services/live-activities.md
@@ -84,6 +84,21 @@ Shows complete details for the current set so users can perform it without openi
 - **Dynamic Island compact**: Dumbbell icon (leading), percentage complete (trailing)
 - **Dynamic Island minimal**: Dumbbell icon
 
+#### 2a. Cursor Advance on Skip / Completion
+
+The "current exercise" passed to `updateWorkoutLiveActivity()` is derived as the first exercise in the session containing a set whose status is still `pending`. Skipping a set (marking it `skipped`) does not count as pending, so skipping the last pending set(s) of an exercise advances the cursor to the next exercise that still has pending sets.
+
+- When the user skips the last pending set of an exercise, the running Live Activity **must** advance to display the next exercise with pending sets (its first pending set's weight × reps). It must not remain stuck on the just-skipped exercise.
+- This advance must be applied even if a previous update fired within the throttle window: when the resolved current exercise differs from a "no pending sets remain" terminal state, the update is significant and must not be silently dropped (see Update Throttling).
+
+#### 2b. No Pending Sets Remaining (Finishing State)
+
+When **no** exercise in the session has any pending set (every set is `completed` or `skipped`) and there is no active rest timer, the current exercise resolves to `nil`. In this case the workout is effectively done but the user has not yet tapped Finish, so the Live Activity **must not** be left displaying the stale prior exercise. Instead it transitions to a **finishing state**:
+
+- Title "Workout Complete", subtitle "Great job!", progress `1.0` — visually identical to the completion message shown by `endWorkoutLiveActivity()` so that skip-to-finish and explicit-finish look consistent.
+- The activity is **kept alive** (not dismissed). `updateWorkoutLiveActivity()` only updates content; the activity is dismissed only when the workout is formally ended/cancelled/paused via `endWorkoutLiveActivity()`.
+- This transition is **not** subject to the update throttle — it must always be applied so the cursor never gets stuck on a skipped exercise.
+
 #### 2. Rest Timer State
 
 Shows a countdown timer and previews the next set so users know what's coming:
@@ -107,6 +122,14 @@ The rest timer uses `timerEndDate` with SwiftUI's `Text(date, style: .timer)`. C
 - `timerEndDate <= now` → red (expired, counting up)
 
 Note: The system `.timer` style automatically counts down to the target date, then counts up past it.
+
+### Update Throttling
+
+`updateWorkoutLiveActivity()` throttles ordinary content refreshes to at most one per second to avoid excessive Live Activity churn during rapid set logging. However, two transitions are considered significant and must bypass the throttle so they are never dropped:
+
+- A transition **into** the finishing state (no pending sets remain) — see "No Pending Sets Remaining".
+
+All other updates (active set → active set, rest timer ticks) remain throttled.
 
 ### Progress Bar
 
@@ -182,6 +205,11 @@ All operations silently catch and discard errors. Live Activities are an optiona
 - Rest timer state must include: "Rest" as exercise name, timer end date, next exercise name with its set details, and progress.
 - When there is no next exercise (last exercise in workout), `nextExerciseName` and `nextSetDetail` must be nil.
 - Widget UI must show green timer color when time remains and red when timer has expired.
+
+### Cursor Advance on Skip
+- Skipping the last pending set of an exercise resolves the current exercise to the next exercise with pending sets; the resolved active-set state must name that next exercise, not the skipped one.
+- When all sets are completed/skipped (no pending sets remain), the resolved state must be the finishing state ("Workout Complete" / "Great job!" / progress 1.0), not the stale prior exercise and not a no-op that leaves the activity unchanged.
+- The finishing-state transition bypasses the update throttle.
 
 ### Race Condition Prevention
 - The end-then-start sequence in `startWorkoutLiveActivity()` must be serialized — the new activity must not be requested until the previous one is confirmed ended.


### PR DESCRIPTION
Fixes #144

## Root cause
`LiveActivityService.updateWorkoutActivity()` early-`return`ed when the current exercise was `nil`. `ActiveWorkoutViewModel.updateLiveActivity()` derives the current exercise as the first one with a `pending` set. When a user skips the last pending set(s) of a workout, no exercise has pending sets, so the current exercise resolves to `nil`, hit the `else { return }`, and the running Live Activity was left stuck showing the just-skipped exercise as current.

## Fix
When no exercise has pending sets remaining (and there's no active rest timer), the Live Activity now transitions to an in-place **finishing state** — visually identical to the end-of-workout completion message ("Workout Complete" / "Great job!" / progress 1.0) — instead of returning early. The activity is kept alive; it's only dismissed when the workout is formally ended via `endWorkoutActivity()`. This keeps skip-to-finish and tap-Finish consistent (no divergent code path).

The finishing transition also **bypasses the 1s update throttle**, so a rapid skip-to-finish can't be dropped and leave the cursor stale. Ordinary active→active and rest-tick updates remain throttled.

State resolution is extracted into a pure `resolveContentState()` so the advance/finishing logic is unit-testable without a live ActivityKit instance. Completion title/subtitle are now shared constants reused by `endWorkoutActivity`.

## Spec
Updated `spec/services/live-activities.md`: added "Cursor Advance on Skip", "No Pending Sets Remaining (Finishing State)", an "Update Throttling" section, and matching test entries.

## Tested
- New tests: advance to next exercise when current skipped; advance past a skipped last set within an exercise; finishing state when the final exercise is skipped; finishing state matches the end-of-workout message.
- `make build` succeeds.
- Full unit suite: **878 tests, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)