### PR TITLE
feat(cdk): DNS foundation stack for getlift.md + liftmd.app

### DIFF
--- a/validator/cdk/app.ts
+++ b/validator/cdk/app.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import * as cdk from 'aws-cdk-lib';
-import { ENVS, envPrefix } from './config';
+import { ENVS, VANITY_DOMAINS, envPrefix } from './config';
+import { LmwfDnsFoundationStack } from './dns-stack';
 import { LmwfEdgeStack } from './edge-stack';
 import { LmwfValidatorStack } from './stack';
 
@@ -36,3 +37,13 @@ for (const cfg of Object.values(ENVS)) {
     webAclArn: edge.webAclArn,
   });
 }
+
+// Vanity / redirect domains — long-lived zones + wildcard certs in the prod
+// account, decoupled from any validator env so an app teardown can't orphan
+// registrar delegation. us-east-1 so the certs are CloudFront-ready.
+new LmwfDnsFoundationStack(app, 'LmwfDnsFoundationStack', {
+  description: 'LiftMark vanity-domain hosted zones + wildcard certs (getlift.md, liftmd.app)',
+  env: { account: ENVS.prod.account, region: 'us-east-1' },
+  tags: { ...commonTags, Service: 'lmwf-dns' },
+  domains: VANITY_DOMAINS,
+});

--- a/validator/cdk/config.ts
+++ b/validator/cdk/config.ts
@@ -91,3 +91,16 @@ export const ENVS: Record<EnvName, EnvConfig> = {
 export function envPrefix(env: EnvConfig): string {
   return `Lmwf${env.name.charAt(0).toUpperCase()}${env.name.slice(1)}`;
 }
+
+/**
+ * Vanity / redirect domains that get their own long-lived Route 53 hosted
+ * zone + wildcard cert in the prod account, managed by the
+ * LmwfDnsFoundationStack. Decoupled from ENVS because these are not validator
+ * environments — they own registrar delegation and must outlive any app-stack
+ * teardown.
+ *
+ * Note: `.md` is Moldova's ccTLD and is not registrable via Route 53; the
+ * domain is registered at an external registrar, and only its NS delegation
+ * points at the zone created here.
+ */
+export const VANITY_DOMAINS = ['getlift.md', 'liftmd.app'] as const;

--- a/validator/cdk/deploy-policy.json
+++ b/validator/cdk/deploy-policy.json
@@ -271,6 +271,23 @@
       ]
     },
     {
+      "Sid": "Route53HostedZoneLifecycle",
+      "Effect": "Allow",
+      "Action": [
+        "route53:CreateHostedZone",
+        "route53:DeleteHostedZone",
+        "route53:GetHostedZone",
+        "route53:GetHostedZoneCount",
+        "route53:ListHostedZones",
+        "route53:ListHostedZonesByName",
+        "route53:ChangeResourceRecordSets",
+        "route53:ListResourceRecordSets",
+        "route53:ChangeTagsForResource",
+        "route53:ListTagsForResource"
+      ],
+      "Resource": "*"
+    },
+    {
       "Sid": "ApiGatewayDomainNames",
       "Effect": "Allow",
       "Action": [

--- a/validator/cdk/dns-stack.ts
+++ b/validator/cdk/dns-stack.ts
@@ -1,0 +1,77 @@
+import * as cdk from 'aws-cdk-lib';
+import * as acm from 'aws-cdk-lib/aws-certificatemanager';
+import * as route53 from 'aws-cdk-lib/aws-route53';
+import { Construct } from 'constructs';
+
+export interface LmwfDnsFoundationStackProps extends cdk.StackProps {
+  /** Vanity / redirect domains to create a zone + wildcard cert for. */
+  domains: readonly string[];
+}
+
+/**
+ * DNS foundation stack — long-lived Route 53 hosted zones (+ wildcard ACM
+ * certs) for vanity / redirect domains that are NOT tied to a validator env.
+ *
+ * Kept deliberately separate from the per-env edge + validator stacks: these
+ * zones own the registrar delegation — their NS records are pasted into each
+ * registrar exactly once — so they must outlive any app-stack `cdk destroy`.
+ * A validator teardown must never orphan these delegations.
+ *
+ * Lives in us-east-1 so the wildcard certs are directly usable by a future
+ * CloudFront distribution without a cross-region cert lookup.
+ *
+ * Deploy ordering (DNS-validated certs need a resolvable zone):
+ *   1. `cdk deploy` creates the hosted zones quickly, then BLOCKS on ACM
+ *      validation of each cert.
+ *   2. While it blocks, read each zone's NS records (Route 53 console or
+ *      `aws route53 list-hosted-zones` / `get-hosted-zone`) and paste them
+ *      into the matching registrar.
+ *   3. Once delegation propagates, ACM validates and the deploy completes,
+ *      printing the NS records as stack outputs for the record.
+ * If a registrar is slow, the cert resource can time out — re-run the deploy
+ * after delegation lands; the zone already exists so it's idempotent.
+ */
+export class LmwfDnsFoundationStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props: LmwfDnsFoundationStackProps) {
+    super(scope, id, props);
+
+    for (const domain of props.domains) {
+      const cid = domainToConstructId(domain);
+
+      const zone = new route53.HostedZone(this, `${cid}Zone`, {
+        zoneName: domain,
+        comment: `LiftMark vanity domain ${domain} — created by CDK`,
+      });
+
+      new acm.Certificate(this, `${cid}Cert`, {
+        domainName: domain,
+        // Wildcard SAN covers future subdomains (www.*, app.*, …) without a
+        // cert rotation — mirrors the per-env edge cert.
+        subjectAlternativeNames: [`*.${domain}`],
+        validation: acm.CertificateValidation.fromDns(zone),
+      });
+
+      new cdk.CfnOutput(this, `${cid}ZoneId`, {
+        value: zone.hostedZoneId,
+        description: `Hosted zone ID for ${domain}`,
+      });
+
+      new cdk.CfnOutput(this, `${cid}NameServers`, {
+        value: cdk.Fn.join(',', zone.hostedZoneNameServers ?? []),
+        description: `Delegate ${domain} at the registrar to these name servers`,
+      });
+    }
+  }
+}
+
+/**
+ * Turn a domain into a PascalCase construct-id prefix.
+ * `getlift.md` → `GetliftMd`, `liftmd.app` → `LiftmdApp`.
+ */
+function domainToConstructId(domain: string): string {
+  return domain
+    .split(/[.-]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1).toLowerCase())
+    .join('');
+}


### PR DESCRIPTION
## What
Adds `LmwfDnsFoundationStack` — long-lived Route 53 hosted zones + wildcard ACM certs for the vanity/redirect domains **getlift.md** and **liftmd.app**, in the **prod** account, **us-east-1** (CloudFront-ready).

## Why a separate stack
These zones own registrar delegation — their NS records get pasted into each registrar exactly once. Keeping them out of the per-env edge/validator stacks means a validator `cdk destroy` can never orphan that delegation. Domains are driven off `VANITY_DOMAINS` in `config.ts`; the stack creates one zone + one wildcard cert (`domain` + `*.domain`) per entry and emits NS + zone-id outputs.

## Changes
- `dns-stack.ts` — new `LmwfDnsFoundationStack` (zone + wildcard cert per domain, NS/zone-id outputs).
- `config.ts` — `VANITY_DOMAINS = ['getlift.md', 'liftmd.app']`.
- `app.ts` — instantiate once for the prod account in us-east-1.
- `deploy-policy.json` — new `Route53HostedZoneLifecycle` statement so the deploy identity can `CreateHostedZone` (these actions can't be ARN-scoped — zone IDs don't exist pre-create).

## Verified
- `cdk synth LmwfDnsFoundationStack` clean; template has both zones, both wildcard certs, and the four outputs.
- `deploy-policy.json` re-validated as JSON (21 statements). Removed an illegal `Comment` element so the doc stays IAM-valid.

## Deploy ordering (important — DNS-validated certs need a resolvable zone)
1. `cdk deploy LmwfDnsFoundationStack` creates the zones fast, then **blocks on ACM cert validation**.
2. While it blocks, read each zone's NS records and paste them into the matching registrar (getlift.md at its external `.md` registrar — not Route 53; liftmd.app wherever it's registered).
3. Once delegation propagates, ACM validates and the deploy finishes, printing the NS outputs. If a registrar is slow and the cert times out, just re-run the deploy after delegation lands — the zone already exists, so it's idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)