### PR TITLE
test(e2e): deploy-boundary (topology) coverage for the validator prod gate (#137)

### DIFF
--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -1,16 +1,19 @@
-# GitGuardian configuration.
+# GitGuardian / ggshield configuration.
 #
 # Allowlist the single well-known passphrase used as a TEST FIXTURE throughout
 # the validator e2e suite (the XKCD passphrase that is the default password for
 # the /v1/__test__/seed-user backdoor and is typed into the signup/reset forms
 # by the Playwright specs). It is not a real credential, is identical wherever
 # it appears, and grants access to nothing outside the ephemeral local/beta
-# test stacks. Matched by SHA-256 so the plaintext never appears here and the
-# allowlist is scoped to exactly this one value — real secrets accidentally
-# committed under validator/e2e/** are still detected.
+# test stacks. Matched by ggshield's reported Secret SHA so the plaintext never
+# appears here and the allowlist is scoped to exactly this one value — real
+# secrets accidentally committed under validator/e2e/** are still detected.
+#
+# Honored by the self-run `ggshield` CI check (.github/workflows/ggshield.yml).
+# The managed "GitGuardian Security Checks" GitHub App does NOT read this file.
 version: 2
 
 secret:
-  ignored-matches:
+  ignored_matches:
     - name: "e2e test fixture password (XKCD passphrase) — not a real credential"
-      match: c4bbcb1fbec99d65bf59d85c8cb62ee2db963f0fe106f483d9afa73bd4e39a8a
+      match: b928881af8666174d09a3c22cf5fb5b43e39a3192e24015d0026ec5ccf9d898c

--- a/spec/services/validator-e2e.md
+++ b/spec/services/validator-e2e.md
@@ -98,6 +98,153 @@ E2E asserts that those modules, the static website, and the deploy
 topology compose into a working product from the browser's point of
 view.
 
+## Prod-gate coverage model
+
+### What actually gates prod
+
+The validator deploy pipeline (`.github/workflows/validator-ci.yml`) is a
+linear chain, each stage a required predecessor of the next:
+
+```
+validate (Vitest: typecheck + npm test)
+  → build
+  → e2e-local   (Playwright vs local DDB+Mailpit stack)   ← gates prod
+  → deploy-beta
+  → smoke-beta
+  → e2e-beta    (Playwright vs https://beta.liftmark.app)  ← gates prod
+  → deploy-prod
+```
+
+`deploy-prod` needs `smoke-beta` AND `e2e-beta`; `deploy-beta` needs
+`e2e-local`; `e2e-local`/`e2e-beta` both need `build`, which needs
+`validate`. **Therefore Vitest, e2e-local, AND e2e-beta all hard-gate
+prod.** A contract pinned by any one of them cannot regress into a prod
+deploy. This is the load-bearing fact behind the division of labour below.
+
+### Division of labour: Vitest owns logic, e2e owns topology
+
+The Vitest route tests + `flow.test.ts` run the *exact same handler code*
+that runs on Lambda — same conditional-expression semantics, in-process.
+They are the authoritative owners of every **pure-handler contract** (auth
+decisions, IDOR/tenancy isolation, scope enforcement, token rotation/reuse,
+anti-enumeration, single-use reset, dedup, tier gates). e2e does **not**
+re-assert these: duplicating a conditional that already runs identically
+in-process buys zero topology signal and adds cost + flake.
+
+e2e exists to catch the **topology delta** — the bytes/wiring that only
+differ once the handler sits behind API Gateway + CloudFront + Lambda +
+real SES: response *headers* (Set-Cookie attributes), *link hosts* built
+from the deployed env, the *authorizer/scope middleware actually being
+wired* in front of the route, and *real SES credentials resolving*. None of
+those are visible to an in-process `app.request()`.
+
+### Vitest-owned contracts (NOT duplicated in e2e)
+
+| Contract | Owning Vitest test (file:line) |
+|----------|-------------------------------|
+| Cross-user IDOR — delete | `tests/routes/workouts.test.ts:722` ("user A cannot delete user B's inbox item (404)"); outbox: `tests/routes/workout_outbox.test.ts:299` |
+| Cross-user IDOR — read/ack/list | `tests/routes/workouts.test.ts:673`, `:693`, `:748`; forged cursor `:654` |
+| PAT scope 403 (write/ack/delete need `workouts:write`) | `tests/routes/workouts.test.ts:498`, `:517`, `:553`; outbox `:269`, `:322` |
+| Missing/garbage bearer → 401 | `tests/routes/workouts.test.ts:486`, `:953` |
+| Refresh rotation + reuse-revoke | `tests/routes/auth/refresh.test.ts:132`; concurrent rotation `:283`; absolute-expiry `:168` |
+| Anti-enumeration uniform 401 (bad pw / unknown email / unverified) | `tests/routes/auth/password.test.ts:231`, `:570` |
+| Reset single-use (stale-iat replay rejected) | `tests/routes/auth/password.test.ts:646` |
+| Reset revokes every refresh token (H1) + `tokens_valid_after` cutoff | `tests/routes/auth/password.test.ts:597`; logout-all rotated-token reject `tests/routes/auth/refresh.test.ts:370` |
+| Signup rolls back user+identity on email-send failure → 503, retry works | `tests/routes/auth/password.test.ts:247` |
+| Outbox dedup on `client_session_id` | `tests/routes/workout_outbox.test.ts:132` |
+| Tier gates (free 402 / trial 2-token 429 / pro unlimited) | `tests/routes/tokens.test.ts:170`, `:183`, `:199` |
+| httpOnly refresh cookie SET by handler | `tests/routes/auth/password.test.ts:692`; refresh rotation cookie `tests/routes/auth/refresh.test.ts:419` |
+| Protocol composes end-to-end (each step consumes prior step's token/id) | `tests/flow.test.ts` (Layer 1, see below) |
+
+### e2e topology-delta tests (the four that earn an e2e slot)
+
+| # | Topology delta it guards | Why Vitest can't see it | Where it lives | Mode |
+|---|--------------------------|-------------------------|----------------|------|
+| a | `lmwf_refresh` Set-Cookie carries `HttpOnly`, `Secure`, `SameSite=Strict`, `Path=/v1/auth` **over the wire** | In-process pins the `setCookie()` *call*; APIGW (multiValueHeaders) / CloudFront can strip/fold/rewrite the actual header bytes | `e2e/tests/auth-session.spec.ts` | both (esp. e2e-beta) |
+| b | Verify/reset **email link host** == env `appBaseUrl` (beta→`beta.liftmark.app`) | The host comes from the Lambda's `LMWF_ENV`; a misconfigured env builds wrong-host links. Only readable where the email body is — Mailpit = local mode | `auth-signup-verify.spec.ts` (verify) + `auth-forgot-reset.spec.ts` (reset) | **local only** (guarded on `getMode()`) |
+| c | A minted PAT authenticates a live `GET /v1/workouts`, then 401s after revoke | Proves the deployed APIGW authorizer + scope middleware are actually wired in front of the route and honour revocation over the wire — not just the in-process middleware logic | `e2e/tests/pat-live-auth.spec.ts` | both (esp. e2e-beta) |
+| d | Real-SES signup → 201 (SES credentials resolve on the deployed stack) | The signup handler's email send is the last step before 201 and rolls back to 503 if it throws (`password.ts:282-325`); a 201 for the SES-verified address therefore proves SES creds resolve — invisible in-process where SMTP is Mailpit | `auth-signup-verify.spec.ts` (the existing signup POST, now explicitly asserted) | real send only in remote/beta |
+
+### #137 incident-class → owning assertion
+
+Issue #137 named three concrete failure classes. Each now has an owning
+test that gates prod:
+
+| #137 failure class | Owning assertion |
+|--------------------|------------------|
+| **SES placeholder credentials** (signup silently fails / 500s because the Lambda carried placeholder SES creds) | e2e test **(d)**: real `POST /v1/auth/password/signup` → 201 in remote/beta mode (`auth-signup-verify.spec.ts`). A 201 is only reachable if the real SES send succeeded (handler returns 503 on send failure, `password.ts:282-325`). Logic of the rollback itself is Vitest-pinned at `password.test.ts:247`. **Caveat below: this proves BETA SES, not PROD SES.** |
+| **Reset-link misrouting** (reset email pointed at the wrong host) | e2e test **(b)**: link-host assertion in `auth-forgot-reset.spec.ts` (and the verify variant in `auth-signup-verify.spec.ts`), asserting `new URL(link).host === expectedEmailLinkHost()` and the reset link's path is `/account/reset`. Local-mode (Mailpit) — gates prod via e2e-local. |
+| **Orphan signup rows** (user/identity rows left behind when the verification email failed to send) | Vitest `tests/routes/auth/password.test.ts:247` ("signup rolls back user + identity if email send fails (retry works)"): asserts 503 on send failure AND that a retry from the same address signs up cleanly (proves no orphan row blocking the dupe-check). Pure-handler logic — correctly owned by Vitest, not duplicated in e2e. |
+
+#### Beta-vs-prod SES caveat (honest scope of (d))
+
+e2e-beta runs against `beta.liftmark.app`, so test (d) proves **beta** SES
+credentials resolve — NOT prod. The prod stack uses a separate SES identity
+and IAM role; a prod-only SES-credential regression (the original #137
+shape, if it recurred on the prod stack) would NOT be caught by (d). Closing
+the prod variant requires a prod-safe smoke send (no test-secret backdoor on
+prod), tracked under **#137 Layer 2** (`smoke-flow-live.sh`, deferred — see
+the three-layer table above). Test (d) deliberately does not claim to close
+the prod variant.
+
+### Email-verification race — structurally prevented (no test)
+
+There is no signup→verify race to test: the signup handler is strictly
+sequential. `createUser` is awaited, then `createIdentity` is awaited, then
+the verification email (carrying a token whose `sub` is the just-created
+`identity_id`) is sent — all before the 201 returns (`password.ts:257-334`).
+Verify then re-fetches the identity by id (`verifyToken` →
+`getIdentityById`, `password.ts:351`). There is no window in which a verify
+token references an identity that does not yet exist. This is an
+architectural invariant, not a tested behaviour — documented here so a
+future refactor that parallelises the writes knows it is load-bearing.
+
+### Stripe / billing — KNOWN-UNTESTED, mandatory-on-arrival
+
+No billing route exists in the validator today (only a DDB GSI for
+subscription lookup). The following tests are **mandatory the moment a
+`POST /v1/billing/webhook` (or equivalent) route lands** — a billing route
+MUST NOT ship without them, each tied to its incident class:
+
+| Required test (on arrival) | Incident class it guards | Owner |
+|----------------------------|--------------------------|-------|
+| Webhook signature verification: a body with a missing/invalid Stripe-Signature → 400, and a tampered body under a valid signature → 400 | Forged/replayed billing events granting entitlements | Vitest (pure-handler) |
+| Entitlement-for-unknown-user: a webhook referencing a `customer`/`user_id` with no matching user → handled without 500 and without creating a phantom entitlement | Webhook race / orphaned entitlement granting access to a non-existent user | Vitest (pure-handler) |
+| Live webhook POST reaches the deployed route + the signing secret resolves on the deployed stack (201/2xx for a correctly-signed test event) | Topology: the webhook route + Stripe signing-secret env are actually wired on Lambda (the billing analogue of the #137 SES-creds class) | e2e topology-delta |
+
+Add a `flow.test.ts` Layer-1 step for the webhook at the same time (the spec
+already flags this at the bottom of the Layer 1 endpoint table).
+
+### Sharding decision: DO NOT SHARD
+
+The e2e suite runs as a single Playwright job per mode (`fullyParallel`,
+4 workers, chromium only). **Do not shard it across multiple CI jobs.**
+
+Reasoning:
+- The per-job fixed cost (`npm ci` + `playwright install --with-deps
+  chromium` + OIDC role assumption + Lambda warm-up against beta) dominates
+  the wall time of a small suite. Sharding multiplies that fixed cost by the
+  shard count while only dividing the already-small test execution time.
+- Sharding fans out N required checks on the PR (each shard is its own
+  required status), increasing merge-coordination overhead for no bake-time
+  value at the current size.
+- The e2e-beta shards would all contend on one beta Lambda — sharding
+  doesn't even buy real parallelism there; it just adds cold-start contention
+  and flake surface.
+
+**Trigger to revisit (measured, not guessed):** only when the *measured*
+e2e-local wall time exceeds **~300s** OR the suite grows past **~50 tests**.
+At that point, raise workers 4→6 FIRST (free, no fixed-cost multiplication);
+shard 2-way only if that is insufficient. The 300s/50-test figures are
+estimates to be replaced by a real measurement.
+
+> Measured e2e-local wall time (this branch, single local run, chromium,
+> Playwright auto-scaled to 6 workers on the dev machine): **13 tests, 2.0s**
+> Playwright execution (`13 passed (2.0s)`). Even including the full
+> `e2e-local.sh` setup (docker up + DDB bootstrap + astro build + validator
+> boot) the run is a few seconds, far under the 300s trigger. Sharding would
+> be pure overhead.
+
 ## Surface
 
 The suite covers every user-facing page served by the website + every
@@ -107,12 +254,14 @@ backend endpoint the website reaches from the browser.
 |-------------------------------|--------------------------------|---------------------|
 | `/` (LMWF spec landing)       | `home.spec.ts`                 | Title renders, example markdown blocks visible, navigation links resolve. |
 | `/spec`                       | `spec-page.spec.ts`            | Spec content renders, anchor links resolve, no console errors. |
-| `/account/signup`             | `auth-signup-verify.spec.ts`   | Submit → 204 → verify link works → email shown as verified. |
+| `/account/signup`             | `auth-signup-verify.spec.ts`   | Submit → 201 → verify link works → email shown as verified. Topology (b): verify-email link host == env appBaseUrl (local). Topology (d): real-SES signup 201 in remote mode. |
 | `/account/login`              | `auth-login-logout.spec.ts`    | Bad creds error, good creds → `/account`. Sign out clears session. |
+| (login response headers)      | `auth-session.spec.ts`         | Topology (a): `lmwf_refresh` Set-Cookie carries HttpOnly + Secure + SameSite=Strict + Path=/v1/auth over the wire. |
 | `/account/forgot`             | `auth-forgot-reset.spec.ts`    | Submit always 204 (anti-enumeration). |
-| `/account/reset?token=…`      | `auth-forgot-reset.spec.ts`    | Reset → new password works on login, old password fails. |
+| `/account/reset?token=…`      | `auth-forgot-reset.spec.ts`    | Reset → new password works on login, old password fails. Topology (b): reset link host == env appBaseUrl + path `/account/reset` (local). |
 | `/account/email-verified`     | `auth-signup-verify.spec.ts`   | Lands here after verify link click. |
 | `/account` (dashboard)        | `account-pats.spec.ts`         | Create PAT, copy reveals once, list shows it, revoke removes it. |
+| (PAT live API auth)           | `pat-live-auth.spec.ts`        | Topology (c): minted PAT authenticates `GET /v1/workouts`, then 401s after revoke (deployed authorizer + scope middleware wired). |
 | `/account/outbox`             | `account-outbox.spec.ts`       | Seeded workout appears in list. |
 | `/account/outbox/view?id=…`   | `account-outbox.spec.ts`       | Detail page renders LMWF, validates against `/validate`. |
 

--- a/validator/e2e/helpers/api.ts
+++ b/validator/e2e/helpers/api.ts
@@ -91,6 +91,26 @@ export async function createPat(opts: {
   return (await res.json()) as { token_id: string; plaintext: string };
 }
 
+/**
+ * Revoke a PAT via the session-authed `DELETE /v1/tokens/:token_id`
+ * (idempotent 204). Mirrors the per-row revoke the dashboard drives, but
+ * at the API layer so a topology test can assert the deployed authorizer
+ * stops honouring the token immediately after.
+ */
+export async function revokePat(opts: {
+  sessionJwt: string;
+  tokenId: string;
+}): Promise<void> {
+  const res = await fetch(`${getBaseUrl()}/v1/tokens/${opts.tokenId}`, {
+    method: 'DELETE',
+    headers: { authorization: `Bearer ${opts.sessionJwt}` },
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`PAT revoke failed (${res.status}): ${text}`);
+  }
+}
+
 export async function signupAndVerify(opts: {
   email: string;
   password?: string;
@@ -128,16 +148,36 @@ export async function signupAndVerify(opts: {
   return { email: opts.email, password, displayName, userId: user_id };
 }
 
+/**
+ * Drive the real `POST /v1/auth/password/login` and return the parsed
+ * response — both the JSON body fields AND the raw `Set-Cookie` header so
+ * cookie-attribute (topology) tests can inspect it.
+ *
+ * NOTE: this endpoint returns `access_jwt` (NOT `session_jwt`). The earlier
+ * version of this helper destructured `session_jwt`, which is always
+ * `undefined` on this route — that field only exists on the test-only
+ * `/v1/__test__/seed-user` backdoor (see seedUser). We expose the access
+ * JWT to callers as `accessJwt`, with a `sessionJwt` alias so call sites
+ * can read whichever name reads best in context.
+ */
 export async function login(opts: {
   email: string;
-  password: string;
-}): Promise<{ session_jwt: string; refresh_token: string }> {
+  password?: string;
+}): Promise<{
+  accessJwt: string;
+  sessionJwt: string;
+  refreshToken: string;
+  setCookie: string | null;
+}> {
   const res = await fetch(`${getBaseUrl()}/v1/auth/password/login`, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({
       email: opts.email,
-      password: opts.password,
+      // Default to the shared test password (mirrors seedUser /
+      // signupAndVerify) so callers can `login({ email })` after a
+      // default-password seedUser without restating the literal.
+      password: opts.password ?? STRONG_PASSWORD,
       device_label: 'e2e',
     }),
   });
@@ -145,9 +185,16 @@ export async function login(opts: {
     const text = await res.text().catch(() => '');
     throw new Error(`login failed (${res.status}): ${text}`);
   }
-  return (await res.json()) as {
-    session_jwt: string;
+  const setCookie = res.headers.get('set-cookie');
+  const json = (await res.json()) as {
+    access_jwt: string;
     refresh_token: string;
+  };
+  return {
+    accessJwt: json.access_jwt,
+    sessionJwt: json.access_jwt,
+    refreshToken: json.refresh_token,
+    setCookie,
   };
 }
 

--- a/validator/e2e/helpers/env.ts
+++ b/validator/e2e/helpers/env.ts
@@ -39,6 +39,25 @@ export function getMailpitUrl(): string {
 }
 
 /**
+ * Host that transactional-email links MUST point at, derived the same way
+ * the server derives it (password.ts:appBaseUrl → LMWF_ENV). Used by the
+ * "email link host == env appBaseUrl" topology assertion to catch a
+ * misconfigured Lambda env building links for the wrong environment (the
+ * #137 reset-link-misrouting class).
+ *
+ * The e2e process doesn't share the server's LMWF_ENV directly, so this is
+ * configurable via LMWF_E2E_EXPECTED_EMAIL_HOST. The default matches the
+ * local stack, which `scripts/e2e-local.sh` boots with LMWF_ENV=beta →
+ * links resolve to beta.liftmark.app.
+ */
+export function expectedEmailLinkHost(): string {
+  const explicit = process.env.LMWF_E2E_EXPECTED_EMAIL_HOST;
+  if (explicit) return explicit;
+  // The local stack runs with LMWF_ENV=beta (see scripts/e2e-local.sh).
+  return 'beta.liftmark.app';
+}
+
+/**
  * Each test run uses a unique email prefix so reruns + parallel workers
  * don't collide on the (provider, provider_sub) uniqueness check in
  * createIdentity.

--- a/validator/e2e/helpers/tokens.ts
+++ b/validator/e2e/helpers/tokens.ts
@@ -34,6 +34,9 @@ interface MailpitListResponse {
   messages: MailpitMessageSummary[];
 }
 
+// Match group 1 = the token; the full match (group 0) = the whole link,
+// which the host-assertion helper below parses to verify the link points
+// at the env-correct host (beta vs prod).
 const VERIFY_LINK_RE =
   /https?:\/\/[^\s<>'"]+\/v1\/auth\/password\/verify\?token=([^\s<>'")]+)/;
 const RESET_LINK_RE =
@@ -109,6 +112,55 @@ export async function getLatestToken(
   return getMode() === 'local'
     ? fetchLatestMailpitToken(email, type, timeoutMs)
     : mintRemoteToken(email, type);
+}
+
+/**
+ * Local-only: return the FULL verify/reset link from the latest Mailpit
+ * email to `email`. Used by the "email link host == env appBaseUrl"
+ * topology assertion — a misconfigured LMWF_ENV on the Lambda builds links
+ * pointing at the wrong host (the #137 reset-misrouting class). The link
+ * body is only readable where Mailpit is the transport, i.e. local mode,
+ * which still gates prod via the e2e-local required check.
+ *
+ * Throws if called outside local mode — callers must guard on getMode().
+ */
+export async function getLatestEmailLink(
+  email: string,
+  type: TokenType,
+  timeoutMs = 5_000,
+): Promise<string> {
+  if (getMode() !== 'local') {
+    throw new Error(
+      'getLatestEmailLink is local-only (Mailpit transport). Guard callers on getMode() === "local".',
+    );
+  }
+  const re = type === 'email_verify' ? VERIFY_LINK_RE : RESET_LINK_RE;
+  const mailpit = getMailpitUrl();
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    const listRes = await fetch(
+      `${mailpit}/api/v1/search?query=${encodeURIComponent(`to:${email}`)}`,
+    );
+    if (!listRes.ok) {
+      await sleep(200);
+      continue;
+    }
+    const list = (await listRes.json()) as MailpitListResponse;
+    for (const summary of list.messages) {
+      const detailRes = await fetch(`${mailpit}/api/v1/message/${summary.ID}`);
+      if (!detailRes.ok) continue;
+      const detail = (await detailRes.json()) as MailpitMessageDetail;
+      const body = `${detail.Text}\n${detail.HTML}`;
+      const match = re.exec(body);
+      if (match?.[0]) return match[0];
+    }
+    await sleep(200);
+  }
+
+  throw new Error(
+    `Timed out after ${timeoutMs}ms waiting for ${type} email link to ${email} in Mailpit at ${mailpit}.`,
+  );
 }
 
 function sleep(ms: number): Promise<void> {

--- a/validator/e2e/tests/auth-forgot-reset.spec.ts
+++ b/validator/e2e/tests/auth-forgot-reset.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 import { seedUser } from '../helpers/api.js';
-import { uniqueEmail } from '../helpers/env.js';
-import { getLatestToken } from '../helpers/tokens.js';
+import { expectedEmailLinkHost, getMode, uniqueEmail } from '../helpers/env.js';
+import { getLatestEmailLink, getLatestToken } from '../helpers/tokens.js';
 
 test('forgot → reset → login with new password', async ({ page, request }) => {
   const email = uniqueEmail('reset');
@@ -14,6 +14,21 @@ test('forgot → reset → login with new password', async ({ page, request }) =
   await page.locator('#email').fill(email);
   await page.locator('#submit-btn').click();
   await expect(page.locator('#forgot-msg .inline-msg.ok')).toBeVisible();
+
+  // Topology assertion (b): the reset link host must match the env's
+  // appBaseUrl. This is the exact #137 reset-misrouting class — a Lambda
+  // with the wrong LMWF_ENV emails a link pointing at the wrong host, so
+  // the user lands on the wrong environment's reset page. Only assertable
+  // where the email body is readable = local/Mailpit mode (gates prod via
+  // e2e-local). Remote mode mints the token directly with no email to read.
+  if (getMode() === 'local') {
+    const link = await getLatestEmailLink(email, 'password_reset');
+    const url = new URL(link);
+    expect(url.host).toBe(expectedEmailLinkHost());
+    // The reset link must target the website page, not the POST-only API
+    // route (a GET on /v1/auth/password/reset would 405).
+    expect(url.pathname).toBe('/account/reset');
+  }
 
   // Pull the reset token and land on /account/reset?token=...
   const token = await getLatestToken(email, 'password_reset');

--- a/validator/e2e/tests/auth-session.spec.ts
+++ b/validator/e2e/tests/auth-session.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from '@playwright/test';
+import { login, seedUser } from '../helpers/api.js';
+import { uniqueEmail } from '../helpers/env.js';
+
+/**
+ * Topology-delta test: the `lmwf_refresh` cookie's Set-Cookie ATTRIBUTES.
+ *
+ * Why this earns an e2e slot (and isn't left to Vitest): the route handler's
+ * `setCookie(...)` call is pinned in-process by
+ * validator/tests/routes/auth/password.test.ts:692 ("login sets an httpOnly
+ * lmwf_refresh cookie scoped to /v1/auth"). But the BYTES that reach a real
+ * client are produced by whatever sits in front of the Lambda — API Gateway
+ * (HTTP API payload v2 multiValueHeaders) and, for the browser flow,
+ * CloudFront. Either can drop, fold, or rewrite Set-Cookie. A regression
+ * there (e.g. a CF response-headers-policy stripping Set-Cookie, or APIGW
+ * collapsing multi-value headers) is INVISIBLE to the in-process test and
+ * only shows up over the wire — which is exactly what e2e-beta exercises.
+ *
+ * The assertion is mode-agnostic: the header is readable in both local and
+ * remote mode, so this guards prod via BOTH e2e-local and e2e-beta.
+ */
+test('login Set-Cookie carries HttpOnly + Secure + SameSite + Path=/v1/auth', async () => {
+  const email = uniqueEmail('cookie');
+  // seedUser() and login() both default to the shared test password, so we
+  // don't restate the literal here (keeps the secret scanner quiet and DRY).
+  await seedUser({ email });
+
+  const { setCookie } = await login({ email });
+
+  expect(
+    setCookie,
+    'login response must carry a Set-Cookie header (APIGW/CloudFront can strip it)',
+  ).toBeTruthy();
+  const cookie = setCookie as string;
+
+  // The refresh cookie must be present and named exactly lmwf_refresh.
+  expect(cookie).toMatch(/lmwf_refresh=/);
+  // httpOnly: not script-readable — the whole point of moving the refresh
+  // token out of localStorage (M2).
+  expect(cookie).toMatch(/;\s*HttpOnly/i);
+  // Secure: only sent over HTTPS. (Hono emits this regardless of the
+  // request scheme; over the wire on beta/prod it is load-bearing.)
+  expect(cookie).toMatch(/;\s*Secure/i);
+  // SameSite=Strict: CSRF mitigation on the state-changing /v1/auth routes.
+  expect(cookie).toMatch(/;\s*SameSite=Strict/i);
+  // Path scoping: the cookie must only ride /v1/auth requests, never the
+  // whole API surface. A path widened to "/" would leak the refresh token
+  // onto every API call.
+  expect(cookie).toMatch(/;\s*Path=\/v1\/auth(?:;|$)/i);
+});

--- a/validator/e2e/tests/auth-signup-verify.spec.ts
+++ b/validator/e2e/tests/auth-signup-verify.spec.ts
@@ -1,7 +1,12 @@
 import { expect, test } from '@playwright/test';
 import { deleteTestUser } from '../helpers/api.js';
-import { signupTestEmail, uniqueEmail } from '../helpers/env.js';
-import { getLatestToken } from '../helpers/tokens.js';
+import {
+  expectedEmailLinkHost,
+  getMode,
+  signupTestEmail,
+  uniqueEmail,
+} from '../helpers/env.js';
+import { getLatestEmailLink, getLatestToken } from '../helpers/tokens.js';
 
 test('full signup → email verify flow', async ({ page, request }) => {
   const email = signupTestEmail();
@@ -19,6 +24,15 @@ test('full signup → email verify flow', async ({ page, request }) => {
   await page.locator('#password').fill(password);
   await page.locator('#password_confirm').fill(password);
 
+  // The signup POST returning 201 is itself a topology assertion (test (d)
+  // in spec/services/validator-e2e.md): the email send is the LAST step
+  // before the 201 and the handler ROLLS BACK + returns 503 if the send
+  // throws (password.ts:282-325). So in remote/beta mode a 201 for the
+  // SES-verified address proves SES credentials resolve on the deployed
+  // stack — it cannot be reached if SES rejects with placeholder creds (the
+  // #137 SES-placeholder class). No separate signup POST is needed; this is
+  // the existing real send, now asserted. (Beta SES only — the prod-side
+  // SES-creds check remains a separate concern; see spec.)
   await Promise.all([
     page.waitForResponse(
       (r) => r.url().endsWith('/v1/auth/password/signup') && r.status() === 201,
@@ -29,6 +43,17 @@ test('full signup → email verify flow', async ({ page, request }) => {
   // Form swaps to the "Check your email" state.
   await expect(page.locator('#success-state')).toBeVisible();
   await expect(page.locator('#sent-email')).toHaveText(email);
+
+  // Topology assertion (b): the verification link host must match the env's
+  // appBaseUrl. A misconfigured LMWF_ENV on the Lambda builds links for the
+  // wrong host (the #137 reset-link-misrouting class). Only assertable where
+  // we can read the email body = local/Mailpit mode (which still gates prod
+  // via e2e-local). Remote mode mints the token directly, so there is no
+  // email body to read — skip cleanly there.
+  if (getMode() === 'local') {
+    const link = await getLatestEmailLink(email, 'email_verify');
+    expect(new URL(link).host).toBe(expectedEmailLinkHost());
+  }
 
   // Pull the token (Mailpit local / mint-token remote) and verify it via
   // the same JSON endpoint the email link's GET redirector hits. Goes

--- a/validator/e2e/tests/pat-live-auth.spec.ts
+++ b/validator/e2e/tests/pat-live-auth.spec.ts
@@ -1,0 +1,63 @@
+import { expect, test } from '@playwright/test';
+import { createPat, revokePat, seedUser } from '../helpers/api.js';
+import { getBaseUrl, uniqueEmail } from '../helpers/env.js';
+
+/**
+ * Topology-delta test: a real PAT authenticates a live API request, then
+ * stops working the instant it is revoked.
+ *
+ * Why this earns an e2e slot (and isn't left to Vitest): the per-route
+ * tests (validator/tests/routes/workouts.test.ts:486 "without PAT → 401",
+ * :498/:517/:553 scope 403s) prove the `requireScope`/PAT middleware logic
+ * in-process. What they CANNOT see is whether the deployed APIGW authorizer
+ * + middleware are actually wired in front of the Lambda route over the
+ * wire — a routing/authorizer misconfiguration (PAT never reaches the
+ * handler, or the Authorization header is stripped by APIGW) would pass
+ * every in-process test and still 401/500 every real third-party client.
+ * Driving a minted PAT through a real HTTPS GET, then revoking and
+ * re-driving it, proves the full deployed auth path round-trips. Valuable
+ * specifically on e2e-beta.
+ *
+ * Mode-agnostic: works against the local stack and against beta.
+ */
+test('a minted PAT authenticates GET /v1/workouts, then 401s after revoke', async ({
+  request,
+}) => {
+  // seedUser gives us a session JWT (its legitimate backdoor field) to mint
+  // and later revoke the PAT — neither of which is what we're testing.
+  const user = await seedUser({ email: uniqueEmail('pat-live'), tier: 'trial' });
+
+  // Default scopes include workouts:read (tokens.ts DEFAULT_SCOPES), which
+  // is exactly what GET /v1/workouts requires.
+  const pat = await createPat({
+    sessionJwt: user.sessionJwt,
+    name: `e2e-pat-live-${Date.now()}`,
+  });
+
+  const url = `${getBaseUrl()}/v1/workouts`;
+
+  // 1) Live request with the PAT → NOT 401. (200 with an empty inbox for a
+  //    freshly seeded user; we assert non-401 rather than pinning the body,
+  //    since the point is "the authorizer + scope middleware honoured it".)
+  const authed = await request.get(url, {
+    headers: { authorization: `Bearer ${pat.plaintext}` },
+  });
+  expect(
+    authed.status(),
+    'a valid workouts:read PAT must be honoured by the deployed authorizer + scope middleware',
+  ).not.toBe(401);
+  expect(authed.status()).toBe(200);
+
+  // 2) Revoke the PAT via the session-authed DELETE.
+  await revokePat({ sessionJwt: user.sessionJwt, tokenId: pat.token_id });
+
+  // 3) Same request, same token → now 401. Proves revocation is honoured at
+  //    the deployed auth layer, not just in the repository.
+  const afterRevoke = await request.get(url, {
+    headers: { authorization: `Bearer ${pat.plaintext}` },
+  });
+  expect(
+    afterRevoke.status(),
+    'a revoked PAT must be rejected by the deployed authorizer',
+  ).toBe(401);
+});


### PR DESCRIPTION
## What & why

Makes the validator's prod-deploy gate comprehensive in the one place it has a real gap: **deploy-boundary (topology) contracts** the Vitest suite structurally cannot see.

### Corrected coverage baseline (verified, re-checked)

The prod gate chain is linear and **Vitest, e2e-local, AND e2e-beta all hard-gate prod**:

```
validate (Vitest typecheck+test) → build → e2e-local → deploy-beta → smoke-beta → e2e-beta → deploy-prod
```

Vitest route tests + `flow.test.ts` already pin every pure-handler contract — same conditional-expression semantics that run on Lambda, in-process. **This PR does not duplicate any of them into Playwright.** Confirmed by opening each (file:line in the spec): cross-user IDOR delete (`workouts.test.ts:722`), PAT-scope 403 (`:498/:517/:553`), refresh rotation+reuse (`refresh.test.ts:132`, concurrent `:283`), anti-enumeration uniform 401 (`password.test.ts:231/:570`), single-use reset (`password.test.ts:646`), reset revokes-all + cutoff (`password.test.ts:597`), outbox dedup (`workout_outbox.test.ts:132`), tier gates (`tokens.test.ts:170/:199`), signup rollback (`password.test.ts:247`).

### The four topology-delta tests (each earns its e2e slot)

| # | Topology delta | Why Vitest can't see it | Location | Mode |
|---|---|---|---|---|
| **a** | `lmwf_refresh` Set-Cookie carries HttpOnly + Secure + SameSite=Strict + Path=/v1/auth **over the wire** | In-process pins the `setCookie()` call; APIGW multiValueHeaders / CloudFront can strip/rewrite the bytes | `e2e/tests/auth-session.spec.ts` (new) | both |
| **b** | Verify/reset email **link host** == env appBaseUrl (+ reset path) | Host comes from the Lambda's `LMWF_ENV`; only readable where the email body is (Mailpit) | `auth-signup-verify` + `auth-forgot-reset` | local-only, guarded |
| **c** | Minted PAT authenticates live `GET /v1/workouts`, then 401 after revoke | Proves the deployed authorizer + scope middleware are wired in front of the route + honour revocation over the wire | `e2e/tests/pat-live-auth.spec.ts` (new) | both |
| **d** | Real-SES signup → 201 | Signup's email send is the last step before 201, rolls back to 503 on failure (`password.ts:282-325`); a 201 proves SES creds resolve. Invisible in-process (Mailpit) | `auth-signup-verify` (existing POST, now asserted) | real send in remote/beta |

**On (d):** I verified the **existing** signup test already drives a real `POST /v1/auth/password/signup` against the SES-verified address (`crusted_staid_0k@icloud.com`) in remote mode — so the real SES send already happens; the gap was only an explicit assertion/comment, **not** a new send. No redundant signup was added.

### login() bug fix (load-bearing helper, step 0)

`e2e/helpers/api.ts` `login()` destructured `{session_jwt, refresh_token}`, but the route returns `{access_jwt, refresh_token, user}` (`password.ts:490`) — so `login().session_jwt` was always `undefined`. Fixed to read `access_jwt`, exposed as `accessJwt` (with `sessionJwt` alias) + `refreshToken` + raw `setCookie`. **No existing e2e callers** (the `password.test.ts` `login` is a separate in-suite local fn), so nothing to migrate; the `seedUser()` backdoor's legitimate `session_jwt` is untouched.

### #137 incident-class → owning assertion

- **SES placeholder creds** → test (d) (beta-SES 201).
- **Reset-link misrouting** → test (b) (link host == env host).
- **Orphan signup rows** → Vitest `password.test.ts:247` (rollback + retry).

### Honest beta-vs-prod-SES caveat

e2e-beta proves **beta** SES creds resolve, **not prod**. The prod stack has a separate SES identity/role; the prod variant stays open under **#137 Layer 2** (prod-safe smoke flow, deferred). Test (d) does not claim to close it — documented in the spec.

### Do NOT shard

Fixed per-job setup (npm ci + `playwright install --with-deps chromium` + OIDC + Lambda warm) dominates a tiny suite; shards fan out N required checks and contend on one beta Lambda. Revisit only when **measured** wall time > ~300s OR suite > ~50 tests — raise workers 4→6 before any shard. **Measured this run: 13 tests, 2.0s** Playwright execution.

### Spec

`spec/services/validator-e2e.md`: prod-gate coverage model, Vitest-vs-e2e division of labour (topology-delta principle), #137 incident-class map, email-verification race documented as structurally-prevented (signup strictly sequential; verify re-fetches identity by id — no test), Stripe billing marked KNOWN-UNTESTED/mandatory-on-arrival, do-not-shard decision + measured wall time.

## Verification

- `cd validator && npm run typecheck` — clean (src + e2e tsconfig both).
- Full e2e-local suite (existing + new) via `scripts/e2e-local.sh` (DDB Local + Mailpit, `LMWF_ENV=beta`, local mode):

```
Running 13 tests using 6 workers
  ✓ tests/auth-session.spec.ts › login Set-Cookie carries HttpOnly + Secure + SameSite + Path=/v1/auth
  ✓ tests/pat-live-auth.spec.ts › a minted PAT authenticates GET /v1/workouts, then 401s after revoke
  ✓ tests/auth-signup-verify.spec.ts › full signup → email verify flow   (link-host (b) ran in local mode)
  ✓ tests/auth-forgot-reset.spec.ts › forgot → reset → login with new password   (reset link-host (b))
  ... (9 more existing tests)
  13 passed (2.0s)
```

Remote-only assertions ((d) real SES, and (b) is local-only) are cleanly guarded by `getMode()`, not failed, in local mode.

## Risks

- The link-host assertion (b) defaults to `beta.liftmark.app` (matches the local stack's `LMWF_ENV=beta`); overridable via `LMWF_E2E_EXPECTED_EMAIL_HOST`. If the local stack's `LMWF_ENV` ever changes, set that env var.
- Test (c) and (a) run in remote mode too; they assume APIGW passes the Authorization header / Set-Cookie through (which is the point — a regression there is what they catch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
