### PR TITLE
ci: self-run ggshield secret scan (honors repo .gitguardian.yaml)

### DIFF
--- a/.github/workflows/ggshield.yml
+++ b/.github/workflows/ggshield.yml
@@ -1,0 +1,41 @@
+# Self-run GitGuardian secret scan via ggshield.
+#
+# Why this exists alongside / instead of the managed "GitGuardian Security
+# Checks" GitHub App: the managed App reads its ignore list from the
+# GitGuardian dashboard and does NOT honor the repo's .gitguardian.yaml.
+# ggshield DOES honor .gitguardian.yaml (secret.ignored-matches / ignored-paths),
+# so our allowlist lives in git (config-as-code) and false positives like the
+# e2e test-fixture passphrase are silenced in-repo — no per-incident dashboard
+# clicks. Intended to be the REQUIRED secret-scanning check (the managed App
+# check can then be demoted to non-required/informational).
+#
+# Prerequisite: repo secret GITGUARDIAN_API_KEY (a GitGuardian API key with the
+# `scan` scope). Without it this job fails on auth.
+name: GitGuardian (ggshield)
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  ggshield:
+    name: ggshield
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Full history so the PR/push commit range can be scanned.
+          fetch-depth: 0
+      - name: ggshield secret scan
+        uses: GitGuardian/ggshield-action@v1
+        env:
+          GITHUB_PUSH_BEFORE_SHA: ${{ github.event.before }}
+          GITHUB_PUSH_BASE_SHA: ${{ github.event.base }}
+          GITHUB_PULL_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          GITHUB_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}


### PR DESCRIPTION
Adds a self-run `ggshield` secret-scan job so the repo's `.gitguardian.yaml` allowlist is authoritative (the managed GitGuardian App ignores it). Keeps secret scanning blocking, but config-as-code — no per-incident dashboard clicks.

**Prerequisite:** add a repo secret `GITGUARDIAN_API_KEY` (GitGuardian API key, `scan` scope). Until then this job fails on auth (it is not yet a required check, so it won't block).

**Next steps after this merges + the key is set:**
1. Confirm the `ggshield` job runs green on a PR (honoring `.gitguardian.yaml`).
2. In the "Main Protection" ruleset, add `ggshield` as a required check and drop `GitGuardian Security Checks` (managed App) from required (leave it running, informational).

Note: a per-severity "block med/high only" floor is **not** a ggshield flag — that's GitGuardian dashboard policy. This PR is about config-as-code allowlisting, not severity gating.