### PR TITLE
fix(outbox): stop silently dropping large completed workouts (WAF 8KB body block)

### DIFF
--- a/mobile-apps/ios/LiftMark/Services/APIClient.swift
+++ b/mobile-apps/ios/LiftMark/Services/APIClient.swift
@@ -5,6 +5,11 @@ import Foundation
 enum APIError: Error {
     case unauthorized
     case forbidden(message: String?)
+    /// A 403 (or similar) produced at the edge — CloudFront/WAF — that never
+    /// reached our API. These carry an HTML body, not our `{"error": "..."}`
+    /// JSON. Transient/infra, NOT a permanent client error, so callers must
+    /// retry rather than treat it as terminal.
+    case edgeBlocked(status: Int)
     case notFound
     case conflict(message: String?)
     case server(status: Int, message: String?)
@@ -202,7 +207,7 @@ final class APIClient: APIClientProtocol, @unchecked Sendable {
         case 401:
             throw APIError.unauthorized
         case 403:
-            throw APIError.forbidden(message: Self.errorMessage(from: data))
+            throw Self.forbiddenError(from: data)
         case 404:
             throw APIError.notFound
         case 409:
@@ -246,7 +251,7 @@ final class APIClient: APIClientProtocol, @unchecked Sendable {
         case 401:
             throw APIError.unauthorized
         case 403:
-            throw APIError.forbidden(message: Self.errorMessage(from: data))
+            throw Self.forbiddenError(from: data)
         case 404:
             throw APIError.notFound
         case 409:
@@ -259,6 +264,20 @@ final class APIClient: APIClientProtocol, @unchecked Sendable {
     private static func errorMessage(from data: Data) -> String? {
         guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
         return json["error"] as? String
+    }
+
+    /// Disambiguate a 403 from our API vs. one injected at the edge.
+    ///
+    /// Our API's 403s ALWAYS carry a JSON `{"error": "..."}` body (scope/quota
+    /// rejections). A CloudFront/WAF block returns a 403 with an HTML body and
+    /// never reaches our API — those have no JSON `error` field. The former is a
+    /// permanent client error; the latter is transient infra that must be
+    /// retried, so map them to distinct cases.
+    private static func forbiddenError(from data: Data) -> APIError {
+        if let message = errorMessage(from: data) {
+            return .forbidden(message: message)
+        }
+        return .edgeBlocked(status: 403)
     }
 }
 

--- a/mobile-apps/ios/LiftMark/Services/CrashReporter.swift
+++ b/mobile-apps/ios/LiftMark/Services/CrashReporter.swift
@@ -25,7 +25,9 @@ final class CrashReporter: @unchecked Sendable {
         "fieldName",
         "fkTable",
         "partialFailureCount",
-        "tag"
+        "tag",
+        "status",
+        "clientSessionId"
     ]
 
     /// Keys permitted on parse-class error events.

--- a/mobile-apps/ios/LiftMark/Services/OutboxPusherService.swift
+++ b/mobile-apps/ios/LiftMark/Services/OutboxPusherService.swift
@@ -275,103 +275,95 @@ final class OutboxPusherService {
             )
             try? queue.remove(clientSessionId: clientSessionId)
             return .pushed
-        } catch APIError.unauthorized {
-            // Treat 401 as auth-missing: tokens refresh in withAuthorizedRequest;
-            // if we still get 401 here, the user effectively isn't signed in.
+        } catch {
+            return classifyPushFailure(error, item: item)
+        }
+    }
+
+    /// Map a thrown push error to a `PushOutcome`. Split out of `pushOne` so each
+    /// method stays focused (and within the function-length lint limit).
+    private func classifyPushFailure(_ error: Error, item: OutboxPendingItem) -> PushOutcome {
+        let clientSessionId = item.clientSessionId
+        guard let apiError = error as? APIError else {
+            // Decoding errors etc. — transient; a response-shape mismatch is more
+            // likely deploy skew than a permanent bad payload on this device.
+            scheduleRetry(item: item, error: error.localizedDescription)
+            return .retryQueued
+        }
+        switch apiError {
+        case .unauthorized:
+            // Tokens refresh in withAuthorizedRequest; a 401 here means the user
+            // effectively isn't signed in.
             lastError = "Authentication required"
             return .authMissing
-        } catch let APIError.edgeBlocked(status) {
-            // Edge/WAF block (HTML 403, e.g. SizeRestrictions_BODY) — this
-            // never reached our API. It's transient infra, NOT a permanent
-            // client error: a large body blocked by the edge must never be
-            // silently dropped. Preserve+back off and surface to Sentry.
+        case let .edgeBlocked(status):
+            // Edge/WAF block (HTML 403, e.g. SizeRestrictions_BODY) — never
+            // reached our API. Transient infra, NOT a permanent client error: a
+            // large body blocked at the edge must never be silently dropped.
             scheduleRetry(item: item, error: "Edge blocked (\(status))")
-            let err = NSError(
-                domain: "LiftMark.Outbox",
-                code: status,
-                userInfo: [NSLocalizedDescriptionKey: "Outbox push blocked at edge (\(status)); preserving queue row"]
-            )
-            CrashReporter.shared.captureError(
-                err,
-                category: .network,
-                metadata: [
-                    "tag": "outbox_edge_blocked",
-                    "status": String(status),
-                    "clientSessionId": clientSessionId,
-                ]
+            captureOutboxFailure(
+                tag: "outbox_edge_blocked", status: status, clientSessionId: clientSessionId,
+                message: "Outbox push blocked at edge (\(status)); preserving queue row"
             )
             return .retryQueued
-        } catch let APIError.forbidden(msg) {
-            // 403 — scope/quota. A real API 403 IS terminal: surfaces to user
-            // via lastError, drop row. Also capture to Sentry so the silent
-            // drop is observable (Problem D).
+        case let .forbidden(msg):
+            // A real API 403 IS terminal: surface via lastError + drop. Capture
+            // so the drop is observable (Problem D).
             Logger.shared.error(
                 .network,
                 "outbox push 403 — dropping queue row",
                 metadata: ["clientSessionId": clientSessionId, "message": msg ?? ""]
             )
             lastError = msg ?? "Forbidden"
-            let err = NSError(
-                domain: "LiftMark.Outbox",
-                code: 403,
-                userInfo: [NSLocalizedDescriptionKey: "Outbox push 403 — dropping queue row: \(msg ?? "")"]
-            )
-            CrashReporter.shared.captureError(
-                err,
-                category: .network,
-                metadata: [
-                    "tag": "outbox_push_403",
-                    "status": "403",
-                    "clientSessionId": clientSessionId,
-                ]
+            captureOutboxFailure(
+                tag: "outbox_push_403", status: 403, clientSessionId: clientSessionId,
+                message: "Outbox push 403 — dropping queue row: \(msg ?? "")"
             )
             try? queue.remove(clientSessionId: clientSessionId)
             return .gaveUpClientError
-        } catch let APIError.server(status, _) where status == 429 {
+        case let .server(status, _) where status == 429:
             scheduleRetry(item: item, error: "Rate limited (\(status))")
             return .retryQueued
-        } catch let APIError.server(status, msg) where status >= 500 {
+        case let .server(status, msg) where status >= 500:
             scheduleRetry(item: item, error: "Server error (\(status)): \(msg ?? "")")
             return .retryQueued
-        } catch let APIError.server(status, msg) {
-            // Other 4xx — bad payload. Don't retry forever; drop the row and
-            // log as an error. Also capture to Sentry so the silent drop is
-            // observable (Problem D).
+        case let .server(status, msg):
+            // Other 4xx — bad payload. Drop the row + capture (Problem D).
             Logger.shared.error(
                 .network,
                 "outbox push gave up on 4xx",
-                metadata: [
-                    "clientSessionId": clientSessionId,
-                    "status": String(status),
-                    "message": msg ?? "",
-                ]
+                metadata: ["clientSessionId": clientSessionId, "status": String(status), "message": msg ?? ""]
             )
-            let err = NSError(
-                domain: "LiftMark.Outbox",
-                code: status,
-                userInfo: [NSLocalizedDescriptionKey: "Outbox push gave up on 4xx (\(status)): \(msg ?? "")"]
-            )
-            CrashReporter.shared.captureError(
-                err,
-                category: .network,
-                metadata: [
-                    "tag": "outbox_push_4xx",
-                    "status": String(status),
-                    "clientSessionId": clientSessionId,
-                ]
+            captureOutboxFailure(
+                tag: "outbox_push_4xx", status: status, clientSessionId: clientSessionId,
+                message: "Outbox push gave up on 4xx (\(status)): \(msg ?? "")"
             )
             try? queue.remove(clientSessionId: clientSessionId)
             return .gaveUpClientError
-        } catch let APIError.transport(error) {
-            scheduleRetry(item: item, error: "Transport: \(error.localizedDescription)")
+        case let .transport(err):
+            scheduleRetry(item: item, error: "Transport: \(err.localizedDescription)")
             return .retryQueued
-        } catch {
-            // Decoding errors etc. — treat as transient; the server's response
-            // shape mismatching is more likely a deploy skew than a permanent
-            // bad-payload condition on this device.
-            scheduleRetry(item: item, error: error.localizedDescription)
+        case .notFound, .conflict, .decoding:
+            // Unexpected for this endpoint — treat as transient rather than
+            // silently dropping a completed workout.
+            scheduleRetry(item: item, error: "Unexpected: \(apiError)")
             return .retryQueued
         }
+    }
+
+    /// Emit one Sentry capture for an outbox push failure. The tag/status/
+    /// clientSessionId keys are on the CrashReporter sync metadata allowlist.
+    private func captureOutboxFailure(tag: String, status: Int, clientSessionId: String, message: String) {
+        let err = NSError(
+            domain: "LiftMark.Outbox",
+            code: status,
+            userInfo: [NSLocalizedDescriptionKey: message]
+        )
+        CrashReporter.shared.captureError(
+            err,
+            category: .network,
+            metadata: ["tag": tag, "status": String(status), "clientSessionId": clientSessionId]
+        )
     }
 
     private func scheduleRetry(item: OutboxPendingItem, error: String) {

--- a/mobile-apps/ios/LiftMark/Services/OutboxPusherService.swift
+++ b/mobile-apps/ios/LiftMark/Services/OutboxPusherService.swift
@@ -76,6 +76,14 @@ final class OutboxPusherService {
             )
         } catch {
             Logger.shared.error(.database, "outbox enqueue failed", error: error)
+            CrashReporter.shared.captureError(
+                error,
+                category: .database,
+                metadata: [
+                    "tag": "outbox_enqueue_failed",
+                    "clientSessionId": clientSessionId,
+                ]
+            )
             return
         }
         Task { await flushIfAuthenticated() }
@@ -102,6 +110,11 @@ final class OutboxPusherService {
             items = try queue.eligibleItems()
         } catch {
             Logger.shared.error(.database, "outbox queue read failed", error: error)
+            CrashReporter.shared.captureError(
+                error,
+                category: .database,
+                metadata: ["tag": "outbox_queue_read_failed"]
+            )
             return
         }
 
@@ -267,14 +280,51 @@ final class OutboxPusherService {
             // if we still get 401 here, the user effectively isn't signed in.
             lastError = "Authentication required"
             return .authMissing
+        } catch let APIError.edgeBlocked(status) {
+            // Edge/WAF block (HTML 403, e.g. SizeRestrictions_BODY) — this
+            // never reached our API. It's transient infra, NOT a permanent
+            // client error: a large body blocked by the edge must never be
+            // silently dropped. Preserve+back off and surface to Sentry.
+            scheduleRetry(item: item, error: "Edge blocked (\(status))")
+            let err = NSError(
+                domain: "LiftMark.Outbox",
+                code: status,
+                userInfo: [NSLocalizedDescriptionKey: "Outbox push blocked at edge (\(status)); preserving queue row"]
+            )
+            CrashReporter.shared.captureError(
+                err,
+                category: .network,
+                metadata: [
+                    "tag": "outbox_edge_blocked",
+                    "status": String(status),
+                    "clientSessionId": clientSessionId,
+                ]
+            )
+            return .retryQueued
         } catch let APIError.forbidden(msg) {
-            // 403 — scope/quota. Surfaces to user via lastError; drop row.
+            // 403 — scope/quota. A real API 403 IS terminal: surfaces to user
+            // via lastError, drop row. Also capture to Sentry so the silent
+            // drop is observable (Problem D).
             Logger.shared.error(
                 .network,
                 "outbox push 403 — dropping queue row",
                 metadata: ["clientSessionId": clientSessionId, "message": msg ?? ""]
             )
             lastError = msg ?? "Forbidden"
+            let err = NSError(
+                domain: "LiftMark.Outbox",
+                code: 403,
+                userInfo: [NSLocalizedDescriptionKey: "Outbox push 403 — dropping queue row: \(msg ?? "")"]
+            )
+            CrashReporter.shared.captureError(
+                err,
+                category: .network,
+                metadata: [
+                    "tag": "outbox_push_403",
+                    "status": "403",
+                    "clientSessionId": clientSessionId,
+                ]
+            )
             try? queue.remove(clientSessionId: clientSessionId)
             return .gaveUpClientError
         } catch let APIError.server(status, _) where status == 429 {
@@ -285,7 +335,8 @@ final class OutboxPusherService {
             return .retryQueued
         } catch let APIError.server(status, msg) {
             // Other 4xx — bad payload. Don't retry forever; drop the row and
-            // log as an error so it surfaces in Sentry.
+            // log as an error. Also capture to Sentry so the silent drop is
+            // observable (Problem D).
             Logger.shared.error(
                 .network,
                 "outbox push gave up on 4xx",
@@ -293,6 +344,20 @@ final class OutboxPusherService {
                     "clientSessionId": clientSessionId,
                     "status": String(status),
                     "message": msg ?? "",
+                ]
+            )
+            let err = NSError(
+                domain: "LiftMark.Outbox",
+                code: status,
+                userInfo: [NSLocalizedDescriptionKey: "Outbox push gave up on 4xx (\(status)): \(msg ?? "")"]
+            )
+            CrashReporter.shared.captureError(
+                err,
+                category: .network,
+                metadata: [
+                    "tag": "outbox_push_4xx",
+                    "status": String(status),
+                    "clientSessionId": clientSessionId,
                 ]
             )
             try? queue.remove(clientSessionId: clientSessionId)

--- a/mobile-apps/ios/LiftMark/Stores/AuthenticationStore.swift
+++ b/mobile-apps/ios/LiftMark/Stores/AuthenticationStore.swift
@@ -268,6 +268,10 @@ final class AuthenticationStore {
                 throw AuthError.unknown(message)
             case .conflict(let message):
                 throw AuthError.unknown(message)
+            case .edgeBlocked:
+                // Blocked at the edge (CloudFront/WAF) — treat as a network
+                // failure so the UI can offer a retry.
+                throw AuthError.network
             case .unauthorized, .forbidden, .notFound, .decoding:
                 throw AuthError.unknown(nil)
             }
@@ -471,7 +475,9 @@ final class AuthenticationStore {
             return .invalidCredentials
         case .forbidden:
             return .emailNotVerified
-        case .transport:
+        case .transport, .edgeBlocked:
+            // .edgeBlocked is an edge/WAF block that never reached the API —
+            // surface it as a network failure so the user can retry.
             return .network
         case .server(_, let message):
             return .unknown(message)

--- a/mobile-apps/ios/LiftMarkTests/OutboxPusherServiceTests.swift
+++ b/mobile-apps/ios/LiftMarkTests/OutboxPusherServiceTests.swift
@@ -12,6 +12,8 @@ final class OutboxPusherServiceTests: XCTestCase {
     private var tokenStore: TokenStore!
     private var mockAPI: MockAPIClient!
     private var queue: OutboxPendingQueueRepository!
+    private var planRepo: WorkoutPlanRepository!
+    private var sessionRepo: SessionRepository!
 
     override func setUp() async throws {
         try await super.setUp()
@@ -25,6 +27,8 @@ final class OutboxPusherServiceTests: XCTestCase {
         tokenStore.clear()
         mockAPI = MockAPIClient()
         queue = OutboxPendingQueueRepository()
+        planRepo = WorkoutPlanRepository()
+        sessionRepo = SessionRepository()
     }
 
     private func ensureAppLogsTableExists() {
@@ -53,6 +57,8 @@ final class OutboxPusherServiceTests: XCTestCase {
         tokenStore = nil
         mockAPI = nil
         queue = nil
+        planRepo = nil
+        sessionRepo = nil
         try await super.tearDown()
     }
 
@@ -61,6 +67,137 @@ final class OutboxPusherServiceTests: XCTestCase {
     private func makeUnauthenticatedStore() -> AuthenticationStore {
         // No tokens → currentUser nil → !isAuthenticated.
         AuthenticationStore(api: mockAPI, tokenStore: tokenStore)
+    }
+
+    /// A store with a live, unexpired access token so `pushOne` actually
+    /// reaches the API call (and we exercise the error-mapping in pushOne's
+    /// catch chain rather than the unauthenticated short-circuit).
+    private func makeAuthenticatedStore() -> AuthenticationStore {
+        tokenStore.saveAccessToken(Self.makeJWT(expSecondsFromNow: 3600))
+        tokenStore.saveRefreshToken("lm_refresh_test")
+        let store = AuthenticationStore(api: mockAPI, tokenStore: tokenStore)
+        XCTAssertTrue(store.isAuthenticated)
+        return store
+    }
+
+    /// Build a minimal completed session so `pushOne` finds a durable row for
+    /// the queued `clientSessionId` (otherwise it drops the row as "session no
+    /// longer exists"). Returns the session id to enqueue.
+    private func makeCompletedSession() throws -> String {
+        let plan = WorkoutPlan(
+            name: "Edge Test",
+            exercises: [PlannedExercise(
+                workoutPlanId: "plan",
+                exerciseName: "Bench",
+                orderIndex: 0,
+                sets: [PlannedSet(
+                    plannedExerciseId: "ex",
+                    orderIndex: 0,
+                    targetWeight: 135,
+                    targetWeightUnit: .lbs,
+                    targetReps: 5
+                )]
+            )]
+        )
+        try planRepo.create(plan)
+        let (session, _) = try sessionRepo.createFromPlan(plan)
+        for exercise in session.exercises {
+            for set in exercise.sets {
+                try sessionRepo.updateSessionSet(
+                    set.id,
+                    actualWeight: set.targetWeight,
+                    actualWeightUnit: .lbs,
+                    actualReps: set.targetReps,
+                    actualTime: nil,
+                    actualRpe: nil,
+                    status: .completed
+                )
+            }
+        }
+        try sessionRepo.complete(session.id)
+        return session.id
+    }
+
+    private static func makeJWT(expSecondsFromNow: TimeInterval, sub: String = "user-test") -> String {
+        let header: [String: Any] = ["alg": "HS256", "typ": "JWT"]
+        let payload: [String: Any] = [
+            "sub": sub,
+            "exp": Date().timeIntervalSince1970 + expSecondsFromNow,
+        ]
+        func b64(_ obj: [String: Any]) -> String {
+            guard let data = try? JSONSerialization.data(withJSONObject: obj) else { return "" }
+            return data.base64EncodedString()
+                .replacingOccurrences(of: "+", with: "-")
+                .replacingOccurrences(of: "/", with: "_")
+                .replacingOccurrences(of: "=", with: "")
+        }
+        return "\(b64(header)).\(b64(payload)).signature-junk"
+    }
+
+    // MARK: - 403 disambiguation: edge block vs. real API forbidden
+
+    /// An edge/WAF 403 (`APIError.edgeBlocked`) is transient infra — the row
+    /// must be PRESERVED and a retry scheduled, never silently dropped.
+    func testEdgeBlocked403PreservesQueueRowAndRetries() async throws {
+        let sessionId = try makeCompletedSession()
+        try queue.enqueue(clientSessionId: sessionId)
+
+        var captures: [(LogCategory, [String: String])] = []
+        CrashReporter.captureErrorRecorder = { _, category, metadata in
+            captures.append((category, metadata))
+        }
+
+        mockAPI.nextError = APIError.edgeBlocked(status: 403)
+
+        let pusher = OutboxPusherService(
+            authStore: makeAuthenticatedStore(),
+            apiClient: mockAPI,
+            queue: queue
+        )
+
+        await pusher.flushIfAuthenticated()
+
+        // Row must survive an edge block — the completed workout is not lost.
+        XCTAssertEqual(try queue.count(), 1, "Edge block must NOT delete the queued completion")
+        XCTAssertEqual(pusher.pendingCount, 1)
+
+        // Captured to Sentry, tagged + carrying status/session, category .network.
+        XCTAssertEqual(captures.count, 1)
+        XCTAssertEqual(captures.first?.0, .network)
+        XCTAssertEqual(captures.first?.1["tag"], "outbox_edge_blocked")
+        XCTAssertEqual(captures.first?.1["status"], "403")
+        XCTAssertEqual(captures.first?.1["clientSessionId"], sessionId)
+    }
+
+    /// A real API 403 (`APIError.forbidden` with a JSON message) IS terminal —
+    /// the row is dropped (and the drop is now also captured to Sentry).
+    func testRealApiForbidden403RemovesQueueRow() async throws {
+        let sessionId = try makeCompletedSession()
+        try queue.enqueue(clientSessionId: sessionId)
+
+        var captures: [(LogCategory, [String: String])] = []
+        CrashReporter.captureErrorRecorder = { _, category, metadata in
+            captures.append((category, metadata))
+        }
+
+        mockAPI.nextError = APIError.forbidden(message: "quota exceeded")
+
+        let pusher = OutboxPusherService(
+            authStore: makeAuthenticatedStore(),
+            apiClient: mockAPI,
+            queue: queue
+        )
+
+        await pusher.flushIfAuthenticated()
+
+        // Real 403 is permanent → row removed.
+        XCTAssertEqual(try queue.count(), 0, "A real API 403 should remove the queue row")
+        XCTAssertEqual(pusher.pendingCount, 0)
+        XCTAssertEqual(pusher.lastError, "quota exceeded")
+
+        // The drop is observable in Sentry (Problem D).
+        XCTAssertEqual(captures.count, 1)
+        XCTAssertEqual(captures.first?.1["tag"], "outbox_push_403")
     }
 
     // MARK: - Auth failure: unauthenticated flush

--- a/spec/services/lmwf-validator.md
+++ b/spec/services/lmwf-validator.md
@@ -159,6 +159,32 @@ and continues to serve everything (site + API) from `beta.liftmark.app`.
 | **`liftmd.app`** | Legacy short domain | **302 → `getlift.md`** (everything) | 302 → `getlift.md` | 302 → `getlift.md` |
 | **`beta.liftmark.app`** | Beta (all-in-one) | Serves | Serves | Serves |
 
+### CloudFront WAF (body-size policy)
+
+The CloudFront-scoped WAFv2 web ACL (`lmwf-<env>-cloudfront`, defined in
+`validator/cdk/edge-stack.ts`) runs AWS managed rule groups (CommonRuleSet,
+KnownBadInputs, IpReputation) plus per-IP rate limits. Two settings exist
+specifically so legitimate large request bodies are **not blocked at the edge**:
+
+- **`SizeRestrictions_BODY` is overridden to `Count`** in the CommonRuleSet.
+  Its default action blocks any body > 8 KB, which silently 403s a completed
+  workout push (`POST /v1/workouts/outbox`) — a real session is ~19 KB+ — at
+  CloudFront, *before* the request reaches API Gateway (so it never appears in
+  the API access log, and the iOS client used to drop it as a "forbidden"
+  error). The route enforces its own 1 MB body cap server-side and the
+  rate-based rules still bound abuse, so demoting this rule to Count is safe.
+- **`associationConfig.requestBody.CLOUDFRONT.defaultSizeInspectionLimit = KB_64`**
+  so the remaining managed rules (SQLi/XSS/etc.) still inspect realistic
+  payloads instead of letting large bodies past uninspected.
+
+The matching client guard (treat an edge/WAF 403 as transient, never drop the
+queued workout) is specified in [workout-outbox.md](workout-outbox.md).
+
+The CFN execution role for the **us-east-1** edge stack therefore needs WAFv2
+write permissions (`wafv2:Get/Create/Update/DeleteWebACL`, tag + logging-config
+actions); these live in `LmwfCdkDeployPolicyExtra` (`deploy-policy-extra.json`),
+attached to **both** region exec roles by `iam/refresh-deploy-policy.sh`.
+
 Redirect semantics:
 
 - Redirects are **302 (temporary)** initially; they are to be promoted to **301

--- a/spec/services/workout-outbox.md
+++ b/spec/services/workout-outbox.md
@@ -180,8 +180,9 @@ Mirrors `InboxPollerService` in lifecycle and observability.
   2. Run `WorkoutExportService.exportSingleSessionAsJson` to produce the envelope (in-memory; do not write a file).
   3. `POST /v1/workouts/outbox` with the envelope + `client_session_id`.
   4. On 2xx: delete the queue row.
-  5. On 4xx (other than 429): log, delete the queue row (no point retrying a bad payload), and report via `Logger.shared.error`.
-  6. On 5xx / network / 429: increment `attempt_count`, set `next_attempt_after = now + backoff(attempt_count)`, leave the row in place.
+  5. On a **real API 4xx** (other than 429) — i.e. a 403/4xx whose body carries our JSON `{"error": ...}` shape, or a 401: log, delete the queue row (no point retrying a bad payload), and **capture to Sentry** (`outbox_push_403` / `outbox_push_4xx`) so a terminal drop is never silent.
+  6. On **5xx / network / 429**: increment `attempt_count`, set `next_attempt_after = now + backoff(attempt_count)`, leave the row in place.
+  7. On an **edge / WAF block** (a 403 with no JSON `{"error"}` body — e.g. CloudFront's `SizeRestrictions_BODY` rejecting a large workout before it reaches the API): this is **infrastructure, not a permanent client error**. The client maps it to `APIError.edgeBlocked(status:)`, **preserves the queue row**, schedules a retry like a transient failure, and captures to Sentry (`outbox_edge_blocked`). Dropping here is exactly the silent data-loss this service must prevent — a large completed workout would vanish. The server-side fix is to keep the CloudFront WAF body-inspection limit and `SizeRestrictions_BODY` override wide enough for real workout payloads (see [lmwf-validator.md](lmwf-validator.md)); the client guard is defense-in-depth so a future edge rejection never silently drops a workout.
 - **Backoff**: 30s, 2m, 10m, 30m, 2h (capped). After 10 attempts, log a Sentry breadcrumb (not an error capture per [[reference-sentry-metadata-allowlist]]) and keep retrying — a sustained 5xx for hours means something is wrong on the server, not the client.
 - **No CloudKit ack flow**. The outbox is one-way; once the server accepts the row, the device's job is done.
 

--- a/validator/cdk/deploy-policy-extra.json
+++ b/validator/cdk/deploy-policy-extra.json
@@ -39,13 +39,24 @@
       "Resource": "arn:aws:ses:*:*:identity/*"
     },
     {
-      "Sid": "WAFv2WebAclRead",
+      "Sid": "WAFv2WebAcl",
       "Effect": "Allow",
       "Action": [
         "wafv2:GetWebACL",
-        "wafv2:ListTagsForResource"
+        "wafv2:CreateWebACL",
+        "wafv2:UpdateWebACL",
+        "wafv2:DeleteWebACL",
+        "wafv2:ListTagsForResource",
+        "wafv2:TagResource",
+        "wafv2:UntagResource",
+        "wafv2:GetLoggingConfiguration",
+        "wafv2:PutLoggingConfiguration",
+        "wafv2:DeleteLoggingConfiguration"
       ],
-      "Resource": "arn:aws:wafv2:us-east-1:*:global/webacl/lmwf-*"
+      "Resource": [
+        "arn:aws:wafv2:us-east-1:*:global/webacl/lmwf-*",
+        "arn:aws:wafv2:us-east-1:*:global/managedruleset/*/*"
+      ]
     }
   ]
 }

--- a/validator/cdk/edge-stack.ts
+++ b/validator/cdk/edge-stack.ts
@@ -57,6 +57,18 @@ export class LmwfEdgeStack extends cdk.Stack {
       defaultAction: { allow: {} },
       // WAFv2 description is regex-constrained (no em-dash / non-ASCII punctuation).
       description: `LMWF ${envConfig.name} CloudFront WAF - managed rules and rate limits`,
+      // CloudFront inspects only the first 16 KB of a request body by default.
+      // Completed-workout outbox pushes (POST /v1/workouts/outbox) routinely
+      // exceed that (a real session is ~19 KB+), so raise the inspection window
+      // to 64 KB. Without this, large bodies sail past the managed rules
+      // uninspected; with it (plus the SizeRestrictions_BODY override below)
+      // they are scanned and allowed instead of blocked. Adds WCU but stays
+      // well within the default 1500 WCU ceiling.
+      associationConfig: {
+        requestBody: {
+          CLOUDFRONT: { defaultSizeInspectionLimit: 'KB_64' },
+        },
+      },
       visibilityConfig: {
         cloudWatchMetricsEnabled: true,
         metricName: `${namePrefix}-cloudfront-acl`,
@@ -122,6 +134,19 @@ export class LmwfEdgeStack extends cdk.Stack {
             managedRuleGroupStatement: {
               vendorName: 'AWS',
               name: 'AWSManagedRulesCommonRuleSet',
+              // SizeRestrictions_BODY blocks any request body > 8 KB. That
+              // silently kills legitimate large outbox pushes at the edge
+              // (CloudFront 403 before the request ever reaches the API), so
+              // a finished workout of any real size never syncs. Demote it to
+              // Count: the outbox route enforces its own 1 MB body cap and the
+              // rate-based rules above still bound abuse. All other CRS rules
+              // (SQLi/XSS/etc.) keep their default Block action.
+              ruleActionOverrides: [
+                {
+                  name: 'SizeRestrictions_BODY',
+                  actionToUse: { count: {} },
+                },
+              ],
             },
           },
           visibilityConfig: {

--- a/validator/cdk/iam/refresh-deploy-policy.sh
+++ b/validator/cdk/iam/refresh-deploy-policy.sh
@@ -67,15 +67,15 @@ fi
 echo "    $POLICY_ARN is current"
 
 # ── 1b. Supplementary policy (overflow from the 6,144-char managed-policy limit)
-# LmwfCdkDeployPolicy is at the size ceiling, so DynamoDB + SES + WAFv2-read
-# perms live in a second managed policy attached to the CFN exec role. Only the
-# primary-region exec role needs these (it owns the tables, SES identity, and
-# the site CloudFront distributions). Idempotent: refresh version + ensure
-# attached.
+# LmwfCdkDeployPolicy is at the size ceiling, so DynamoDB + SES + WAFv2 perms
+# live in a second managed policy attached to the CFN exec roles. Both region
+# exec roles need it: us-west-2 owns the tables + SES identity; us-east-1 owns
+# the CLOUDFRONT-scoped WAFv2 web ACL (EdgeStack), so it needs the WAFv2 perms
+# to create/update it. Idempotent: refresh version + ensure attached in both
+# regions.
 EXTRA_NAME="LmwfCdkDeployPolicyExtra"
 EXTRA_DOC="$DIR/../deploy-policy-extra.json"
 EXTRA_ARN="arn:aws:iam::${ACCT}:policy/${EXTRA_NAME}"
-EXEC_ROLE="cdk-${QUALIFIER}-cfn-exec-role-${ACCT}-us-west-2"
 if [ -f "$EXTRA_DOC" ]; then
   if aws iam get-policy --policy-arn "$EXTRA_ARN" >/dev/null 2>&1; then
     COUNT="$(aws iam list-policy-versions --policy-arn "$EXTRA_ARN" --query 'length(Versions)' --output text)"
@@ -91,12 +91,15 @@ if [ -f "$EXTRA_DOC" ]; then
     echo "==> creating $EXTRA_NAME"
     aws iam create-policy --policy-name "$EXTRA_NAME" --policy-document "file://$EXTRA_DOC" >/dev/null
   fi
-  if ! aws iam list-attached-role-policies --role-name "$EXEC_ROLE" \
-      --query 'AttachedPolicies[].PolicyArn' --output text 2>/dev/null | grep -q "$EXTRA_ARN"; then
-    echo "==> attaching $EXTRA_NAME to $EXEC_ROLE"
-    aws iam attach-role-policy --role-name "$EXEC_ROLE" --policy-arn "$EXTRA_ARN"
-  fi
-  echo "    $EXTRA_ARN is current and attached to $EXEC_ROLE"
+  for EXEC_REGION in us-west-2 us-east-1; do
+    EXEC_ROLE="cdk-${QUALIFIER}-cfn-exec-role-${ACCT}-${EXEC_REGION}"
+    if ! aws iam list-attached-role-policies --role-name "$EXEC_ROLE" \
+        --query 'AttachedPolicies[].PolicyArn' --output text 2>/dev/null | grep -q "$EXTRA_ARN"; then
+      echo "==> attaching $EXTRA_NAME to $EXEC_ROLE"
+      aws iam attach-role-policy --role-name "$EXEC_ROLE" --policy-arn "$EXTRA_ARN"
+    fi
+    echo "    $EXTRA_ARN is current and attached to $EXEC_ROLE"
+  done
 fi
 
 # ── 2. Verify the bootstrap wired it as the CFN execution policy ─────────────


### PR DESCRIPTION
## What & why

A completed workout silently never reached the server/website. Forensics (prod DynamoDB + CloudWatch + WAF) found the root cause: the CloudFront WAF `AWSManagedRulesCommonRuleSet` → **`SizeRestrictions_BODY`** rule **blocks any request body > 8 KB**, so a real workout push (`POST /v1/workouts/outbox`, ~19 KB) was **403'd at the edge before reaching API Gateway** (hence no API access-log entry). The iOS client then mapped that edge-403 to `APIError.forbidden` and **deleted the queue row** — losing the workout, with nothing in Sentry. Workouts < 8 KB synced fine.

This is silent data loss for every large workout, for every user.

## Changes

**Server (CDK `edge-stack.ts`) — deployed to prod + beta:**
- Override `SizeRestrictions_BODY` → **Count** (the route enforces its own 1 MB cap; rate-based rules still bound abuse).
- `AssociationConfig.requestBody.CLOUDFRONT.defaultSizeInspectionLimit = KB_64` so other managed rules still inspect realistic payloads.
- Widen the CFN exec policy (`deploy-policy-extra.json`): full WAFv2 web-ACL write perms; attach `LmwfCdkDeployPolicyExtra` to **both** region exec roles in `refresh-deploy-policy.sh` (the us-east-1 edge role owns the CLOUDFRONT web ACL).

**Client (iOS):**
- `APIClient` distinguishes an edge/WAF 403 (HTML, no JSON `{error}`) from a real API 403 → new `APIError.edgeBlocked(status:)`.
- `OutboxPusherService` treats `edgeBlocked` as transient: **preserves** the queue row, schedules a retry, captures to Sentry (`outbox_edge_blocked`).
- Sentry capture added to the previously-silent drop paths (`outbox_push_403`, `outbox_push_4xx`) and to enqueue/queue-read failures; new metadata keys allowlisted.

**Spec-first:** `workout-outbox.md` (edge-403 handling) + `lmwf-validator.md` (WAF body-size policy).

## Verification
- `cdk diff` clean (in-place WebACL update, no replacement); deployed to prod + beta.
- End-to-end: a >8 KB POST now returns **401 from the API** instead of **403 from CloudFront**; normal traffic (getlift.md, /version, AASA) still 200.
- The user's lost June 2 workout was re-pushed through the real endpoint (201) and verified in the prod outbox (18 exercises / 41 sets).
- iOS: `make build` succeeds; `OutboxPusherServiceTests` 4/4 pass (2 new: edge-403 preserves row + retries; real 403 drops).

## Follow-ups (separate PRs)
- Refresh-token reuse-detection session deaths (server idempotent-rotation grace + client refresh hardening; "survive app updates").
- Profile rehydration false-signout (persist profile locally; `/v1/me`).
- Sign-in modal flicker; "Sync now" should also flush the outbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)