### PR TITLE
fix(ci): bundle hidden files so AASA actually deploys

### DIFF
--- a/.github/workflows/validator-ci.yml
+++ b/.github/workflows/validator-ci.yml
@@ -125,6 +125,12 @@ jobs:
         with:
           name: website-bundle
           path: website/dist
+          # The site ships /.well-known/apple-app-site-association (AASA) for
+          # iOS webcredentials. `.well-known` is a hidden directory, and
+          # upload-artifact excludes hidden files by default (v4+), which
+          # silently dropped the AASA from the bundle so it never reached S3
+          # and CloudFront served 403. Keep hidden files so deploy uploads it.
+          include-hidden-files: true
           if-no-files-found: error
           retention-days: 7
 


### PR DESCRIPTION
## Problem

After #183 + #186, the password-manager association deploy was **green on beta and prod**, yet `https://liftmark.app/.well-known/apple-app-site-association` returned **403 AccessDenied** (CloudFront → S3) on both environments. The file builds correctly into `website/dist/.well-known/` locally.

## Root cause

`actions/upload-artifact@v7` (v4+) **excludes hidden files by default**. `.well-known` is a hidden directory, so the AASA was silently dropped from the `website-bundle` artifact. Deploy jobs download that artifact → `website/dist` has no `.well-known` → `BucketDeployment` uploads everything except the AASA → the S3 object is missing → CloudFront returns 403. Build and deploy both report success because nothing errors; the file just isn't there.

## Fix

Add `include-hidden-files: true` to the website bundle upload step. (Validator bundle is unaffected — no hidden files.)

## Verify post-deploy

`curl -sI https://liftmark.app/.well-known/apple-app-site-association` → expect `200` + `content-type: application/json`, no redirect.