### PR TITLE
fix(cdk): widen CFN exec policy to cover LmwfDnsFoundationStack (unblock prod deploy)

### DIFF
--- a/validator/cdk/deploy-policy.json
+++ b/validator/cdk/deploy-policy.json
@@ -28,8 +28,7 @@
         "cloudformation:DeleteChangeSet"
       ],
       "Resource": [
-        "arn:aws:cloudformation:*:*:stack/Lmwf*ValidatorStack/*",
-        "arn:aws:cloudformation:*:*:stack/Lmwf*EdgeStack/*",
+        "arn:aws:cloudformation:*:*:stack/Lmwf*Stack/*",
         "arn:aws:cloudformation:*:*:stack/LmwfCdkToolkit/*"
       ]
     },
@@ -53,8 +52,7 @@
         "lambda:ListTags"
       ],
       "Resource": [
-        "arn:aws:lambda:*:*:function:Lmwf*ValidatorStack-*",
-        "arn:aws:lambda:*:*:function:Lmwf*EdgeStack-*"
+        "arn:aws:lambda:*:*:function:Lmwf*Stack-*"
       ]
     },
     {
@@ -88,8 +86,7 @@
         "iam:UntagRole"
       ],
       "Resource": [
-        "arn:aws:iam::*:role/Lmwf*ValidatorStack-*",
-        "arn:aws:iam::*:role/Lmwf*EdgeStack-*",
+        "arn:aws:iam::*:role/Lmwf*Stack-*",
         "arn:aws:iam::*:role/cdk-lmwf-*"
       ]
     },
@@ -98,8 +95,7 @@
       "Effect": "Allow",
       "Action": "iam:PassRole",
       "Resource": [
-        "arn:aws:iam::*:role/Lmwf*ValidatorStack-*",
-        "arn:aws:iam::*:role/Lmwf*EdgeStack-*",
+        "arn:aws:iam::*:role/Lmwf*Stack-*",
         "arn:aws:iam::*:role/cdk-lmwf-*"
       ],
       "Condition": {
@@ -113,8 +109,7 @@
       "Effect": "Allow",
       "Action": "iam:AttachRolePolicy",
       "Resource": [
-        "arn:aws:iam::*:role/Lmwf*ValidatorStack-*",
-        "arn:aws:iam::*:role/Lmwf*EdgeStack-*",
+        "arn:aws:iam::*:role/Lmwf*Stack-*",
         "arn:aws:iam::*:role/cdk-lmwf-*"
       ],
       "Condition": {
@@ -138,8 +133,7 @@
         "logs:TagResource"
       ],
       "Resource": [
-        "arn:aws:logs:*:*:log-group:/aws/lambda/Lmwf*ValidatorStack-*",
-        "arn:aws:logs:*:*:log-group:/aws/lambda/Lmwf*EdgeStack-*"
+        "arn:aws:logs:*:*:log-group:/aws/lambda/Lmwf*Stack-*"
       ]
     },
     {


### PR DESCRIPTION
The getlift.md canonicalisation (#206) made the prod validator stack consume getlift.md/liftmd.app zone+cert refs **cross-region** from `LmwfDnsFoundationStack`, so CDK adds a `CrossRegionExportWriter` custom resource (IAM role + Lambda) to that stack. The scoped CFN exec policy only whitelisted `Lmwf*ValidatorStack-*` / `Lmwf*EdgeStack-*`, so `iam:CreateRole` on the new `LmwfDnsFoundationStack-*` role was denied → prod deploy rolled back.

Fix: collapse the per-stack ARN patterns to a single `Lmwf*Stack-*` across the Lambda, IAM (create/pass/attach), CloudFormation-write, and CloudWatch-logs statements. Covers Validator + Edge + DnsFoundation (and future `LmwfXxxStack`), and **shrinks** the managed policy (6051 → 5723 non-ws chars). Escalation surface unchanged — still our stack-named roles + the existing PassRole/AttachRolePolicy conditions.

Already applied live as **LmwfCdkDeployPolicy v8** (`iam/refresh-deploy-policy.sh`), and the failed prod deploy has been re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)