### PR TITLE
fix(validator): dedup identical inbox pushes (#193)

### DIFF
--- a/spec/services/workout-inbox.md
+++ b/spec/services/workout-inbox.md
@@ -79,7 +79,7 @@ degrade to `null` rather than failing the request.
 
 | Method | Path                          | Scope           | Description                                                                                 |
 |--------|-------------------------------|-----------------|---------------------------------------------------------------------------------------------|
-| POST   | `/v1/workouts`                | `workouts:write`| Push a new workout (LMWF body). Returns inbox item summary + warnings.                      |
+| POST   | `/v1/workouts`                | `workouts:write`| Push a new workout (LMWF body). Returns inbox item summary + warnings (**201**). If it dedups onto an existing pending item with identical content, returns that item with `"deduplicated": true` (**200**) — see *Conflict + dedup rules*. |
 | GET    | `/v1/workouts`                | `workouts:read` | List items (latest first). iOS sends no `status` filter so it sees every live row; an optional `?status=` filter still works for the web portal. Returns summary only. |
 | GET    | `/v1/workouts/:inbox_id`      | `workouts:read` | Fetch one item including `workout` (full parsed plan) and `lmwf_text`.                      |
 | POST   | `/v1/workouts/:inbox_id/ack`  | `workouts:write`| **Orphaned/legacy.** Marks item `ingested`. No client calls it anymore (iOS and the web portal both stopped — GH #164); kept only so old rows/clients don't 404. Idempotent. |
@@ -177,7 +177,11 @@ Tap on a row (not swipe) opens a read-only detail sheet (`InboxPreviewSheet`) �
 
 ### Conflict + dedup rules
 
-- Re-polling the same `inbox_id` is a no-op (the row is already cached, so it's skipped). Promotion creates a fresh `WorkoutPlan` UUID each time — so accidentally pushing the same workout twice yields two inbox items that promote to two distinct plans (or the user discards the duplicate).
+- **Push-time idempotency (GH #193).** `POST /v1/workouts` dedups on content: the server stores a `content_hash` (sha256 of the trimmed `lmwf_text`) on each item, and before creating a new row it looks for an existing **pending** item for the same user with the same hash. If one exists, the push returns that item unchanged — same `inbox_id`, `created_at`, and a `"deduplicated": true` flag — with HTTP **200** instead of **201**, and no new row is created. This collapses a double-fired or replayed push (the GH #193 root cause: identical pushes seconds apart) onto a single inbox item. Scope and edges:
+  - **Pending-only.** Dedup matches only un-acted items. Once an item is ingested or discarded (its row is gone), a deliberate re-push produces a fresh item — re-importing a previously-handled plan is intentional.
+  - **Content-keyed, not name-keyed.** An *edited* re-push (e.g. the same plan with one more set) has a different hash and is correctly kept as a distinct item.
+  - **Accepted race.** Two byte-identical pushes that land truly concurrently (both read before either writes) can still both create a row. This is a narrow window; the observed real-world failure (pushes seconds apart) is fully closed by the read-before-write check. Hardening to a conditional write on a deterministic key is out of scope.
+- Re-polling the same `inbox_id` is a no-op (the row is already cached, so it's skipped). Promotion creates a fresh `WorkoutPlan` UUID each time — so a deliberately re-pushed (post-ingest) or edited workout that lands as a second inbox item promotes to a distinct plan (or the user discards the duplicate).
 - Promotion is one-shot: once a `WorkoutPlan` is created from an inbox item, the inbox row is deleted. There is no "re-import from inbox history" — the server-side row is also deleted.
 - A signed-out user's inbox table is wiped on logout (treating inbox as session-scoped device state). This is now lossless: because the poll no longer acks, the server still holds every un-acted item, so signing back in repopulates the inbox from the next poll (GH #164).
 - A `DELETE` that fails (offline) leaves the row server-side; the local row is already gone, so the item reappears on the next poll. The user can re-discard. Accepted edge — the alternative (durably queueing the delete) is out of scope.

--- a/validator/src/repositories/workout_inbox.ts
+++ b/validator/src/repositories/workout_inbox.ts
@@ -16,6 +16,7 @@ import {
   QueryCommand,
   UpdateCommand,
 } from '@aws-sdk/lib-dynamodb';
+import { createHash } from 'node:crypto';
 import { ulid } from 'ulid';
 import { ddb, tableName } from '../infra/ddb.js';
 
@@ -29,6 +30,14 @@ export interface InboxItem {
   status: InboxStatus;
   created_at: string;
   ingested_at?: string;
+  /**
+   * sha256 hex of the (trimmed) `lmwf_text`. Used for push-time dedup so a
+   * double-fired or replayed push of byte-identical content collapses onto
+   * the existing pending item instead of minting a duplicate (GH #193).
+   * Optional on read so legacy rows written before this field existed still
+   * decode — those simply never match a dedup probe.
+   */
+  content_hash?: string;
 }
 
 export interface CreateInboxItemInput {
@@ -36,6 +45,17 @@ export interface CreateInboxItemInput {
   source_token_id: string;
   lmwf_text: string;
   status: InboxStatus;
+}
+
+/**
+ * Stable dedup fingerprint for an inbox push: sha256 hex of the trimmed
+ * `lmwf_text`. Trimming absorbs insignificant leading/trailing whitespace so
+ * a re-push that differs only by a trailing newline still collapses. Two
+ * genuinely different plans (e.g. an edited version with more sets) hash
+ * differently and are kept as distinct items.
+ */
+export function inboxContentHash(lmwf_text: string): string {
+  return createHash('sha256').update(lmwf_text.trim()).digest('hex');
 }
 
 export interface ListInboxOptions {
@@ -106,6 +126,7 @@ export async function createInboxItem(
     ...input,
     inbox_id: ulid(),
     created_at: new Date().toISOString(),
+    content_hash: inboxContentHash(input.lmwf_text),
   };
 
   await ddb.send(
@@ -117,6 +138,41 @@ export async function createInboxItem(
   );
 
   return item;
+}
+
+/**
+ * Find this user's most recent *pending* inbox item whose content matches the
+ * given hash, or null. Backs push-time dedup (GH #193): a push that is
+ * byte-identical (modulo whitespace) to an item the user hasn't yet acted on
+ * returns the existing item rather than creating a duplicate. Scoped to
+ * `pending` on purpose — once an item is ingested or discarded, a deliberate
+ * re-push should produce a fresh item.
+ *
+ * Reads the caller's partition (newest-first) with a server-side filter on
+ * status + content_hash. The inbox is small and self-draining, so this is a
+ * bounded query; no GSI is required.
+ */
+export async function findPendingByContentHash(
+  user_id: string,
+  content_hash: string,
+): Promise<InboxItem | null> {
+  const result = await ddb.send(
+    new QueryCommand({
+      TableName: tableName('workout_inbox'),
+      KeyConditionExpression: 'user_id = :uid',
+      FilterExpression: '#st = :pending AND content_hash = :h',
+      ExpressionAttributeNames: { '#st': 'status' },
+      ExpressionAttributeValues: {
+        ':uid': user_id,
+        ':pending': 'pending',
+        ':h': content_hash,
+      },
+      // Newest first — ULID SK is lexicographically chronological.
+      ScanIndexForward: false,
+    }),
+  );
+  const items = (result.Items as InboxItem[] | undefined) ?? [];
+  return items[0] ?? null;
 }
 
 export async function getInboxItemsByUser(

--- a/validator/src/routes/workouts.ts
+++ b/validator/src/routes/workouts.ts
@@ -27,8 +27,10 @@ import { requireScope, type AuthVariables } from '../middleware/auth.js';
 import {
   createInboxItem,
   deleteInboxItem,
+  findPendingByContentHash,
   getInboxItem,
   getInboxItemsByUser,
+  inboxContentHash,
   InvalidCursorError,
   markIngested,
   type InboxStatus,
@@ -275,6 +277,40 @@ workoutsRouter.post('/', requireScope('workouts:write'), async (c) => {
   }
 
   const summary = summarize(result);
+
+  // Push-time idempotency (GH #193). A double-fired or replayed push of
+  // byte-identical content would otherwise mint a fresh inbox_id every time,
+  // fanning the user's inbox out into near-duplicate rows. If an *un-acted*
+  // (pending) item with the same content already exists, return it unchanged
+  // instead of creating another. Scoped to pending: once the user has
+  // ingested or discarded an item, a deliberate re-push is a new item.
+  const contentHash = inboxContentHash(markdown);
+  const existing = await findPendingByContentHash(
+    c.var.user.user_id,
+    contentHash,
+  );
+  if (existing) {
+    log({
+      level: 'info',
+      requestId,
+      event: 'workouts_push_deduplicated',
+      status: 200,
+      inboxId: existing.inbox_id,
+      durationMs: Date.now() - startTime,
+    });
+    return c.json(
+      {
+        inbox_id: existing.inbox_id,
+        status: existing.status,
+        created_at: existing.created_at,
+        deduplicated: true,
+        summary,
+        warnings: result.warnings,
+      },
+      200,
+    );
+  }
+
   // Session-authed pushes (web dashboard) record 'session' as their
   // source — distinguishes "pushed via PAT X" from "pushed via the web
   // portal" in the audit trail. PAT pushes record the token's ULID.

--- a/validator/tests/repositories/workout_inbox.test.ts
+++ b/validator/tests/repositories/workout_inbox.test.ts
@@ -1,9 +1,24 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import {
   createInboxItem,
+  findPendingByContentHash,
   getInboxItemsByUser,
+  inboxContentHash,
   markIngested,
 } from '../../src/repositories/workout_inbox.js';
+
+describe('inboxContentHash', () => {
+  it('is stable and ignores surrounding whitespace', () => {
+    const a = inboxContentHash('# Push\n## Bench\n- 135 x 5');
+    const b = inboxContentHash('\n  # Push\n## Bench\n- 135 x 5  \n');
+    expect(a).toBe(b);
+    expect(a).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('differs for different content', () => {
+    expect(inboxContentHash('a')).not.toBe(inboxContentHash('b'));
+  });
+});
 
 const liveDdb = process.env.DDB_ENDPOINT ? describe : describe.skip;
 
@@ -28,6 +43,39 @@ liveDdb('workout_inbox repository', () => {
     // ULIDs are 26 chars of Crockford base32 — lexicographic = chronological.
     expect(item.inbox_id).toMatch(/^[0-9A-HJKMNP-TV-Z]{26}$/);
     expect(item.ingested_at).toBeUndefined();
+    // Content hash is stamped for push-time dedup (GH #193).
+    expect(item.content_hash).toBe(inboxContentHash(item.lmwf_text));
+  });
+
+  it('findPendingByContentHash matches a pending item, scoped per-user and to pending', async () => {
+    const user_id = `user-${Date.now()}-${Math.random()}`;
+    const lmwf = '# Push Day\n## Bench Press\n- 135 x 5';
+    const hash = inboxContentHash(lmwf);
+
+    const item = await createInboxItem({
+      user_id,
+      source_token_id: 'tok',
+      lmwf_text: lmwf,
+      status: 'pending',
+    });
+
+    // Same content, same user → found.
+    const found = await findPendingByContentHash(user_id, hash);
+    expect(found?.inbox_id).toBe(item.inbox_id);
+
+    // Different content → not found.
+    expect(
+      await findPendingByContentHash(user_id, inboxContentHash('other')),
+    ).toBeNull();
+
+    // Another user with the same content → not found (per-user scope).
+    expect(
+      await findPendingByContentHash(`other-${user_id}`, hash),
+    ).toBeNull();
+
+    // Once ingested, it no longer matches (pending-only scope).
+    await markIngested(user_id, item.inbox_id);
+    expect(await findPendingByContentHash(user_id, hash)).toBeNull();
   });
 
   it('lists items newest-first for a user', async () => {

--- a/validator/tests/routes/workouts.test.ts
+++ b/validator/tests/routes/workouts.test.ts
@@ -144,6 +144,143 @@ live('Workout inbox routes (/v1/workouts)', () => {
     expect(single.workout.exercises[0].sets[2].targetReps).toBe(5);
   });
 
+  it('POST identical content twice dedups onto one pending item (GH #193)', async () => {
+    const { plaintext } = await mintUserAndPat('push-dedup');
+
+    const first = await app.request('/v1/workouts', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${plaintext}`,
+      },
+      body: JSON.stringify({ lmwf: VALID_LMWF }),
+    });
+    expect(first.status).toBe(201);
+    const firstBody = (await first.json()) as { inbox_id: string };
+
+    // A double-fired / replayed identical push must collapse onto the same
+    // item: 200 (not 201), deduplicated flag, same inbox_id, and the list
+    // still holds exactly one row.
+    const second = await app.request('/v1/workouts', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${plaintext}`,
+      },
+      body: JSON.stringify({ lmwf: VALID_LMWF }),
+    });
+    expect(second.status).toBe(200);
+    const secondBody = (await second.json()) as {
+      inbox_id: string;
+      deduplicated?: boolean;
+      summary: { workoutName: string };
+    };
+    expect(secondBody.deduplicated).toBe(true);
+    expect(secondBody.inbox_id).toBe(firstBody.inbox_id);
+    expect(secondBody.summary.workoutName).toBe('Push Day');
+
+    const list = (await (
+      await app.request('/v1/workouts', {
+        headers: { authorization: `Bearer ${plaintext}` },
+      })
+    ).json()) as { items: unknown[] };
+    expect(list.items).toHaveLength(1);
+  });
+
+  it('POST edited content creates a distinct item (dedup is content-keyed, not name-keyed)', async () => {
+    const { plaintext } = await mintUserAndPat('push-edited');
+
+    await app.request('/v1/workouts', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${plaintext}`,
+      },
+      body: JSON.stringify({ lmwf: VALID_LMWF }),
+    });
+
+    // Same workout name, one extra set → different content hash → new item.
+    const edited = `${VALID_LMWF}- 245 x 3\n`;
+    const res = await app.request('/v1/workouts', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${plaintext}`,
+      },
+      body: JSON.stringify({ lmwf: edited }),
+    });
+    expect(res.status).toBe(201);
+
+    const list = (await (
+      await app.request('/v1/workouts', {
+        headers: { authorization: `Bearer ${plaintext}` },
+      })
+    ).json()) as { items: unknown[] };
+    expect(list.items).toHaveLength(2);
+  });
+
+  it('re-push after the item is acted on (ingested) creates a fresh item', async () => {
+    const { plaintext } = await mintUserAndPat('push-reingest');
+
+    const created = (await (
+      await app.request('/v1/workouts', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          authorization: `Bearer ${plaintext}`,
+        },
+        body: JSON.stringify({ lmwf: VALID_LMWF }),
+      })
+    ).json()) as { inbox_id: string };
+
+    // Ack (ingest) the item — it's no longer pending.
+    await app.request(`/v1/workouts/${created.inbox_id}/ack`, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${plaintext}` },
+    });
+
+    // A deliberate re-push of the same content is now a brand-new item.
+    const res = await app.request('/v1/workouts', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${plaintext}`,
+      },
+      body: JSON.stringify({ lmwf: VALID_LMWF }),
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { inbox_id: string };
+    expect(body.inbox_id).not.toBe(created.inbox_id);
+  });
+
+  it('dedup is per-user: identical content from two users yields two items', async () => {
+    const a = await mintUserAndPat('dedup-user-a');
+    const b = await mintUserAndPat('dedup-user-b');
+
+    const resA = await app.request('/v1/workouts', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${a.plaintext}`,
+      },
+      body: JSON.stringify({ lmwf: VALID_LMWF }),
+    });
+    const resB = await app.request('/v1/workouts', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${b.plaintext}`,
+      },
+      body: JSON.stringify({ lmwf: VALID_LMWF }),
+    });
+    // Both are first-for-their-user → both 201, distinct rows.
+    expect(resA.status).toBe(201);
+    expect(resB.status).toBe(201);
+    const idA = ((await resA.json()) as { inbox_id: string }).inbox_id;
+    const idB = ((await resB.json()) as { inbox_id: string }).inbox_id;
+    expect(idA).not.toBe(idB);
+  });
+
   it('POST /v1/workouts (text/markdown) creates a pending inbox item', async () => {
     const { plaintext } = await mintUserAndPat('push-md');
 
@@ -585,13 +722,15 @@ live('Workout inbox routes (/v1/workouts)', () => {
   it('pagination: limit=2 over 3 items yields next_cursor and second page returns the rest', async () => {
     const { plaintext } = await mintUserAndPat('pagination');
     for (let i = 0; i < 3; i++) {
+      // Distinct content per push — push-time dedup (GH #193) would otherwise
+      // collapse identical bodies onto a single item.
       const res = await app.request('/v1/workouts', {
         method: 'POST',
         headers: {
           'content-type': 'application/json',
           authorization: `Bearer ${plaintext}`,
         },
-        body: JSON.stringify({ lmwf: VALID_LMWF }),
+        body: JSON.stringify({ lmwf: `${VALID_LMWF}- ${100 + i} x ${i + 1}\n` }),
       });
       expect(res.status).toBe(201);
       // Spread created_at slightly so the ULID sort is unambiguous.


### PR DESCRIPTION
Closes #193.

## Root cause (verified against the live inbox)
`POST /v1/workouts` called `createInboxItem` unconditionally, minting a fresh `inbox_id` on every push. Inspecting the reporting account's live inbox showed **11 items, each a distinct server-side push** — including two byte-identical batches 8 seconds apart (a double-fired push) and other batches with genuinely different set counts (real edited re-pushes). The iOS client was faithfully rendering distinct server rows, so this is a **server-side** dedup gap, not an app bug. (The current spec even documented "a push always mints a new `inbox_id`".)

## Fix
Push-time idempotency on `POST /v1/workouts`:
- Stamp each item with `content_hash = sha256(trimmed lmwf_text)`.
- Before inserting, look for an existing **pending** item for the same user with the same hash. If found, return it unchanged with `"deduplicated": true` and HTTP **200** (instead of minting a duplicate at **201**).

### Semantics
- **Pending-only** — once an item is ingested/discarded, a deliberate re-push is a new item.
- **Content-keyed** — an edited re-push (e.g. one more set) hashes differently and stays a distinct item.
- **Per-user** — identical content from two users yields two items.
- **Accepted edge** — truly-concurrent identical pushes (both read before either writes) can still both create; the observed seconds-apart failure is fully closed by the read-before-write check.

`content_hash` is a non-key attribute (DynamoDB is schemaless for non-keys) — **no table/CDK change**, no GSI.

## Tests
- Repo: `inboxContentHash` stability, `findPendingByContentHash` (per-user + pending-only scope), hash stamped on create.
- Route: identical double-push → 200 + dedup + one row; edited push → distinct item; re-push after ack → fresh item; per-user isolation.
- Full validator suite green (331 passed, 60 skipped) against local DynamoDB.

## Rollout notes
- Takes effect after a validator deploy (`cdk deploy` / deploy-validator). Until then, behavior is unchanged.
- This prevents **future** duplicates only; the existing duplicate rows already in the inbox should be discarded in-app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)