### PR TITLE
feat(auth): associate app with getlift.md for password autofill

### DIFF
--- a/mobile-apps/ios/LiftMark/LiftMark.entitlements
+++ b/mobile-apps/ios/LiftMark/LiftMark.entitlements
@@ -4,6 +4,7 @@
 <dict>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
+		<string>webcredentials:getlift.md</string>
 		<string>webcredentials:liftmark.app</string>
 	</array>
 	<key>com.apple.developer.healthkit</key>


### PR DESCRIPTION
Adds `webcredentials:getlift.md` to the associated-domains entitlement so iOS Password autofill works on getlift.md login pages, now that getlift.md is the canonical site (#206).

- Keeps `webcredentials:liftmark.app` so installed users keep autofill on the (now-redirecting) liftmark.app origin.
- No AASA content change: getlift.md serves the same `/.well-known/apple-app-site-association` as liftmark.app (same `website/dist` bucket).

## Ordering / dependencies
- **Depends on #206** deploying first — getlift.md must actually serve the AASA file before this entitlement does anything useful.
- ⚠️ Merging pushes to main → triggers a **TestFlight beta build** (per the release pipeline). The entitlement change reaches users only via an App Store release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)