### PR TITLE
fix(cdk): complete exec-policy + smoke test for getlift.md canonical deploy

### DIFF
--- a/.github/workflows/validator-ci.yml
+++ b/.github/workflows/validator-ci.yml
@@ -492,4 +492,36 @@ jobs:
       - name: Smoke test prod
         run: |
           chmod +x validator/scripts/smoke-test-live.sh
-          validator/scripts/smoke-test-live.sh https://liftmark.app "${{ github.sha }}"
+          # getlift.md is the canonical site and also proxies the API, so the
+          # full smoke (static site + /version + /validate) runs against it.
+          validator/scripts/smoke-test-live.sh https://getlift.md "${{ github.sha }}"
+      - name: Verify canonical redirect topology
+        run: |
+          set -euo pipefail
+          fail() { echo "FAIL: $1" >&2; exit 2; }
+
+          # liftmark.app site page must 302 to getlift.md (preserving path).
+          loc=$(curl -s -o /dev/null -w '%{http_code} %{redirect_url}' https://liftmark.app/format)
+          echo "liftmark.app/format -> $loc"
+          [ "$loc" = "302 https://getlift.md/format" ] || fail "liftmark.app/format should 302 to getlift.md/format, got: $loc"
+
+          # liftmark.app must STILL serve the API directly (no redirect).
+          code=$(curl -s -o /dev/null -w '%{http_code}' -X POST -H 'Content-Type: application/json' \
+            -d '{"markdown":"# T\n## Squat\n- 100 lbs x 5\n"}' https://liftmark.app/validate)
+          echo "liftmark.app/validate -> $code"
+          [ "$code" = "200" ] || fail "liftmark.app/validate should be 200 (API not redirected), got: $code"
+
+          # AASA must be served directly (Apple does not follow redirects).
+          aasa=$(curl -s -o /dev/null -w '%{http_code} %{content_type} [%{redirect_url}]' https://liftmark.app/.well-known/apple-app-site-association)
+          echo "liftmark.app AASA -> $aasa"
+          case "$aasa" in
+            "200 application/json"*"[]") : ;;
+            *) fail "AASA must be 200/application/json with no redirect, got: $aasa" ;;
+          esac
+
+          # liftmd.app must 302 everything to getlift.md.
+          loc=$(curl -s -o /dev/null -w '%{http_code} %{redirect_url}' https://liftmd.app/)
+          echo "liftmd.app/ -> $loc"
+          [ "$loc" = "302 https://getlift.md/" ] || fail "liftmd.app/ should 302 to getlift.md/, got: $loc"
+
+          echo "✓ canonical redirect topology verified"

--- a/validator/cdk/deploy-policy-extra.json
+++ b/validator/cdk/deploy-policy-extra.json
@@ -1,0 +1,51 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "DynamoDBTables",
+      "Effect": "Allow",
+      "Action": [
+        "dynamodb:CreateTable",
+        "dynamodb:DescribeTable",
+        "dynamodb:UpdateTable",
+        "dynamodb:DeleteTable",
+        "dynamodb:DescribeContinuousBackups",
+        "dynamodb:UpdateContinuousBackups",
+        "dynamodb:DescribeTimeToLive",
+        "dynamodb:UpdateTimeToLive",
+        "dynamodb:TagResource",
+        "dynamodb:UntagResource",
+        "dynamodb:ListTagsOfResource"
+      ],
+      "Resource": [
+        "arn:aws:dynamodb:*:*:table/lmwf-*",
+        "arn:aws:dynamodb:*:*:table/lmwf-*/index/*"
+      ]
+    },
+    {
+      "Sid": "SESEmailIdentity",
+      "Effect": "Allow",
+      "Action": [
+        "ses:CreateEmailIdentity",
+        "ses:GetEmailIdentity",
+        "ses:DeleteEmailIdentity",
+        "ses:PutEmailIdentityMailFromAttributes",
+        "ses:PutEmailIdentityDkimAttributes",
+        "ses:PutEmailIdentityDkimSigningAttributes",
+        "ses:TagResource",
+        "ses:UntagResource",
+        "ses:ListTagsForResource"
+      ],
+      "Resource": "arn:aws:ses:*:*:identity/*"
+    },
+    {
+      "Sid": "WAFv2WebAclRead",
+      "Effect": "Allow",
+      "Action": [
+        "wafv2:GetWebACL",
+        "wafv2:ListTagsForResource"
+      ],
+      "Resource": "arn:aws:wafv2:us-east-1:*:global/webacl/lmwf-*"
+    }
+  ]
+}

--- a/validator/cdk/deploy-policy.json
+++ b/validator/cdk/deploy-policy.json
@@ -166,8 +166,8 @@
       "Effect": "Allow",
       "Action": "s3:*",
       "Resource": [
-        "arn:aws:s3:::liftmark-workoutformat-*",
-        "arn:aws:s3:::liftmark-workoutformat-*/*"
+        "arn:aws:s3:::liftmark-*-site-*",
+        "arn:aws:s3:::liftmark-*-site-*/*"
       ]
     },
     {

--- a/validator/cdk/deploy-policy.json
+++ b/validator/cdk/deploy-policy.json
@@ -129,12 +129,17 @@
         "logs:DeleteLogGroup",
         "logs:PutRetentionPolicy",
         "logs:DeleteRetentionPolicy",
-        "logs:DescribeLogGroups",
         "logs:TagResource"
       ],
       "Resource": [
         "arn:aws:logs:*:*:log-group:/aws/lambda/Lmwf*Stack-*"
       ]
+    },
+    {
+      "Sid": "CloudWatchLogsDescribe",
+      "Effect": "Allow",
+      "Action": "logs:DescribeLogGroups",
+      "Resource": "*"
     },
     {
       "Sid": "CloudWatchAlarms",

--- a/validator/cdk/iam/refresh-deploy-policy.sh
+++ b/validator/cdk/iam/refresh-deploy-policy.sh
@@ -66,6 +66,39 @@ else
 fi
 echo "    $POLICY_ARN is current"
 
+# ── 1b. Supplementary policy (overflow from the 6,144-char managed-policy limit)
+# LmwfCdkDeployPolicy is at the size ceiling, so DynamoDB + SES + WAFv2-read
+# perms live in a second managed policy attached to the CFN exec role. Only the
+# primary-region exec role needs these (it owns the tables, SES identity, and
+# the site CloudFront distributions). Idempotent: refresh version + ensure
+# attached.
+EXTRA_NAME="LmwfCdkDeployPolicyExtra"
+EXTRA_DOC="$DIR/../deploy-policy-extra.json"
+EXTRA_ARN="arn:aws:iam::${ACCT}:policy/${EXTRA_NAME}"
+EXEC_ROLE="cdk-${QUALIFIER}-cfn-exec-role-${ACCT}-us-west-2"
+if [ -f "$EXTRA_DOC" ]; then
+  if aws iam get-policy --policy-arn "$EXTRA_ARN" >/dev/null 2>&1; then
+    COUNT="$(aws iam list-policy-versions --policy-arn "$EXTRA_ARN" --query 'length(Versions)' --output text)"
+    if [ "$COUNT" -ge 5 ]; then
+      OLDEST="$(aws iam list-policy-versions --policy-arn "$EXTRA_ARN" \
+        --query 'sort_by(Versions[?IsDefaultVersion==`false`],&CreateDate)[0].VersionId' --output text)"
+      aws iam delete-policy-version --policy-arn "$EXTRA_ARN" --version-id "$OLDEST"
+    fi
+    echo "==> refreshing $EXTRA_NAME (new default version)"
+    aws iam create-policy-version --policy-arn "$EXTRA_ARN" \
+      --policy-document "file://$EXTRA_DOC" --set-as-default >/dev/null
+  else
+    echo "==> creating $EXTRA_NAME"
+    aws iam create-policy --policy-name "$EXTRA_NAME" --policy-document "file://$EXTRA_DOC" >/dev/null
+  fi
+  if ! aws iam list-attached-role-policies --role-name "$EXEC_ROLE" \
+      --query 'AttachedPolicies[].PolicyArn' --output text 2>/dev/null | grep -q "$EXTRA_ARN"; then
+    echo "==> attaching $EXTRA_NAME to $EXEC_ROLE"
+    aws iam attach-role-policy --role-name "$EXEC_ROLE" --policy-arn "$EXTRA_ARN"
+  fi
+  echo "    $EXTRA_ARN is current and attached to $EXEC_ROLE"
+fi
+
 # ── 2. Verify the bootstrap wired it as the CFN execution policy ─────────────
 echo "==> checking CDK bootstrap ($TOOLKIT) CFN execution policy per region"
 NEEDS_FIX=0


### PR DESCRIPTION
The first **full-template** prod deploy since the CFN exec policy was scoped exposed several permission/config gaps (a full update re-evaluates existing resources that incremental changeset deploys never touched). All fixes below are **already applied live** — this PR syncs the repo and makes `smoke-prod` green.

## Exec policy (`LmwfCdkDeployPolicy` → live **v10**)
- `logs:DescribeLogGroups` split to `Resource: "*"` (list action, can't be ARN-scoped).
- `S3SiteBucket` was scoped to a stale `liftmark-workoutformat-*`; the real bucket is `liftmark-<env>-site-<acct>` → fixed to `liftmark-*-site-*`.
- (Earlier in this branch: collapsed per-stack ARN patterns to `Lmwf*Stack-*` so the cross-region export-writer role in `LmwfDnsFoundationStack` is covered — that part shipped as v8 via #208's squash; included here for completeness.)

## Supplementary policy (`deploy-policy-extra.json` → `LmwfCdkDeployPolicyExtra` v2)
The main policy is at IAM's **6,144-char ceiling**, so the missing service perms overflow into a second managed policy attached to the primary-region CFN exec role:
- **DynamoDB** (table lifecycle) and **SES** (EmailIdentity) — these resources predate the policy's tightening, so they had *zero* coverage.
- **`wafv2:GetWebACL`** — CloudFront verifies read access to the web ACL when a new distribution sets `webAclId` (needed for the getlift.md distribution).

`refresh-deploy-policy.sh` now also creates/refreshes + attaches the supplementary policy.

## Smoke test (`smoke-prod`)
- Repointed the full smoke at `https://getlift.md` (canonical site, also proxies the API) instead of `liftmark.app` (whose site pages now 302).
- Added a **redirect-topology** assertion step: `liftmark.app/<page>` 302→getlift.md, `liftmark.app/validate` still 200, AASA 200/`application/json`/no-redirect, `liftmd.app` 302→getlift.md.

## Status
Prod is **`UPDATE_COMPLETE`** and redirects are verified live (getlift.md serves; liftmark.app site→302; API + AASA intact on liftmark.app; liftmd.app→302). Merging re-runs the pipeline; the deploy is a near-noop and `smoke-prod` now passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)