### PR TITLE
fix(validator): serve AASA without a second BucketDeployment (unblock deploy)

### DIFF
--- a/spec/services/password-manager.md
+++ b/spec/services/password-manager.md
@@ -72,7 +72,8 @@ account credential and must keep `.password` without a paired `.username`.)
 ### Location
 
 Served at the apex by the validator CDK stack, which uploads the Astro build
-output (`website/dist`) to the prod S3 bucket via a `BucketDeployment`. Astro
+output (`website/dist`) to the prod S3 bucket via a **single**
+`BucketDeployment` (the whole site, including the `.well-known/` subtree). Astro
 copies `website/public/**` verbatim into `website/dist/**`, so the source file
 lives at:
 
@@ -120,10 +121,25 @@ Two stack behaviours would otherwise break this and are explicitly handled in
 
 2. **Content-Type.** S3/`BucketDeployment` infers content type from the file
    extension; an extensionless object defaults to `application/octet-stream`.
-   A dedicated `BucketDeployment` scoped to `.well-known/*` uploads that subtree
-   with an explicit `contentType: 'application/json'`. The main site
-   `BucketDeployment` excludes `.well-known/*` so the two deployments don't
-   fight over the same keys (each prunes only its own keyspace).
+   A small CloudFront **viewer-response** Function (`AasaContentTypeFn`),
+   associated with the default behaviour, overrides the response
+   `content-type` to `application/json` for the exact URI
+   `/.well-known/apple-app-site-association`. This is CloudFront-native — it
+   needs no Lambda layer and no extra IAM.
+
+   A **second `BucketDeployment`** is deliberately **NOT** used for this. Each
+   `BucketDeployment` provisions its own AWS-CLI Lambda layer, and publishing
+   that layer requires `lambda:PublishLayerVersion`, which the scoped
+   `cdk-lmwf-cfn-exec-role` is not permitted to call. A second deployment for
+   `.well-known/*` (the original PR #183 approach) therefore fails the deploy
+   with a 403 on `lambda:PublishLayerVersion`. The single site
+   `BucketDeployment` uploads the whole site (no `.well-known` exclude), and
+   the viewer-response function handles the Content-Type.
+
+   Note: Apple's `webcredentials` fetch does not strictly require
+   `application/json` (octet-stream also works for password autofill), so the
+   viewer-response override is a correctness nicety rather than a hard
+   requirement — but it is cheap and CloudFront-native, so it is kept.
 
 The default CloudFront behaviour serves S3, so `/.well-known/*` is **not**
 routed to the `/validate`, `/v1/*`, or `/version` API origins.
@@ -155,7 +171,9 @@ Recommended sequence:
   byte-for-byte identical to the source, and it is valid JSON
   (`jq . website/dist/.well-known/apple-app-site-association`).
 - The CDK stack synthesises (`cd validator/cdk && npx cdk synth`) with the
-  rewrite-function exception and the scoped `.well-known` `BucketDeployment`.
+  viewer-request rewrite-function `.well-known` short-circuit and the
+  viewer-response `AasaContentTypeFn`, served from the single site
+  `BucketDeployment` (no second `.well-known` deployment / AwsCliLayer).
 - `cd mobile-apps/ios && make generate && make build` regenerates the project
   with the entitlement and compiles cleanly.
 - Post-deploy, on device: invoke the sign-in form; iCloud Keychain / the

--- a/validator/cdk/stack.ts
+++ b/validator/cdk/stack.ts
@@ -395,6 +395,30 @@ function handler(event) {
       comment: 'Rewrite /foo and /foo/ to /foo/index.html (skips /.well-known/*)',
     });
 
+    // The apple-app-site-association (AASA) file is extensionless by Apple's
+    // spec, so S3/BucketDeployment stores it as application/octet-stream. A
+    // CloudFront viewer-RESPONSE function overrides the Content-Type to
+    // application/json for that one path on the way back to the client. This
+    // is CloudFront-native — no Lambda layer, no extra IAM — which is why it
+    // replaces the second BucketDeployment that PR #183 used (and that broke
+    // the deploy via lambda:PublishLayerVersion). A separate function is
+    // required because a single CloudFront Function cannot be associated with
+    // both the viewer-request and viewer-response events.
+    const aasaContentTypeFunction = new cloudfront.Function(this, 'AasaContentTypeFn', {
+      code: cloudfront.FunctionCode.fromInline(`
+function handler(event) {
+  var request = event.request;
+  var response = event.response;
+  // Only the AASA path; everything else keeps its origin Content-Type.
+  if (request.uri === '/.well-known/apple-app-site-association') {
+    response.headers['content-type'] = { value: 'application/json' };
+  }
+  return response;
+}
+      `),
+      comment: 'Set content-type: application/json for the AASA file',
+    });
+
     const s3Origin = origins.S3BucketOrigin.withOriginAccessControl(siteBucket);
     const apiOrigin = new origins.HttpOrigin(apiHostname, {
       protocolPolicy: cloudfront.OriginProtocolPolicy.HTTPS_ONLY,
@@ -484,10 +508,17 @@ function handler(event) {
             : cloudfront.CachePolicy.CACHING_OPTIMIZED,
         allowedMethods: cloudfront.AllowedMethods.ALLOW_GET_HEAD_OPTIONS,
         compress: true,
-        functionAssociations: [{
-          eventType: cloudfront.FunctionEventType.VIEWER_REQUEST,
-          function: urlRewriteFunction,
-        }],
+        functionAssociations: [
+          {
+            eventType: cloudfront.FunctionEventType.VIEWER_REQUEST,
+            function: urlRewriteFunction,
+          },
+          {
+            // Sets content-type: application/json on the AASA response.
+            eventType: cloudfront.FunctionEventType.VIEWER_RESPONSE,
+            function: aasaContentTypeFunction,
+          },
+        ],
       },
       additionalBehaviors: {
         '/validate': {
@@ -532,42 +563,25 @@ function handler(event) {
     // whole reason we're not doing this with a separate `aws s3 sync` step.
     const siteDistPath = path.join(__dirname, '..', '..', 'website', 'dist');
 
+    // Single deployment for the entire site, INCLUDING
+    // /.well-known/apple-app-site-association. A second BucketDeployment is
+    // deliberately avoided: each BucketDeployment provisions its own AWS-CLI
+    // Lambda layer, and publishing that layer requires
+    // lambda:PublishLayerVersion — which the scoped cdk-lmwf-cfn-exec-role is
+    // NOT permitted to call. Adding a second deployment for /.well-known/* is
+    // exactly what regressed the beta deploy (PR #183: WellKnownContents/
+    // AwsCliLayer → CREATE_FAILED, 403 PublishLayerVersion). The AASA file's
+    // Content-Type is set instead by the viewer-response CloudFront Function
+    // below (aasaContentTypeFunction) — CloudFront-native, no Lambda layer,
+    // no extra IAM.
     new s3deploy.BucketDeployment(this, 'SiteContents', {
-      // Everything except /.well-known/* — that subtree is uploaded by a
-      // separate deployment below so it can carry an explicit Content-Type.
-      // `exclude` keeps prune scoped to this keyspace, so the two deployments
-      // don't delete each other's objects.
-      sources: [
-        s3deploy.Source.asset(siteDistPath, { exclude: ['.well-known/**'] }),
-      ],
+      sources: [s3deploy.Source.asset(siteDistPath)],
       destinationBucket: siteBucket,
       distribution,
       distributionPaths: ['/*'],
       prune: true,
-      exclude: ['.well-known/*'],
       // Default Lambda is 128 MiB / 900 s. Site is ~250 KiB today; bump
       // memory only if/when assets grow enough to OOM the copy Lambda.
-      memoryLimit: 256,
-    });
-
-    // The apple-app-site-association (AASA) file is extensionless by Apple's
-    // spec, so S3 would default it to application/octet-stream. Upload the
-    // /.well-known/* subtree with an explicit application/json Content-Type so
-    // iCloud Keychain / password-manager webcredentials checks see the right
-    // type. `include`/`exclude` restrict this deployment (and its prune) to
-    // /.well-known/*, mirroring the main deployment's exclude above.
-    new s3deploy.BucketDeployment(this, 'WellKnownContents', {
-      sources: [
-        s3deploy.Source.asset(siteDistPath, {
-          exclude: ['**', '!.well-known', '!.well-known/**'],
-        }),
-      ],
-      destinationBucket: siteBucket,
-      distribution,
-      distributionPaths: ['/.well-known/*'],
-      prune: true,
-      include: ['.well-known/*'],
-      contentType: 'application/json',
       memoryLimit: 256,
     });
 


### PR DESCRIPTION
## Problem

The validator `deploy-beta` job failed on `main` after #183 merged, rolling back `LmwfBetaValidatorStack`. Prod was never reached, so the AASA (`/.well-known/apple-app-site-association`) is **not live**.

**Root cause:** #183 added a *second* `s3deploy.BucketDeployment` (`WellKnownContents`) purely to set `content-type: application/json`. Each `BucketDeployment` provisions its own AWS-CLI **Lambda layer**, and publishing it calls `lambda:PublishLayerVersion` — which the deliberately-scoped `cdk-lmwf-cfn-exec-role` is not permitted to do:

```
AWS::Lambda::LayerVersion  WellKnownContents/AwsCliLayer  CREATE_FAILED
... not authorized to perform: lambda:PublishLayerVersion ... (403)
```

We do **not** widen the deploy policy (it was intentionally shrunk under IAM's 6144-char limit).

## Fix

- **Remove** the `WellKnownContents` BucketDeployment and the `.well-known/*` exclude on `SiteContents`. A single deployment again uploads the whole `website/dist`, including the AASA file.
- **Set `Content-Type: application/json`** for the AASA path via a new **viewer-response CloudFront Function** (`AasaContentTypeFn`) — CloudFront-native, no Lambda layer, no new IAM. (Separate function because one CloudFront Function can't bind both viewer-request and viewer-response.)
- **Keep** the viewer-request `/.well-known/` short-circuit so the extensionless path isn't rewritten to `index.html`.

Net: no new Lambda layer → no `PublishLayerVersion` → deploy unblocked, AASA served at 200 + `application/json`, no redirect.

Spec `spec/services/password-manager.md` updated to match.

## Verify post-deploy
`curl -sI https://liftmark.app/.well-known/apple-app-site-association` → expect `200` + `content-type: application/json`, no redirect.

Fixes the deploy regression introduced by #183.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>