### PR TITLE
feat(cdk): issue getlift.md wildcard cert (delegation live)

### DIFF
--- a/validator/cdk/config.ts
+++ b/validator/cdk/config.ts
@@ -118,9 +118,8 @@ export interface VanityDomain {
  * points at the zone created here.
  */
 export const VANITY_DOMAINS: readonly VanityDomain[] = [
-  // Pending registration/enablement — zone only for now so we hold stable NS
-  // to hand the .md registrar the moment it's live. Flip to true + redeploy
-  // once delegated.
-  { domain: 'getlift.md', issueCert: false },
+  // Registered + delegated to the zone's AWS nameservers (2026-06-02), so the
+  // wildcard cert can now validate via DNS.
+  { domain: 'getlift.md', issueCert: true },
   { domain: 'liftmd.app', issueCert: true },
 ];


### PR DESCRIPTION
getlift.md is now registered and its registrar (Netim) delegates to the zone's AWS nameservers (verified live 2026-06-02 — `dig NS getlift.md` returns ns-1334/733/394/1908.awsdns-*). Flips `issueCert: true` so `LmwfDnsFoundationStack` creates the `getlift.md` + `*.getlift.md` wildcard cert and validates it via the now-live DNS delegation.

Completes the deferral introduced in #204. Deploy run against prod alongside this PR; cert validation confirmed before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)