### PR TITLE
fix(ios): hide auth-sync banner during an active workout

### DIFF
--- a/mobile-apps/ios/LiftMark/Views/Shared/AuthSyncBannerView.swift
+++ b/mobile-apps/ios/LiftMark/Views/Shared/AuthSyncBannerView.swift
@@ -7,18 +7,28 @@ import SwiftUI
 ///
 /// Visible when:
 ///   `outboxPusher.pendingCount > 0 && (!authStore.isAuthenticated || authStore.sessionExpired)`
+///   — **and** no workout is currently active.
+///
+/// It is suppressed while a workout session is in progress (GH #194 follow-up):
+/// the banner is mounted as a top `safeAreaInset` over the whole tab view, and
+/// the active-workout screen draws its own header (with the Finish button) into
+/// that same top region — so a visible banner overlaps and intercepts taps on
+/// Finish. A sync nag for *past* workouts also shouldn't crowd a live session.
+/// It returns automatically once the workout ends.
 ///
 /// Tapping it presents `LoginView`. A successful login resets `sessionExpired`
 /// and flushes the outbox, which drains the queue and dismisses the banner.
 struct AuthSyncBannerView: View {
     @Environment(AuthenticationStore.self) private var authStore
     @Environment(OutboxPusherService.self) private var outboxPusher
+    @Environment(SessionStore.self) private var sessionStore
 
     @State private var showingLogin = false
 
     private var shouldShow: Bool {
         outboxPusher.pendingCount > 0
             && (!authStore.isAuthenticated || authStore.sessionExpired)
+            && sessionStore.activeSession == nil
     }
 
     private var message: String {
@@ -72,4 +82,5 @@ struct AuthSyncBannerView: View {
     return AuthSyncBannerView()
         .environment(auth)
         .environment(pusher)
+        .environment(SessionStore())
 }

--- a/spec/services/workout-outbox.md
+++ b/spec/services/workout-outbox.md
@@ -217,12 +217,15 @@ This is the one normal-operation path (alongside the giveup-4xx case) that *does
 An app-level banner is shown at the root (`ContentView`) when there are completed workouts that cannot sync because the device needs sign-in:
 
 ```
-outboxPusher.pendingCount > 0 && (!authStore.isAuthenticated || authStore.sessionExpired)
+outboxPusher.pendingCount > 0
+  && (!authStore.isAuthenticated || authStore.sessionExpired)
+  && sessionStore.activeSession == nil
 ```
 
 - Copy: "N workout(s) waiting to sync — sign in to upload." Tapping it presents `LoginView`.
 - Accessibility identifier `auth-sync-banner` for UI tests.
 - A successful login resets `sessionExpired` and triggers `flushIfAuthenticated()`, which drains the queue and clears the banner.
+- **Suppressed during an active workout** (`sessionStore.activeSession != nil`). The banner is mounted as a top `safeAreaInset` over the whole tab view; the active-workout screen draws its own header (including the Finish button) into that same top region, so a visible banner overlaps and intercepts the Finish tap. A sync nag for *past* completed workouts also shouldn't crowd a live session. The banner returns automatically once the workout ends.
 
 ### Re-authentication state
 


### PR DESCRIPTION
## Problem
`testUxImprovements` (the "skip heavy workout shows discard dialog" sub-test) has been **failing on `main`** — confirmed by reproducing it on commit `99a3633`, before #193/#194/#195. It's a **pre-existing** failure from when the auth-sync banner landed (#160), surfaced now because we want the UI suite as a pipeline gate.

**Root cause (from the failure's UI hierarchy + screen recording):** the auth-sync banner is mounted as a top `safeAreaInset` over the whole tab view (`ContentView`). The active-workout screen draws its own header — including the Finish button — into that same top region. When the banner is visible (signed-out user with completed-but-unsynced workouts), it **overlaps and intercepts taps on the Finish button**: the tap opens the login sheet instead of the finish/discard confirmation. By the last of the scenario's 5 workout cycles, enough workouts had accumulated that the 2-line banner fully covered Finish.

This is a real bug for signed-out users mid-workout, not just a test artifact.

## Fix
Suppress the banner while a workout is active (`sessionStore.activeSession != nil`); it returns automatically once the workout ends. A sync nag for *past* completed workouts shouldn't crowd a live session either. Spec (`workout-outbox.md`) updated.

## Verification
- `testUxImprovements` → **now passes** (was failing on `main`).
- Full UI suite → **22 tests, 0 failures**.
- Full unit suite → **886 tests, 0 failures**.

With this, the entire iOS test suite is green and safe to use as a gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)