### PR TITLE
feat(auth): associate app with liftmark.app for password autofill

### DIFF
--- a/mobile-apps/ios/LiftMark/LiftMark.entitlements
+++ b/mobile-apps/ios/LiftMark/LiftMark.entitlements
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>webcredentials:liftmark.app</string>
+	</array>
 	<key>com.apple.developer.healthkit</key>
 	<true/>
 	<key>com.apple.developer.healthkit.access</key>

--- a/mobile-apps/ios/project.yml
+++ b/mobile-apps/ios/project.yml
@@ -118,6 +118,8 @@ targets:
     entitlements:
       path: LiftMark/LiftMark.entitlements
       properties:
+        com.apple.developer.associated-domains:
+          - webcredentials:liftmark.app
         com.apple.developer.healthkit: true
         com.apple.developer.healthkit.access:
           - health-records

--- a/spec/services/password-manager.md
+++ b/spec/services/password-manager.md
@@ -1,0 +1,163 @@
+# Password-Manager Association Service Specification
+
+## Purpose
+
+Enable iCloud Keychain and third-party password managers (1Password, Bitwarden,
+etc.) to offer the user's saved `liftmark.app` credentials when the native iOS
+app shows its account sign-in form. This is Apple's
+[Shared Web Credentials / Associated Domains `webcredentials`](https://developer.apple.com/documentation/xcode/supporting-associated-domains)
+mechanism.
+
+The association is bidirectional and only works when **both** halves agree:
+
+1. The **app** declares the domain it trusts via the
+   `com.apple.developer.associated-domains` entitlement (`webcredentials:liftmark.app`).
+2. The **domain** declares the app(s) it trusts via an
+   `apple-app-site-association` (AASA) file served at
+   `https://liftmark.app/.well-known/apple-app-site-association`.
+
+Apple's CDN fetches the AASA and matches the app's Team ID + bundle ID against
+the `webcredentials.apps` list. Only on a match does autofill light up.
+
+## Identity facts
+
+| Field | Value |
+| --- | --- |
+| Apple Team ID | `43DNX2P3T6` |
+| Prod app bundle ID | `com.eff3.liftmark.native-ios` |
+| Dev/debug app bundle ID | `com.eff3.liftmark.native-ios.dev` |
+| Associated domain | `liftmark.app` (apex) |
+
+The `.dev` bundle ID is included so debug/TestFlight-from-Xcode builds can be
+tested against the same AASA. Both fully-qualified app identifiers are
+`<TeamID>.<bundleID>`.
+
+Scope is **webcredentials only**. No `applinks` / universal-links entry is
+declared — the app has a custom `liftmark://` URL scheme but no universal-link
+handling, so adding `applinks` would be unused surface area.
+
+## Piece 1 — App entitlement
+
+The app target declares the associated domain in two mirrored locations
+(XcodeGen `project.yml` regenerates the `.entitlements` plist, so both must
+stay in sync):
+
+- `mobile-apps/ios/LiftMark/LiftMark.entitlements`
+- `mobile-apps/ios/project.yml` → `targets.LiftMark.entitlements.properties`
+
+Required key/value (added alongside the existing HealthKit / CloudKit / iCloud
+entitlements, none of which are disturbed):
+
+```
+com.apple.developer.associated-domains = [ "webcredentials:liftmark.app" ]
+```
+
+### Login form requirements
+
+The account sign-in form (`mobile-apps/ios/LiftMark/Views/Auth/LoginView.swift`)
+must mark its fields so managers recognise them:
+
+- Email field → `.textContentType(.username)`
+- Password field → `.textContentType(.password)`
+
+There is **no native account-creation / new-password field** — signup and
+password reset are deferred to the web (`beta.liftmark.app`). If a native
+signup field is ever added, its password field must use
+`.textContentType(.newPassword)` so managers offer to generate and save a
+credential. (The Anthropic API-key `SecureField` in Settings is **not** an
+account credential and must keep `.password` without a paired `.username`.)
+
+## Piece 2 — apple-app-site-association (AASA) file
+
+### Location
+
+Served at the apex by the validator CDK stack, which uploads the Astro build
+output (`website/dist`) to the prod S3 bucket via a `BucketDeployment`. Astro
+copies `website/public/**` verbatim into `website/dist/**`, so the source file
+lives at:
+
+```
+website/public/.well-known/apple-app-site-association
+```
+
+and is published at:
+
+```
+https://liftmark.app/.well-known/apple-app-site-association
+```
+
+The file has **no extension** (Apple requires the exact filename).
+
+### Content (strict JSON, no comments)
+
+```json
+{
+  "webcredentials": {
+    "apps": [
+      "43DNX2P3T6.com.eff3.liftmark.native-ios",
+      "43DNX2P3T6.com.eff3.liftmark.native-ios.dev"
+    ]
+  }
+}
+```
+
+### Serving requirements
+
+The AASA must be reachable with:
+
+- **HTTP 200**, no redirect.
+- **`Content-Type: application/json`.**
+
+Two stack behaviours would otherwise break this and are explicitly handled in
+`validator/cdk/stack.ts`:
+
+1. **CloudFront URL-rewrite function.** The viewer-request function rewrites any
+   path whose last segment contains no `.` to `…/index.html` (pretty URLs for
+   the Astro site). `apple-app-site-association` has no dot, so it would be
+   rewritten to `/.well-known/apple-app-site-association/index.html` → 404. The
+   function MUST short-circuit (pass the request through untouched) for any URI
+   beginning with `/.well-known/`.
+
+2. **Content-Type.** S3/`BucketDeployment` infers content type from the file
+   extension; an extensionless object defaults to `application/octet-stream`.
+   A dedicated `BucketDeployment` scoped to `.well-known/*` uploads that subtree
+   with an explicit `contentType: 'application/json'`. The main site
+   `BucketDeployment` excludes `.well-known/*` so the two deployments don't
+   fight over the same keys (each prunes only its own keyspace).
+
+The default CloudFront behaviour serves S3, so `/.well-known/*` is **not**
+routed to the `/validate`, `/v1/*`, or `/version` API origins.
+
+## Deploy / order-of-operations
+
+`website/dist` is **gitignored** and rebuilt fresh (`npm run build`) by the
+`website-build` Make target before every `cdk deploy` (`validator/Makefile`).
+Committing the file under `website/public/` is therefore sufficient — it will
+be present in `website/dist` at deploy time.
+
+**Order matters.** The AASA must be LIVE on `liftmark.app` *before* (or at the
+same time as) an app build carrying the `webcredentials` entitlement reaches
+users. If the entitlement ships first, Apple's CDN caches a missing/old AASA and
+autofill stays silent until the AASA deploys and the CDN re-fetches.
+
+Recommended sequence:
+
+1. Deploy the validator/website change first (publishes the AASA):
+   `cd validator && make deploy-prod`.
+2. Verify:
+   `curl -sI https://liftmark.app/.well-known/apple-app-site-association`
+   → `200` + `content-type: application/json`, no redirect.
+3. Then ship the app build carrying the entitlement.
+
+## Verification
+
+- `website` build produces `website/dist/.well-known/apple-app-site-association`
+  byte-for-byte identical to the source, and it is valid JSON
+  (`jq . website/dist/.well-known/apple-app-site-association`).
+- The CDK stack synthesises (`cd validator/cdk && npx cdk synth`) with the
+  rewrite-function exception and the scoped `.well-known` `BucketDeployment`.
+- `cd mobile-apps/ios && make generate && make build` regenerates the project
+  with the entitlement and compiles cleanly.
+- Post-deploy, on device: invoke the sign-in form; iCloud Keychain / the
+  installed password manager offers saved `liftmark.app` credentials in the
+  QuickType bar.

--- a/validator/cdk/stack.ts
+++ b/validator/cdk/stack.ts
@@ -375,6 +375,12 @@ export class LmwfValidatorStack extends cdk.Stack {
 function handler(event) {
   var request = event.request;
   var uri = request.uri;
+  // Serve well-known assets (e.g. apple-app-site-association) verbatim. They
+  // are extensionless by spec, so the pretty-URL rewrite below would otherwise
+  // turn them into /.well-known/<name>/index.html and 404.
+  if (uri.indexOf('/.well-known/') === 0) {
+    return request;
+  }
   if (uri.endsWith('/')) {
     request.uri = uri + 'index.html';
   } else {
@@ -386,7 +392,7 @@ function handler(event) {
   return request;
 }
       `),
-      comment: 'Rewrite /foo and /foo/ to /foo/index.html',
+      comment: 'Rewrite /foo and /foo/ to /foo/index.html (skips /.well-known/*)',
     });
 
     const s3Origin = origins.S3BucketOrigin.withOriginAccessControl(siteBucket);
@@ -524,14 +530,44 @@ function handler(event) {
     // Keeping the site upload inside CDK means both GHA and Concourse
     // pipelines do the exact same deploy (just `cdk deploy`), which is the
     // whole reason we're not doing this with a separate `aws s3 sync` step.
+    const siteDistPath = path.join(__dirname, '..', '..', 'website', 'dist');
+
     new s3deploy.BucketDeployment(this, 'SiteContents', {
-      sources: [s3deploy.Source.asset(path.join(__dirname, '..', '..', 'website', 'dist'))],
+      // Everything except /.well-known/* — that subtree is uploaded by a
+      // separate deployment below so it can carry an explicit Content-Type.
+      // `exclude` keeps prune scoped to this keyspace, so the two deployments
+      // don't delete each other's objects.
+      sources: [
+        s3deploy.Source.asset(siteDistPath, { exclude: ['.well-known/**'] }),
+      ],
       destinationBucket: siteBucket,
       distribution,
       distributionPaths: ['/*'],
       prune: true,
+      exclude: ['.well-known/*'],
       // Default Lambda is 128 MiB / 900 s. Site is ~250 KiB today; bump
       // memory only if/when assets grow enough to OOM the copy Lambda.
+      memoryLimit: 256,
+    });
+
+    // The apple-app-site-association (AASA) file is extensionless by Apple's
+    // spec, so S3 would default it to application/octet-stream. Upload the
+    // /.well-known/* subtree with an explicit application/json Content-Type so
+    // iCloud Keychain / password-manager webcredentials checks see the right
+    // type. `include`/`exclude` restrict this deployment (and its prune) to
+    // /.well-known/*, mirroring the main deployment's exclude above.
+    new s3deploy.BucketDeployment(this, 'WellKnownContents', {
+      sources: [
+        s3deploy.Source.asset(siteDistPath, {
+          exclude: ['**', '!.well-known', '!.well-known/**'],
+        }),
+      ],
+      destinationBucket: siteBucket,
+      distribution,
+      distributionPaths: ['/.well-known/*'],
+      prune: true,
+      include: ['.well-known/*'],
+      contentType: 'application/json',
       memoryLimit: 256,
     });
 

--- a/website/public/.well-known/apple-app-site-association
+++ b/website/public/.well-known/apple-app-site-association
@@ -1,0 +1,8 @@
+{
+  "webcredentials": {
+    "apps": [
+      "43DNX2P3T6.com.eff3.liftmark.native-ios",
+      "43DNX2P3T6.com.eff3.liftmark.native-ios.dev"
+    ]
+  }
+}


### PR DESCRIPTION
## What this enables

iCloud Keychain and third-party password managers (1Password, Bitwarden, etc.) will offer the user's saved **liftmark.app** credentials in the native app's sign-in form, via Apple's Shared Web Credentials (`webcredentials`) association. The association only works when both halves agree — the app's entitlement and the domain's AASA file — so both ship in this one PR.

Spec-first: see `spec/services/password-manager.md` for the full contract.

## The two pieces

### 1. iOS entitlement
Adds `com.apple.developer.associated-domains` = `webcredentials:liftmark.app` to:
- `mobile-apps/ios/LiftMark/LiftMark.entitlements`
- `mobile-apps/ios/project.yml` (the block XcodeGen regenerates the plist from)

Existing HealthKit / CloudKit / iCloud entitlements are untouched. The login form (`LoginView.swift`) already marks its fields `.textContentType(.username)` / `.password`. Signup/password-reset are web-deferred (`beta.liftmark.app`), so there is no native new-password field to mark `.newPassword`. Scope is **webcredentials only** — no `applinks` added.

### 2. AASA file served at liftmark.app
`website/public/.well-known/apple-app-site-association` (Astro copies `public/` verbatim into `dist/`, which the validator CDK stack uploads to the prod `liftmark.app` S3 bucket):

```json
{
  "webcredentials": {
    "apps": [
      "43DNX2P3T6.com.eff3.liftmark.native-ios",
      "43DNX2P3T6.com.eff3.liftmark.native-ios.dev"
    ]
  }
}
```
(`.dev` included so debug/TestFlight-from-Xcode builds can be tested. Team ID `43DNX2P3T6`.)

**CDK serving fixes** in `validator/cdk/stack.ts`:
- The CloudFront viewer-request rewrite function turned any extensionless path into `…/index.html`. It now passes `/.well-known/*` through untouched, so the extensionless AASA isn't rewritten to a 404.
- A dedicated `BucketDeployment` uploads `/.well-known/*` with explicit `Content-Type: application/json` (an extensionless S3 object would otherwise default to `application/octet-stream`). The main site deployment excludes `/.well-known/*`, so the two deployments prune only their own keyspace and don't fight.

## Verified locally
- `cd website && npm run build` → `dist/.well-known/apple-app-site-association` is present, byte-identical to source, and valid JSON (`jq`).
- `cd validator/cdk && npx cdk synth LmwfProdValidatorStack` → template shows the `/.well-known/` short-circuit in the function source, `SystemMetadata.content-type: application/json` + `Include: .well-known/*` on the scoped deployment, and `Exclude: .well-known/*` on the main one. Staged asset for the scoped deployment contains exactly `.well-known/apple-app-site-association`; the main asset contains zero `well-known` entries. (Did NOT deploy.)
- `cd mobile-apps/ios && make generate && make build` → BUILD SUCCEEDED with the entitlement; XcodeGen regenerated the `.entitlements` plist from `project.yml` (both in sync). Reverted the incidental `BuildInfo.swift` git-hash regen.

## Deploy steps the user must run (NOT done here)
`website/dist` is gitignored and rebuilt fresh by the `website-build` Make target before every `cdk deploy`, so committing the file under `website/public/` is sufficient.

**Order of operations matters.** The AASA must be LIVE on `liftmark.app` **before** (or at the same time as) an app build carrying the entitlement reaches users — otherwise Apple's CDN caches a missing AASA and autofill stays silent until it re-fetches.

1. Deploy the validator/website change first (publishes the AASA):
   `cd validator && make deploy-prod`
2. Verify:
   `curl -sI https://liftmark.app/.well-known/apple-app-site-association`
   → expect `HTTP 200`, `content-type: application/json`, no redirect.
3. Then ship the app build carrying the entitlement; test autofill on device (sign-in form should surface saved liftmark.app credentials in the QuickType bar).

## Risks / uncertainties
- Could not curl the live endpoint (no deploy in this task) — serving correctness is proven via the synthesized CloudFormation, not a live request.
- Adding `com.apple.developer.associated-domains` may require the App ID's "Associated Domains" capability to be enabled in the Apple Developer portal / provisioning profile for the Release (Manual signing) configuration; if signing fails on the next archive, enable the capability and regenerate the `LiftMark Native App Store` profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)