### PR TITLE
fix(cdk): defer getlift.md cert + complete Route53 deploy perms

### DIFF
--- a/validator/cdk/config.ts
+++ b/validator/cdk/config.ts
@@ -92,9 +92,23 @@ export function envPrefix(env: EnvConfig): string {
   return `Lmwf${env.name.charAt(0).toUpperCase()}${env.name.slice(1)}`;
 }
 
+export interface VanityDomain {
+  /** Apex domain — gets its own hosted zone. */
+  domain: string;
+  /**
+   * Issue the wildcard ACM cert now. Keep `false` until the domain is
+   * registered AND its NS are delegated to this zone: a DNS-validated cert
+   * blocks the *entire stack's* CREATE until it validates, and an
+   * undelegated domain never will — it just times out and rolls back every
+   * other resource (including healthy zones). Defer the cert, ship the zone
+   * to hold stable NS, then flip to `true` once delegation is live.
+   */
+  issueCert: boolean;
+}
+
 /**
  * Vanity / redirect domains that get their own long-lived Route 53 hosted
- * zone + wildcard cert in the prod account, managed by the
+ * zone (+ optional wildcard cert) in the prod account, managed by the
  * LmwfDnsFoundationStack. Decoupled from ENVS because these are not validator
  * environments — they own registrar delegation and must outlive any app-stack
  * teardown.
@@ -103,4 +117,10 @@ export function envPrefix(env: EnvConfig): string {
  * domain is registered at an external registrar, and only its NS delegation
  * points at the zone created here.
  */
-export const VANITY_DOMAINS = ['getlift.md', 'liftmd.app'] as const;
+export const VANITY_DOMAINS: readonly VanityDomain[] = [
+  // Pending registration/enablement — zone only for now so we hold stable NS
+  // to hand the .md registrar the moment it's live. Flip to true + redeploy
+  // once delegated.
+  { domain: 'getlift.md', issueCert: false },
+  { domain: 'liftmd.app', issueCert: true },
+];

--- a/validator/cdk/deploy-policy.json
+++ b/validator/cdk/deploy-policy.json
@@ -260,30 +260,15 @@
       "Sid": "Route53DNS",
       "Effect": "Allow",
       "Action": [
-        "route53:ChangeResourceRecordSets",
-        "route53:GetHostedZone",
-        "route53:ListResourceRecordSets",
-        "route53:GetChange"
-      ],
-      "Resource": [
-        "arn:aws:route53:::hostedzone/Z082094022DMVFBOHDGOE",
-        "arn:aws:route53:::change/*"
-      ]
-    },
-    {
-      "Sid": "Route53HostedZoneLifecycle",
-      "Effect": "Allow",
-      "Action": [
         "route53:CreateHostedZone",
         "route53:DeleteHostedZone",
         "route53:GetHostedZone",
-        "route53:GetHostedZoneCount",
-        "route53:ListHostedZones",
-        "route53:ListHostedZonesByName",
         "route53:ChangeResourceRecordSets",
         "route53:ListResourceRecordSets",
         "route53:ChangeTagsForResource",
-        "route53:ListTagsForResource"
+        "route53:ListTagsForResource",
+        "route53:ListQueryLoggingConfigs",
+        "route53:GetChange"
       ],
       "Resource": "*"
     },

--- a/validator/cdk/dns-stack.ts
+++ b/validator/cdk/dns-stack.ts
@@ -2,10 +2,11 @@ import * as cdk from 'aws-cdk-lib';
 import * as acm from 'aws-cdk-lib/aws-certificatemanager';
 import * as route53 from 'aws-cdk-lib/aws-route53';
 import { Construct } from 'constructs';
+import type { VanityDomain } from './config';
 
 export interface LmwfDnsFoundationStackProps extends cdk.StackProps {
-  /** Vanity / redirect domains to create a zone + wildcard cert for. */
-  domains: readonly string[];
+  /** Vanity / redirect domains to create a zone (+ optional wildcard cert) for. */
+  domains: readonly VanityDomain[];
 }
 
 /**
@@ -35,7 +36,7 @@ export class LmwfDnsFoundationStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: LmwfDnsFoundationStackProps) {
     super(scope, id, props);
 
-    for (const domain of props.domains) {
+    for (const { domain, issueCert } of props.domains) {
       const cid = domainToConstructId(domain);
 
       const zone = new route53.HostedZone(this, `${cid}Zone`, {
@@ -43,13 +44,18 @@ export class LmwfDnsFoundationStack extends cdk.Stack {
         comment: `LiftMark vanity domain ${domain} — created by CDK`,
       });
 
-      new acm.Certificate(this, `${cid}Cert`, {
-        domainName: domain,
-        // Wildcard SAN covers future subdomains (www.*, app.*, …) without a
-        // cert rotation — mirrors the per-env edge cert.
-        subjectAlternativeNames: [`*.${domain}`],
-        validation: acm.CertificateValidation.fromDns(zone),
-      });
+      // Deferred until the domain is registered + delegated (see VanityDomain
+      // docs): a DNS-validated cert blocks the whole stack's CREATE until it
+      // validates, which an undelegated domain never does.
+      if (issueCert) {
+        new acm.Certificate(this, `${cid}Cert`, {
+          domainName: domain,
+          // Wildcard SAN covers future subdomains (www.*, app.*, …) without a
+          // cert rotation — mirrors the per-env edge cert.
+          subjectAlternativeNames: [`*.${domain}`],
+          validation: acm.CertificateValidation.fromDns(zone),
+        });
+      }
 
       new cdk.CfnOutput(this, `${cid}ZoneId`, {
         value: zone.hostedZoneId,


### PR DESCRIPTION
Follow-up to #202, applying what the live prod deploy of `LmwfDnsFoundationStack` surfaced. **Already deployed to prod** (stack `CREATE_COMPLETE`); this lands the code so the repo matches AWS.

## 1. Per-domain cert deferral
A DNS-validated ACM cert blocks the **whole stack's CREATE** until it validates — which an undelegated domain never does. `getlift.md` isn't registered yet (`.md` enablement pending), so bundling its cert wedged the stack, and a timeout would have rolled back the healthy `liftmd.app` zone too.

`VANITY_DOMAINS` entries now carry an `issueCert` flag:
- **getlift.md** → zone only (holds stable NS to hand the registrar once `.md` is live); flip `issueCert: true` + redeploy when delegated.
- **liftmd.app** → zone + wildcard cert now.

## 2. CFN exec-role Route53 permissions
The scoped `LmwfCdkDeployPolicy` was missing actions the `AWS::Route53::HostedZone` resource handler calls:
- `CreateHostedZone` / `DeleteHostedZone` (create + rollback)
- `ListQueryLoggingConfigs` (delete handler)

Merged them into the `Route53DNS` statement and broadened it to `Resource: "*"`. `CreateHostedZone` can't be ARN-scoped (zone ID doesn't exist pre-create), and merging (vs. a second statement) kept the managed policy under IAM's 6,144-char limit. **Trade-off:** the deploy role can now change records in any prod zone, not just `liftmark.app` — acceptable since it already creates zones from scratch in this account. The live policy is at **v7**; `iam/refresh-deploy-policy.sh prod` reproduces it from this JSON.

## Verified live
- `LmwfDnsFoundationStack` `CREATE_COMPLETE` in prod.
- `liftmd.app` zone `Z012021614MHG0QJASF2Z`, cert **ISSUED** (`liftmd.app` + `*.liftmd.app`).
- `getlift.md` zone `Z0563826KGPGB50NU8HX`, NS held, no cert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)