### PR TITLE
feat(web): canonicalize to getlift.md (302 redirects from liftmark.app + liftmd.app)

### DIFF
--- a/spec/services/lmwf-validator.md
+++ b/spec/services/lmwf-validator.md
@@ -143,13 +143,42 @@ Matches the iOS parser error and warning codes exactly:
 ## Test Parity
 The TypeScript parser MUST pass the same test cases as the native iOS parser (`MarkdownParserTests.swift`). Both parsers must produce identical results for identical inputs. Any new test case added to either parser must be added to both.
 
+## Domains & Hosting Topology
+
+The service is fronted by CloudFront. As of the canonical-domain change, the
+public website lives at **`getlift.md`**; `liftmark.app` and `liftmd.app` are
+retained for the iOS app's API + password-autofill needs and for redirecting
+legacy traffic to the canonical site. This is **prod-only** — beta is unaffected
+and continues to serve everything (site + API) from `beta.liftmark.app`.
+
+| Domain | Role | Site pages (`/`, `/install.sh`, …) | API paths (`/validate`, `/v1/*`, `/version`) | `/.well-known/apple-app-site-association` |
+|---|---|---|---|---|
+| **`getlift.md`** | Canonical site | **Serves** (own CloudFront distribution; same S3 `website/dist` content + same API proxy behaviors) | **Serves** | Serves (200, `application/json`, no redirect) |
+| **`liftmark.app`** | App API + AASA host; legacy site → redirect | **302 → `getlift.md`** (same path) | **Serves** (unchanged — iOS app calls these) | **Serves** (unchanged — Apple does NOT follow redirects for AASA, so it must NOT be redirected) |
+| **`workoutformat.liftmark.app`** | Legacy alias of `liftmark.app` | **302 → `getlift.md`** | Serves | Serves |
+| **`liftmd.app`** | Legacy short domain | **302 → `getlift.md`** (everything) | 302 → `getlift.md` | 302 → `getlift.md` |
+| **`beta.liftmark.app`** | Beta (all-in-one) | Serves | Serves | Serves |
+
+Redirect semantics:
+
+- Redirects are **302 (temporary)** initially; they are to be promoted to **301
+  (permanent)** once the canonical move is proven stable.
+- On `liftmark.app` / `workoutformat.liftmark.app` the redirect applies **only**
+  to site pages. The API paths (`/validate`, `/v1/*`, `/version`) and the AASA
+  path (`/.well-known/apple-app-site-association`) are explicitly excluded so the
+  shipped iOS app's API calls and password autofill keep working without a new
+  build. Per-path redirect/exclusion is implemented as a CloudFront Function (not
+  a second `BucketDeployment` / Lambda@Edge — see the BucketDeployment layer-limit
+  constraint in the AASA section of `password-manager.md`).
+- `liftmd.app` redirects **all** paths (it never hosted the app's API or AASA).
+
 ## Deployment
 - Runtime: Node.js 22 on AWS Lambda (arm64)
-- Infrastructure: AWS CDK (`validator/cdk/`) — edge stack (us-east-1: hosted zone, ACM cert, CLOUDFRONT-scoped WAFv2 web ACL) + main stack (Lambda, HTTP API, DynamoDB, CloudFront, DNS, alarms)
+- Infrastructure: AWS CDK (`validator/cdk/`) — edge stack (us-east-1: hosted zone, ACM cert, CLOUDFRONT-scoped WAFv2 web ACL) + main stack (Lambda, HTTP API, DynamoDB, CloudFront, DNS, alarms). In prod the canonical `getlift.md` distribution serves the site + API, while the `liftmark.app` / `liftmd.app` distributions handle the redirect topology above.
 - The public `/validate` and `/version` endpoints require no authentication; the `/v1/*` auth/PAT/workout routes are bearer-authenticated (session JWT or PAT)
 
 ### Edge security controls
-- **CORS**: explicit origin allowlist (no wildcard), derived per-env via `corsAllowedOrigins()` in `validator/cdk/config.ts` — the env site domain, the legacy `workoutformat.` prod subdomain, and (beta only) the local Astro dev origin. `allowCredentials: true` so the SameSite refresh-token cookie flow works.
+- **CORS**: explicit origin allowlist (no wildcard), derived per-env via `corsAllowedOrigins()` in `validator/cdk/config.ts` — the env site domain (prod: the canonical `getlift.md`, plus `liftmark.app` and its legacy `workoutformat.` subdomain so requests originating from the redirecting hosts still pass), and (beta only) the local Astro dev origin. `allowCredentials: true` so the SameSite refresh-token cookie flow works.
 - **Security response headers**: a CloudFront `ResponseHeadersPolicy` is attached to every behavior — strict CSP (`default-src 'self'`, no `unsafe-inline`; inline site scripts load via CSP hashes), HSTS (1y, includeSubDomains, preload), `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY` + `frame-ancestors 'none'`, `Referrer-Policy: strict-origin-when-cross-origin`.
 - **WAF**: CLOUDFRONT-scoped WAFv2 web ACL (in the us-east-1 edge stack, wired to the distribution via `crossRegionReferences`) — AWS managed rule groups (Common, KnownBadInputs, AmazonIpReputationList), a broad per-IP rate limit, and a stricter per-IP rate-based rule scoped to `/v1/auth/*` to blunt credential stuffing. Per-account application lockout is a deferred follow-up (needs a DDB counter table).
 - **Access logging**: the HTTP API stage writes a JSON access log (source IP, route, status, auth subject/principal) to CloudWatch Logs.

--- a/spec/services/password-manager.md
+++ b/spec/services/password-manager.md
@@ -144,6 +144,20 @@ Two stack behaviours would otherwise break this and are explicitly handled in
 The default CloudFront behaviour serves S3, so `/.well-known/*` is **not**
 routed to the `/validate`, `/v1/*`, or `/version` API origins.
 
+### Canonical domain & redirects
+
+The canonical website domain is **`getlift.md`** (see "Domains & Hosting
+Topology" in `lmwf-validator.md`). `liftmark.app` now 302-redirects its **site
+pages** to `getlift.md`, but the AASA is the load-bearing exception: Apple's
+`webcredentials` fetcher does **not** follow redirects, so
+`https://liftmark.app/.well-known/apple-app-site-association` MUST keep returning
+the file directly (HTTP 200, no redirect). The same exclusion applies to the
+app's API paths (`/validate`, `/v1/*`, `/version`). The associated-domains
+entitlement still targets `webcredentials:liftmark.app`, so AASA hosting stays on
+`liftmark.app` even though the marketing site has moved. (`liftmd.app` redirects
+everything, including `/.well-known/*`, because it never hosted the app's
+entitlement.)
+
 ## Deploy / order-of-operations
 
 `website/dist` is **gitignored** and rebuilt fresh (`npm run build`) by the

--- a/spec/services/validator-e2e.md
+++ b/spec/services/validator-e2e.md
@@ -286,11 +286,13 @@ The suite runs in three modes, selected by env var `LMWF_E2E_MODE`:
   suite calls the test-only `/v1/__test__/mint-token` endpoint
   (see below) to obtain verification + reset tokens without inspecting
   email.
-- `remote:prod` — reserved for ad-hoc verification against
-  `https://liftmark.app`. Prod intentionally does NOT set the
-  `E2E_TEST_SECRET` env var, so token-mint is unavailable — only the
-  no-auth-required tests (`home.spec.ts`, `spec-page.spec.ts`) execute.
-  Not wired into any pipeline; runnable locally for incident response.
+- `remote:prod` — reserved for ad-hoc verification against the canonical
+  prod site `https://getlift.md` (and the redirect/legacy hosts —
+  see "Canonical-domain redirect topology" below). Prod intentionally
+  does NOT set the `E2E_TEST_SECRET` env var, so token-mint is
+  unavailable — only the no-auth-required tests (`home.spec.ts`,
+  `spec-page.spec.ts`, and the redirect-topology checks) execute. Not
+  wired into any pipeline; runnable locally for incident response.
 
 ## Test-only token endpoint
 
@@ -364,6 +366,30 @@ website bucket.
 
 This keeps E2E hitting a single origin (no CORS, no proxy config)
 while the production topology stays untouched.
+
+## Canonical-domain redirect topology (`remote:prod` only)
+
+The prod canonical site is `getlift.md`; `liftmark.app` (and its legacy
+`workoutformat.liftmark.app` alias) and `liftmd.app` redirect to it, with
+explicit non-redirect exceptions for the app's API + AASA paths (see
+"Domains & Hosting Topology" in `lmwf-validator.md`). This topology is a
+prod-only deploy concern, so it is verified only in `remote:prod` mode and
+is **not** wired into the pipeline (beta is single-origin and unaffected).
+
+These are HTTP-level checks (status / `Location` / `Content-Type`), run
+with redirect-following disabled so the redirect itself is observable:
+
+| # | Request | Expectation |
+|---|---------|-------------|
+| 1 | `GET https://getlift.md/` | 200, serves the site (canonical home page) |
+| 2 | `GET https://getlift.md/validate` (or `POST`) | reaches the validator API (not a redirect) |
+| 3 | `GET https://liftmark.app/` (a site page) | **302**, `Location: https://getlift.md/` (same path) |
+| 4 | `POST https://liftmark.app/validate` | **200** — served directly, **NOT** redirected (shipped iOS app depends on this) |
+| 5 | `GET https://liftmark.app/.well-known/apple-app-site-association` | **200**, `Content-Type: application/json`, **NOT** redirected (Apple does not follow redirects) |
+| 6 | `GET https://liftmd.app/` (and any path) | **302**, `Location: https://getlift.md/…` |
+
+Redirects are **302** today; when they are promoted to **301**, update
+the expected status in checks 3 and 6 accordingly.
 
 ## Pipeline integration
 

--- a/validator/cdk/app.ts
+++ b/validator/cdk/app.ts
@@ -12,6 +12,29 @@ const commonTags = {
   Service: 'lmwf-validator',
 };
 
+// Vanity / redirect domains — long-lived zones + wildcard certs in the prod
+// account, decoupled from any validator env so an app teardown can't orphan
+// registrar delegation. us-east-1 so the certs are CloudFront-ready. Created
+// before the env loop so the prod stack can serve / redirect these domains.
+const dnsFoundation = new LmwfDnsFoundationStack(app, 'LmwfDnsFoundationStack', {
+  description: 'LiftMark vanity-domain hosted zones + wildcard certs (getlift.md, liftmd.app)',
+  env: { account: ENVS.prod.account, region: 'us-east-1' },
+  tags: { ...commonTags, Service: 'lmwf-dns' },
+  domains: VANITY_DOMAINS,
+});
+
+/** Resolve a vanity domain to its {domain, zone, certificate} from the DNS stack. */
+function vanityWebDomain(domain: string) {
+  const zone = dnsFoundation.zonesByDomain[domain];
+  const certificate = dnsFoundation.certsByDomain[domain];
+  if (!zone || !certificate) {
+    throw new Error(
+      `canonical/redirect domain "${domain}" needs a zone + issued cert in VANITY_DOMAINS (issueCert: true)`,
+    );
+  }
+  return { domain, zone, certificate };
+}
+
 for (const cfg of Object.values(ENVS)) {
   const prefix = envPrefix(cfg);
   const tags = { ...commonTags, Env: cfg.name };
@@ -25,6 +48,16 @@ for (const cfg of Object.values(ENVS)) {
     envConfig: cfg,
   });
 
+  // When the env canonicalises to a vanity domain, hand the prod stack the
+  // canonical site's zone + cert plus each redirect domain's zone + cert.
+  const canonicalWeb =
+    cfg.canonicalWebDomain && cfg.canonicalWebDomain !== cfg.domainName
+      ? vanityWebDomain(cfg.canonicalWebDomain)
+      : undefined;
+  const redirectWeb = canonicalWeb
+    ? (cfg.redirectWebDomains ?? []).map(vanityWebDomain)
+    : [];
+
   // Main stack — Lambda, HTTP API, DDB, CloudFront, DNS, alarms.
   new LmwfValidatorStack(app, `${prefix}ValidatorStack`, {
     description: `LMWF Validator (${cfg.name}) - LiftMark Workout Format validation service`,
@@ -35,15 +68,7 @@ for (const cfg of Object.values(ENVS)) {
     hostedZone: edge.hostedZone,
     cloudFrontCertificate: edge.certificate,
     webAclArn: edge.webAclArn,
+    canonicalWeb,
+    redirectWeb,
   });
 }
-
-// Vanity / redirect domains — long-lived zones + wildcard certs in the prod
-// account, decoupled from any validator env so an app teardown can't orphan
-// registrar delegation. us-east-1 so the certs are CloudFront-ready.
-new LmwfDnsFoundationStack(app, 'LmwfDnsFoundationStack', {
-  description: 'LiftMark vanity-domain hosted zones + wildcard certs (getlift.md, liftmd.app)',
-  env: { account: ENVS.prod.account, region: 'us-east-1' },
-  tags: { ...commonTags, Service: 'lmwf-dns' },
-  domains: VANITY_DOMAINS,
-});

--- a/validator/cdk/config.ts
+++ b/validator/cdk/config.ts
@@ -15,6 +15,23 @@ export interface EnvConfig {
   region: string;
   /** Apex (or near-apex) domain served by CloudFront for this env. */
   domainName: string;
+  /**
+   * Canonical web domain for the env. When set AND different from
+   * `domainName`, the site is served at this domain and `domainName` (plus any
+   * `redirectWebDomains`) 302-redirect their site pages here — preserving path
+   * + query. API paths (`/validate`, `/v1/*`, `/version`) and the AASA file are
+   * NOT redirected on `domainName`, so the iOS app and installed-app password
+   * autofill keep working. The canonical domain's zone + cert come from the
+   * LmwfDnsFoundationStack (passed in via stack props). Leave undefined to keep
+   * `domainName` as the canonical site (beta).
+   */
+  canonicalWebDomain?: string;
+  /**
+   * Extra domains whose site pages 302-redirect to `canonicalWebDomain`
+   * (full redirect — no API/AASA carve-out). Each needs a zone + cert from the
+   * LmwfDnsFoundationStack. Ignored unless `canonicalWebDomain` is set.
+   */
+  redirectWebDomains?: readonly string[];
   /** Stripe API mode. Used by app code to pick test vs live keys. */
   stripeMode: 'test' | 'live';
   /**
@@ -57,6 +74,12 @@ export function corsAllowedOrigins(env: EnvConfig): string[] {
   if (env.name === 'prod') {
     origins.push(`https://workoutformat.${env.domainName}`);
   }
+  // The canonical site (getlift.md) makes credentialed, same-origin API calls
+  // through its own CloudFront, so its origin must be allowed too. domainName
+  // stays in the list during the transition (it still proxies the API).
+  if (env.canonicalWebDomain && env.canonicalWebDomain !== env.domainName) {
+    origins.push(`https://${env.canonicalWebDomain}`);
+  }
   if (env.allowLocalDevOrigin) {
     origins.push(LOCAL_DEV_ORIGIN);
   }
@@ -81,6 +104,11 @@ export const ENVS: Record<EnvName, EnvConfig> = {
     account: '825347768149',
     region: 'us-west-2',
     domainName: 'liftmark.app',
+    // getlift.md is the canonical brand site; liftmark.app + liftmd.app
+    // redirect to it (liftmark.app keeps serving the API + AASA). Zones/certs
+    // for both come from the LmwfDnsFoundationStack.
+    canonicalWebDomain: 'getlift.md',
+    redirectWebDomains: ['liftmd.app'],
     stripeMode: 'live',
     sesMailFromSubdomain: 'mail',
     dmarcPolicy: 'v=DMARC1; p=none;',

--- a/validator/cdk/dns-stack.ts
+++ b/validator/cdk/dns-stack.ts
@@ -33,6 +33,14 @@ export interface LmwfDnsFoundationStackProps extends cdk.StackProps {
  * after delegation lands; the zone already exists so it's idempotent.
  */
 export class LmwfDnsFoundationStack extends cdk.Stack {
+  /** Hosted zone per vanity domain, for other stacks to add records to. */
+  public readonly zonesByDomain: Record<string, route53.IHostedZone> = {};
+  /**
+   * Issued wildcard cert per vanity domain (us-east-1, CloudFront-ready).
+   * Only present for domains with `issueCert: true`.
+   */
+  public readonly certsByDomain: Record<string, acm.ICertificate> = {};
+
   constructor(scope: Construct, id: string, props: LmwfDnsFoundationStackProps) {
     super(scope, id, props);
 
@@ -43,12 +51,13 @@ export class LmwfDnsFoundationStack extends cdk.Stack {
         zoneName: domain,
         comment: `LiftMark vanity domain ${domain} — created by CDK`,
       });
+      this.zonesByDomain[domain] = zone;
 
       // Deferred until the domain is registered + delegated (see VanityDomain
       // docs): a DNS-validated cert blocks the whole stack's CREATE until it
       // validates, which an undelegated domain never does.
       if (issueCert) {
-        new acm.Certificate(this, `${cid}Cert`, {
+        this.certsByDomain[domain] = new acm.Certificate(this, `${cid}Cert`, {
           domainName: domain,
           // Wildcard SAN covers future subdomains (www.*, app.*, …) without a
           // cert rotation — mirrors the per-env edge cert.

--- a/validator/cdk/stack.ts
+++ b/validator/cdk/stack.ts
@@ -74,6 +74,44 @@ function createTable(
   return table;
 }
 
+/**
+ * CloudFront Function (viewer-request) body that 302-redirects to
+ * `canonicalHost`, preserving path + query. When `keepWellKnown` is true,
+ * `/.well-known/*` is served from origin instead of redirected — required so
+ * Apple can fetch the AASA file directly (it does not follow redirects).
+ * The redirect is returned at the edge; the origin is never reached.
+ */
+function redirectFnCode(canonicalHost: string, keepWellKnown: boolean): string {
+  const wellKnownGuard = keepWellKnown
+    ? "  if (request.uri.indexOf('/.well-known/') === 0) { return request; }\n"
+    : '';
+  return `
+function handler(event) {
+  var request = event.request;
+${wellKnownGuard}  var qs = '';
+  var keys = Object.keys(request.querystring);
+  if (keys.length > 0) {
+    qs = '?' + keys.map(function (k) {
+      var v = request.querystring[k];
+      return v.value !== '' ? k + '=' + v.value : k;
+    }).join('&');
+  }
+  return {
+    statusCode: 302,
+    statusDescription: 'Found',
+    headers: { 'location': { value: 'https://${canonicalHost}' + request.uri + qs } },
+  };
+}
+`;
+}
+
+/** A vanity domain's zone + cert (from LmwfDnsFoundationStack) for the prod stack. */
+export interface WebDomainRef {
+  domain: string;
+  zone: route53.IHostedZone;
+  certificate: acm.ICertificate;
+}
+
 export interface LmwfValidatorStackProps extends cdk.StackProps {
   envConfig: EnvConfig;
   hostedZone: route53.IHostedZone;
@@ -84,6 +122,15 @@ export interface LmwfValidatorStackProps extends cdk.StackProps {
    * `webAclId`.
    */
   webAclArn: string;
+  /**
+   * When set, the site is served canonically at this domain (its own
+   * CloudFront, same S3 + API origins) and `domainName`'s default behavior
+   * 302-redirects site pages here (API paths + AASA stay). Comes from
+   * EnvConfig.canonicalWebDomain resolved against the DNS foundation stack.
+   */
+  canonicalWeb?: WebDomainRef;
+  /** Domains that 302-redirect entirely to `canonicalWeb` (e.g. liftmd.app). */
+  redirectWeb?: readonly WebDomainRef[];
 }
 
 export class LmwfValidatorStack extends cdk.Stack {
@@ -91,6 +138,7 @@ export class LmwfValidatorStack extends cdk.Stack {
     super(scope, id, props);
 
     const { envConfig, hostedZone, cloudFrontCertificate, webAclArn } = props;
+    const { canonicalWeb, redirectWeb = [] } = props;
     const env = envConfig; // shorthand for the rest of this constructor
     const domainName = env.domainName;
 
@@ -419,6 +467,22 @@ function handler(event) {
       comment: 'Set content-type: application/json for the AASA file',
     });
 
+    // Canonical-domain redirect functions (only when the env canonicalises to a
+    // vanity domain). One keeps /.well-known/* on the source domain (so AASA +
+    // password autofill survive); the other redirects everything.
+    const redirectExceptWellKnownFn = canonicalWeb
+      ? new cloudfront.Function(this, 'RedirectToCanonicalFn', {
+          code: cloudfront.FunctionCode.fromInline(redirectFnCode(canonicalWeb.domain, true)),
+          comment: `302 site pages to https://${canonicalWeb.domain} (serves /.well-known/* locally)`,
+        })
+      : undefined;
+    const redirectAllFn = canonicalWeb
+      ? new cloudfront.Function(this, 'RedirectAllToCanonicalFn', {
+          code: cloudfront.FunctionCode.fromInline(redirectFnCode(canonicalWeb.domain, false)),
+          comment: `302 everything to https://${canonicalWeb.domain}`,
+        })
+      : undefined;
+
     const s3Origin = origins.S3BucketOrigin.withOriginAccessControl(siteBucket);
     const apiOrigin = new origins.HttpOrigin(apiHostname, {
       protocolPolicy: cloudfront.OriginProtocolPolicy.HTTPS_ONLY,
@@ -486,70 +550,134 @@ function handler(event) {
         ? [domainName, `workoutformat.${domainName}`]
         : [domainName];
 
-    const distribution = new cloudfront.Distribution(this, 'SiteDistribution', {
-      defaultRootObject: 'index.html',
-      domainNames: cfDomainNames,
-      certificate: cloudFrontCertificate,
-      // CLOUDFRONT-scoped WAFv2 web ACL (managed rules + rate limits),
-      // created in the us-east-1 edge stack and resolved here via
-      // crossRegionReferences. (M3)
-      webAclId: webAclArn,
-      priceClass: cloudfront.PriceClass.PRICE_CLASS_100,
-      httpVersion: cloudfront.HttpVersion.HTTP2_AND_3,
-      minimumProtocolVersion: cloudfront.SecurityPolicyProtocol.TLS_V1_2_2021,
-      comment: `LMWF ${env.name} — ${domainName} (S3 static + /validate origin)`,
-      defaultBehavior: {
-        origin: s3Origin,
-        viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
-        responseHeadersPolicy,
-        cachePolicy:
-          env.name === 'beta'
-            ? cloudfront.CachePolicy.CACHING_DISABLED
-            : cloudfront.CachePolicy.CACHING_OPTIMIZED,
-        allowedMethods: cloudfront.AllowedMethods.ALLOW_GET_HEAD_OPTIONS,
-        compress: true,
-        functionAssociations: [
-          {
-            eventType: cloudfront.FunctionEventType.VIEWER_REQUEST,
-            function: urlRewriteFunction,
-          },
-          {
-            // Sets content-type: application/json on the AASA response.
-            eventType: cloudfront.FunctionEventType.VIEWER_RESPONSE,
-            function: aasaContentTypeFunction,
-          },
-        ],
-      },
-      additionalBehaviors: {
-        '/validate': {
-          origin: apiOrigin,
-          viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
-          responseHeadersPolicy,
-          cachePolicy: cloudfront.CachePolicy.CACHING_DISABLED,
-          originRequestPolicy: cloudfront.OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
-          allowedMethods: cloudfront.AllowedMethods.ALLOW_ALL,
-          compress: false,
-        },
-        '/v1/*': {
-          origin: apiOrigin,
-          viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
-          responseHeadersPolicy,
-          cachePolicy: cloudfront.CachePolicy.CACHING_DISABLED,
-          originRequestPolicy: cloudfront.OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
-          allowedMethods: cloudfront.AllowedMethods.ALLOW_ALL,
-          compress: true,
-        },
-        '/version': {
-          origin: apiOrigin,
-          viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
-          responseHeadersPolicy,
-          cachePolicy: cloudfront.CachePolicy.CACHING_DISABLED,
-          originRequestPolicy: cloudfront.OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
-          allowedMethods: cloudfront.AllowedMethods.ALLOW_ALL,
-          compress: true,
-        },
-      },
+    // Shared API proxy behaviors — identical on every site distribution so the
+    // website's same-origin /validate + /v1/* calls work wherever it's served.
+    const apiBehavior = (compress: boolean): cloudfront.BehaviorOptions => ({
+      origin: apiOrigin,
+      viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+      responseHeadersPolicy,
+      cachePolicy: cloudfront.CachePolicy.CACHING_DISABLED,
+      originRequestPolicy: cloudfront.OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
+      allowedMethods: cloudfront.AllowedMethods.ALLOW_ALL,
+      compress,
     });
+    const apiBehaviors: Record<string, cloudfront.BehaviorOptions> = {
+      '/validate': apiBehavior(false),
+      '/v1/*': apiBehavior(true),
+      '/version': apiBehavior(true),
+    };
+
+    // Builds a full site distribution (S3 static default + API proxy).
+    // `requestFn` is the default behavior's viewer-request function: the
+    // pretty-URL rewriter when this distribution serves the site, or the
+    // redirect-except-/.well-known function when it only redirects.
+    const buildSiteDistribution = (
+      id: string,
+      aliases: string[],
+      certificate: acm.ICertificate,
+      requestFn: cloudfront.IFunction,
+    ): cloudfront.Distribution =>
+      new cloudfront.Distribution(this, id, {
+        defaultRootObject: 'index.html',
+        domainNames: aliases,
+        certificate,
+        // CLOUDFRONT-scoped WAFv2 web ACL (managed rules + rate limits),
+        // created in the us-east-1 edge stack and resolved here via
+        // crossRegionReferences. (M3)
+        webAclId: webAclArn,
+        priceClass: cloudfront.PriceClass.PRICE_CLASS_100,
+        httpVersion: cloudfront.HttpVersion.HTTP2_AND_3,
+        minimumProtocolVersion: cloudfront.SecurityPolicyProtocol.TLS_V1_2_2021,
+        comment: `LMWF ${env.name} — ${aliases[0]} (S3 static + /validate origin)`,
+        defaultBehavior: {
+          origin: s3Origin,
+          viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+          responseHeadersPolicy,
+          cachePolicy:
+            env.name === 'beta'
+              ? cloudfront.CachePolicy.CACHING_DISABLED
+              : cloudfront.CachePolicy.CACHING_OPTIMIZED,
+          allowedMethods: cloudfront.AllowedMethods.ALLOW_GET_HEAD_OPTIONS,
+          compress: true,
+          functionAssociations: [
+            { eventType: cloudfront.FunctionEventType.VIEWER_REQUEST, function: requestFn },
+            // Sets content-type: application/json on the AASA response.
+            { eventType: cloudfront.FunctionEventType.VIEWER_RESPONSE, function: aasaContentTypeFunction },
+          ],
+        },
+        additionalBehaviors: apiBehaviors,
+      });
+
+    // liftmark.app (+ legacy workoutformat.) distribution. Logical id stays
+    // 'SiteDistribution' so this is an in-place update, not a replacement. In
+    // canonical mode its default behavior 302-redirects site pages to the
+    // canonical host (API behaviors + AASA still served locally); otherwise it
+    // serves the site (beta).
+    const distribution = buildSiteDistribution(
+      'SiteDistribution',
+      cfDomainNames,
+      cloudFrontCertificate,
+      redirectExceptWellKnownFn ?? urlRewriteFunction,
+    );
+
+    // Apex + www A/AAAA alias records pointing a zone at a distribution.
+    const aliasZoneToDistribution = (
+      idPrefix: string,
+      zone: route53.IHostedZone,
+      dist: cloudfront.Distribution,
+    ) => {
+      for (const [label, idSuffix] of [['', ''], ['www', 'Www']] as const) {
+        new route53.ARecord(this, `${idPrefix}Alias${idSuffix}`, {
+          zone,
+          recordName: label || undefined,
+          target: route53.RecordTarget.fromAlias(new route53targets.CloudFrontTarget(dist)),
+        });
+        new route53.AaaaRecord(this, `${idPrefix}AliasIpv6${idSuffix}`, {
+          zone,
+          recordName: label || undefined,
+          target: route53.RecordTarget.fromAlias(new route53targets.CloudFrontTarget(dist)),
+        });
+      }
+    };
+
+    // Canonical site (e.g. getlift.md) + full-redirect vanity domains
+    // (e.g. liftmd.app). Prod-only — gated on canonicalWeb being passed in.
+    let canonicalDistribution: cloudfront.Distribution | undefined;
+    if (canonicalWeb && redirectAllFn) {
+      canonicalDistribution = buildSiteDistribution(
+        'CanonicalSiteDistribution',
+        [canonicalWeb.domain, `www.${canonicalWeb.domain}`],
+        canonicalWeb.certificate,
+        urlRewriteFunction,
+      );
+      aliasZoneToDistribution('Canonical', canonicalWeb.zone, canonicalDistribution);
+
+      // Redirect-only vanity domains: a tiny distribution that 302s every path
+      // to the canonical host. The dummy S3 origin is never reached — the
+      // viewer-request function returns the redirect at the edge.
+      for (const r of redirectWeb) {
+        const cid = r.domain.replace(/[^a-z0-9]+/gi, '-');
+        const redirectDist = new cloudfront.Distribution(this, `Redirect-${cid}`, {
+          domainNames: [r.domain, `www.${r.domain}`],
+          certificate: r.certificate,
+          priceClass: cloudfront.PriceClass.PRICE_CLASS_100,
+          httpVersion: cloudfront.HttpVersion.HTTP2_AND_3,
+          minimumProtocolVersion: cloudfront.SecurityPolicyProtocol.TLS_V1_2_2021,
+          comment: `LMWF ${env.name} — ${r.domain} → https://${canonicalWeb.domain} (302)`,
+          defaultBehavior: {
+            origin: s3Origin,
+            viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+            responseHeadersPolicy,
+            cachePolicy: cloudfront.CachePolicy.CACHING_DISABLED,
+            allowedMethods: cloudfront.AllowedMethods.ALLOW_GET_HEAD_OPTIONS,
+            functionAssociations: [
+              { eventType: cloudfront.FunctionEventType.VIEWER_REQUEST, function: redirectAllFn },
+            ],
+          },
+        });
+        aliasZoneToDistribution(`Redirect${cid.replace(/-/g, '')}`, r.zone, redirectDist);
+      }
+    }
 
     // ── Static site upload + CloudFront invalidation ──
     // Built by the website workspace into ../../website/dist before
@@ -577,7 +705,11 @@ function handler(event) {
     new s3deploy.BucketDeployment(this, 'SiteContents', {
       sources: [s3deploy.Source.asset(siteDistPath)],
       destinationBucket: siteBucket,
-      distribution,
+      // Invalidate the live site's distribution. In canonical mode that's the
+      // canonical (getlift.md) distribution; otherwise the env apex. (The
+      // liftmark.app distribution mostly redirects + serves the rarely-changing
+      // AASA, so it doesn't need per-deploy invalidation.)
+      distribution: canonicalDistribution ?? distribution,
       distributionPaths: ['/*'],
       prune: true,
       // Default Lambda is 128 MiB / 900 s. Site is ~250 KiB today; bump

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -2,11 +2,12 @@
 import { defineConfig } from 'astro/config';
 
 export default defineConfig({
-  // Canonical domain. The format hub now lives at liftmark.app/format; the
+  // Canonical domain is now getlift.md; liftmark.app 302-redirects its site
+  // pages to getlift.md. The format hub lives at getlift.md/format; the
   // legacy workoutformat.liftmark.app subdomain still resolves to the same
   // CloudFront distribution (see validator/cdk/stack.ts), so old links keep
-  // working while canonical/OG/sitemap metadata points at the apex.
-  site: 'https://liftmark.app',
+  // working while canonical/OG/sitemap metadata points at getlift.md.
+  site: 'https://getlift.md',
   output: 'static',
   trailingSlash: 'ignore',
   // Old format URLs → new IA. Astro emits these as meta-refresh redirect

--- a/website/src/pages/format/index.astro
+++ b/website/src/pages/format/index.astro
@@ -183,7 +183,7 @@ const richHtml = highlightLmwf(richExample);
     <li><a href="/format/spec">Full specification</a> (also available as <a href="/spec.md">raw markdown</a>)</li>
     <li><a href="https://github.com/vfilby/liftmark" rel="external noopener">GitHub repository</a></li>
     <li>
-      Validator API: <code>POST https://liftmark.app/validate</code>
+      Validator API: <code>POST https://getlift.md/validate</code>
       with JSON body <code>&#123;"markdown": "..."&#125;</code>
     </li>
     <li><a href="/llms.txt">llms.txt</a> — machine-readable index for LLMs</li>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -27,11 +27,11 @@ import Base from '../layouts/Base.astro';
 
     <div class="install">
       <div class="install-body">
-        <code class="install-cmd"><span class="prompt">$</span>curl -fsSL https://liftmark.app/install.sh | sh</code>
+        <code class="install-cmd"><span class="prompt">$</span>curl -fsSL https://getlift.md/install.sh | sh</code>
         <button
           type="button"
           class="install-copy"
-          data-copy="curl -fsSL https://liftmark.app/install.sh | sh"
+          data-copy="curl -fsSL https://getlift.md/install.sh | sh"
           aria-label="Copy install command"
         >Copy</button>
       </div>

--- a/website/src/pages/install.sh.ts
+++ b/website/src/pages/install.sh.ts
@@ -2,10 +2,10 @@ import type { APIRoute } from 'astro';
 
 const script = `#!/usr/bin/env sh
 # lift.md format generate-workout — Claude Code skill installer.
-# See https://liftmark.app/format for docs.
+# See https://getlift.md/format for docs.
 set -eu
 DIR="\${CLAUDE_CONFIG_DIR:-$HOME/.claude}/skills/generate-workout"
-BASE="https://liftmark.app/skill"
+BASE="https://getlift.md/skill"
 mkdir -p "$DIR"
 curl -fsSL "$BASE/SKILL.md"    -o "$DIR/SKILL.md"
 curl -fsSL "$BASE/validate.sh" -o "$DIR/validate.sh"

--- a/website/src/pages/llms.txt.ts
+++ b/website/src/pages/llms.txt.ts
@@ -6,13 +6,13 @@ lift.md format (formerly "LMWF") is a markdown-based format for strength trainin
 
 ## Docs
 
-- [Format hub](https://liftmark.app/format): Pitch, examples, live validator, and the full spec.
-- [Full spec](https://liftmark.app/spec.md): Complete lift.md format specification in markdown.
-- [Validator API](https://liftmark.app/validate): POST JSON \`{"markdown": "..."}\` to validate lift.md format content. Returns \`{success, summary, errors, warnings}\`.
+- [Format hub](https://getlift.md/format): Pitch, examples, live validator, and the full spec.
+- [Full spec](https://getlift.md/spec.md): Complete lift.md format specification in markdown.
+- [Validator API](https://getlift.md/validate): POST JSON \`{"markdown": "..."}\` to validate lift.md format content. Returns \`{success, summary, errors, warnings}\`.
 
 ## Optional
 
-- [Claude Code skill installer](https://liftmark.app/install.sh): One-line installer (\`curl -fsSL https://liftmark.app/install.sh | sh\`) for a skill that generates and validates lift.md format workouts.
+- [Claude Code skill installer](https://getlift.md/install.sh): One-line installer (\`curl -fsSL https://getlift.md/install.sh | sh\`) for a skill that generates and validates lift.md format workouts.
 `;
 
 export const GET: APIRoute = () => {


### PR DESCRIPTION
Makes **getlift.md** the canonical website (prod-only). getlift.md serves the site + proxies the API; liftmark.app and liftmd.app 302-redirect to it.

## ⚠️ Merging triggers a prod deploy
This touches `validator/cdk`, so the CI pipeline will `cdk deploy` prod on merge — i.e. **liftmark.app starts redirecting to getlift.md** as soon as this lands. Redirects are **302 (temporary)** for now so it's reversible; promote to 301 later.

## What changes (verified via `cdk diff`)
- **SiteDistribution (liftmark.app + workoutformat.)** — *in-place* update: its default-behavior viewer-request function swaps to a 302→getlift.md redirect that **keeps `/.well-known/*` on-origin** (Apple doesn't follow redirects for AASA) and **keeps the `/validate`, `/v1/*`, `/version` API behaviors** (the iOS app calls `liftmark.app/v1/*`). No replacement.
- **CanonicalSiteDistribution (getlift.md + www)** — new; serves the site + same API proxy.
- **Redirect-liftmd.app** — new; 302s everything to getlift.md.
- New alias A/AAAA records in the getlift.md + liftmd.app zones; site-upload invalidation retargeted to the canonical distribution; CORS adds `https://getlift.md`.
- **beta untouched** (stays on beta.liftmark.app).

## Website
- `astro.config.mjs` `site:` → `https://getlift.md` (canonical/OG/sitemap).
- Self-referential URLs updated (install.sh, llms.txt, homepage install cmd, format validator-API doc). Build passes.

## Spec
- Domain/redirect topology + AASA carve-out documented in `lmwf-validator.md`, `password-manager.md`, `validator-e2e.md`.

## Not in this PR
- **iOS password autofill on getlift.md** (`webcredentials:getlift.md` entitlement) — separate PR, needs an App Store release. Until then autofill stays bound to liftmark.app (still works via the AASA carve-out).

## Verification done
`cdk diff LmwfProdValidatorStack`: SiteDistribution = in-place (function swap only), everything else additive `[+]`; beta diff = no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)