### PR TITLE
fix(ios): sign-in modal flicker + Sync now flushes the outbox

### DIFF
--- a/mobile-apps/ios/LiftMark/Database/OutboxPendingQueueRepository.swift
+++ b/mobile-apps/ios/LiftMark/Database/OutboxPendingQueueRepository.swift
@@ -40,6 +40,23 @@ struct OutboxPendingQueueRepository {
         }
     }
 
+    /// All queued items, oldest first, **ignoring `next_attempt_after`**. Used by
+    /// a manual / forced flush ("Sync now"), where the user has explicitly asked
+    /// us to push everything — the retry-backoff timer is an automatic-flush
+    /// concern and must not park items behind a manual sync.
+    func allItems() throws -> [OutboxPendingItem] {
+        let dbQueue = try dbManager.database()
+        return try dbQueue.read { db in
+            let rows = try Row.fetchAll(db, sql: """
+                SELECT client_session_id, enqueued_at, attempt_count,
+                       next_attempt_after, last_error
+                FROM outbox_pending_queue
+                ORDER BY enqueued_at ASC
+                """)
+            return rows.compactMap(Self.assemble)
+        }
+    }
+
     func count() throws -> Int {
         let dbQueue = try dbManager.database()
         return try dbQueue.read { db in

--- a/mobile-apps/ios/LiftMark/Services/OutboxPusherService.swift
+++ b/mobile-apps/ios/LiftMark/Services/OutboxPusherService.swift
@@ -95,7 +95,12 @@ final class OutboxPusherService {
     /// queue is preserved and the failure is surfaced loudly (device log +
     /// Sentry + observable `lastError`) so a silently-unsynced completed
     /// workout can't go unnoticed (GH #143).
-    func flushIfAuthenticated() async {
+    ///
+    /// - Parameter force: when `true` (a manual "Sync now"), process ALL queued
+    ///   items regardless of their `next_attempt_after` backoff timer. The
+    ///   automatic flush (foreground, enqueue, reachability) leaves `force` at
+    ///   its default `false` and only touches items eligible *now*.
+    func flushIfAuthenticated(force: Bool = false) async {
         guard authStore.isAuthenticated else {
             reportAuthFailure(reason: "not_authenticated")
             return
@@ -107,7 +112,7 @@ final class OutboxPusherService {
 
         let items: [OutboxPendingItem]
         do {
-            items = try queue.eligibleItems()
+            items = force ? try queue.allItems() : try queue.eligibleItems()
         } catch {
             Logger.shared.error(.database, "outbox queue read failed", error: error)
             CrashReporter.shared.captureError(

--- a/mobile-apps/ios/LiftMark/Views/Settings/SettingsAccountSection.swift
+++ b/mobile-apps/ios/LiftMark/Views/Settings/SettingsAccountSection.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct SettingsAccountSection: View {
     @Environment(AuthenticationStore.self) private var authStore
     @Environment(InboxPollerService.self) private var inboxPoller
+    @Environment(OutboxPusherService.self) private var outboxPusher
     @Environment(FeatureFlagsStore.self) private var featureFlags
     @State private var showingLogin = false
     @State private var isSigningOut = false
@@ -61,17 +62,26 @@ struct SettingsAccountSection: View {
         .accessibilityIdentifier("account-inbox-status")
 
         Button {
-            Task { await inboxPoller.pollIfAuthenticated() }
+            // A manual "Sync now" must move data in BOTH directions: poll the
+            // inbox AND flush the outbox. `force: true` bypasses the per-item
+            // retry backoff so completed workouts parked behind `next_attempt_
+            // after` push immediately — the backoff timer is an automatic-flush
+            // concern, not a manual-sync one. See spec/services/workout-outbox.md.
+            Task {
+                async let poll: Void = inboxPoller.pollIfAuthenticated()
+                async let flush: Void = outboxPusher.flushIfAuthenticated(force: true)
+                _ = await (poll, flush)
+            }
         } label: {
             HStack {
                 Text("Sync now")
                 Spacer()
-                if inboxPoller.isPolling {
+                if inboxPoller.isPolling || outboxPusher.isFlushing {
                     ProgressView()
                 }
             }
         }
-        .disabled(inboxPoller.isPolling)
+        .disabled(inboxPoller.isPolling || outboxPusher.isFlushing)
         .accessibilityIdentifier("account-inbox-sync-now")
     }
 

--- a/mobile-apps/ios/LiftMark/Views/Shared/AuthSyncBannerView.swift
+++ b/mobile-apps/ios/LiftMark/Views/Shared/AuthSyncBannerView.swift
@@ -38,41 +38,58 @@ struct AuthSyncBannerView: View {
     }
 
     var body: some View {
-        if shouldShow {
-            Button {
-                showingLogin = true
-            } label: {
-                HStack(spacing: LiftMarkTheme.spacingSM) {
-                    Image(systemName: "exclamationmark.icloud.fill")
-                        .foregroundStyle(.white)
-                    Text(message)
-                        .font(.subheadline.weight(.medium))
-                        .foregroundStyle(.white)
-                        .multilineTextAlignment(.leading)
-                        .lineLimit(2)
-                    Spacer(minLength: LiftMarkTheme.spacingSM)
-                    Text("Sign in")
-                        .font(.subheadline.weight(.semibold))
-                        .foregroundStyle(.white)
-                    Image(systemName: "chevron.right")
-                        .font(.caption.weight(.bold))
-                        .foregroundStyle(.white.opacity(0.8))
-                }
-                .padding(.horizontal, LiftMarkTheme.spacingMD)
-                .padding(.vertical, LiftMarkTheme.spacingSM + 2)
-                .frame(maxWidth: .infinity)
-                .background(LiftMarkTheme.warning)
-            }
-            .buttonStyle(.plain)
-            .transition(.move(edge: .top).combined(with: .opacity))
-            .accessibilityElement(children: .combine)
-            .accessibilityLabel(message)
-            .accessibilityHint("Opens sign-in to upload your completed workouts")
-            .accessibilityIdentifier("auth-sync-banner")
-            .sheet(isPresented: $showingLogin) {
-                LoginView()
+        // The `.sheet` modifier is hoisted onto a *stably-mounted* container
+        // (this VStack always exists) rather than the conditionally-rendered
+        // banner button. When the sheet hung off the `if shouldShow` branch, the
+        // first "Sign in" tap toggled `showingLogin` *and* the presenting view
+        // lived inside a structurally unstable `if` — SwiftUI tore down and
+        // re-established the branch on the ensuing re-render, dropping the
+        // in-flight sheet presentation. You had to tap a second time for it to
+        // stick. Keeping the presenter mounted for the banner's lifetime makes
+        // the modal appear on the FIRST tap. An empty VStack collapses to zero
+        // height, so the top `safeAreaInset` still reserves no space when the
+        // banner is hidden, and grows to fit it when shown.
+        VStack(spacing: 0) {
+            if shouldShow {
+                bannerButton
             }
         }
+        .sheet(isPresented: $showingLogin) {
+            LoginView()
+        }
+    }
+
+    private var bannerButton: some View {
+        Button {
+            showingLogin = true
+        } label: {
+            HStack(spacing: LiftMarkTheme.spacingSM) {
+                Image(systemName: "exclamationmark.icloud.fill")
+                    .foregroundStyle(.white)
+                Text(message)
+                    .font(.subheadline.weight(.medium))
+                    .foregroundStyle(.white)
+                    .multilineTextAlignment(.leading)
+                    .lineLimit(2)
+                Spacer(minLength: LiftMarkTheme.spacingSM)
+                Text("Sign in")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.white)
+                Image(systemName: "chevron.right")
+                    .font(.caption.weight(.bold))
+                    .foregroundStyle(.white.opacity(0.8))
+            }
+            .padding(.horizontal, LiftMarkTheme.spacingMD)
+            .padding(.vertical, LiftMarkTheme.spacingSM + 2)
+            .frame(maxWidth: .infinity)
+            .background(LiftMarkTheme.warning)
+        }
+        .buttonStyle(.plain)
+        .transition(.move(edge: .top).combined(with: .opacity))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(message)
+        .accessibilityHint("Opens sign-in to upload your completed workouts")
+        .accessibilityIdentifier("auth-sync-banner")
     }
 }
 

--- a/mobile-apps/ios/LiftMarkTests/OutboxPusherServiceTests.swift
+++ b/mobile-apps/ios/LiftMarkTests/OutboxPusherServiceTests.swift
@@ -250,6 +250,55 @@ final class OutboxPusherServiceTests: XCTestCase {
         return false
     }
 
+    // MARK: - Forced flush bypasses the retry backoff
+
+    /// A manual "Sync now" (`flushIfAuthenticated(force: true)`) must push an
+    /// item parked behind a future `next_attempt_after`, while the normal
+    /// automatic flush (eligible-only) leaves it untouched.
+    func testForcedFlushPushesItemParkedBehindBackoff() async throws {
+        let sessionId = try makeCompletedSession()
+        try queue.enqueue(clientSessionId: sessionId)
+
+        // Park the item far in the future — the automatic flush, which reads
+        // `eligibleItems()`, must NOT consider it eligible.
+        let future = Date().addingTimeInterval(3600)
+        try queue.recordTransientFailure(
+            clientSessionId: sessionId,
+            nextAttemptAfter: future,
+            lastError: "Server error (503)"
+        )
+
+        // Sanity: eligibleItems() skips it, allItems() includes it.
+        XCTAssertTrue(try queue.eligibleItems().isEmpty, "Future backoff must be skipped by eligibleItems()")
+        XCTAssertEqual(try queue.allItems().count, 1, "allItems() must ignore next_attempt_after")
+
+        let pusher = OutboxPusherService(
+            authStore: makeAuthenticatedStore(),
+            apiClient: mockAPI,
+            queue: queue
+        )
+
+        // 1) Normal (non-forced) flush: nothing is eligible, so the API is never
+        //    hit and the row survives.
+        await pusher.flushIfAuthenticated()
+        XCTAssertTrue(mockAPI.sentPaths.isEmpty, "Eligible-only flush must skip a parked item")
+        XCTAssertEqual(try queue.count(), 1, "Eligible-only flush must leave the parked row in place")
+        XCTAssertEqual(pusher.pendingCount, 1)
+
+        // 2) Forced flush: queue a successful push response, force-flush, and the
+        //    parked row is pushed and removed despite its future backoff.
+        mockAPI.nextDecodableResponse = [
+            "outbox_id": "ob-1",
+            "client_session_id": sessionId,
+            "dedup_hit": false,
+        ]
+        await pusher.flushIfAuthenticated(force: true)
+
+        XCTAssertEqual(mockAPI.sentPaths, ["/v1/workouts/outbox"], "Forced flush must push the parked item")
+        XCTAssertEqual(try queue.count(), 0, "Forced flush must drain the queue past the backoff")
+        XCTAssertEqual(pusher.pendingCount, 0)
+    }
+
     func testFlushWhileSignedOutWithEmptyQueueStaysQuiet() async throws {
         XCTAssertEqual(try queue.count(), 0)
 

--- a/spec/services/workout-outbox.md
+++ b/spec/services/workout-outbox.md
@@ -174,6 +174,10 @@ Mirrors `InboxPollerService` in lifecycle and observability.
   - On app foreground transition.
   - On network reachability change from offline → online.
   - On manual "Sync now" tap in Settings.
+- **Automatic vs. forced flush.** `flushIfAuthenticated(force:)` takes a `force` flag (default `false`):
+  - **Automatic flushes** (enqueue, foreground, reachability) leave `force: false` and process only items eligible *now* — i.e. those whose `next_attempt_after` is null or in the past (`OutboxPendingQueueRepository.eligibleItems()`). This honors the retry backoff so a flapping server isn't hammered.
+  - **A manual "Sync now"** passes `force: true` and processes **all** queued items oldest-first regardless of `next_attempt_after` (`OutboxPendingQueueRepository.allItems()`). The backoff timer is an automatic-flush concern; when the user explicitly asks to sync, items parked behind a backoff window must push immediately rather than waiting out the retry timer.
+- **"Sync now" flushes BOTH directions.** The Settings "Sync now" button polls the inbox **and** force-flushes the outbox (`inboxPoller.pollIfAuthenticated()` + `outboxPusher.flushIfAuthenticated(force: true)`, run concurrently). A manual sync that only polled the inbox would silently leave completed workouts unpushed — the symptom this requirement closes.
 - **Single in-flight push gate** (`isFlushing`) — drains the queue serially, oldest first.
 - **Per-item flow**:
   1. Read the `WorkoutSession` from `workout_sessions` + descendants.
@@ -192,7 +196,7 @@ A small status pill in Settings → "Account → Sync to account":
 
 - "All workouts synced" (queue empty).
 - "N workout(s) pending sync. [Sync now]" (queue non-empty).
-- Tapping "Sync now" calls the flush method explicitly.
+- Tapping "Sync now" polls the inbox and **force-flushes the outbox** (`flushIfAuthenticated(force: true)`), bypassing the retry backoff so parked items push immediately. The spinner/disabled state reflects either an in-flight inbox poll or outbox flush.
 
 No outbox-browsing UI — the surface for "my completed workouts" remains the History tab, fed by the local database. The outbox is a side-channel for agents, not a user-facing collection.
 


### PR DESCRIPTION
## Sign-in modal flicker
**Root cause:** in `AuthSyncBannerView`, `.sheet(isPresented:)` was attached to the banner button, which only existed *inside* an `if shouldShow { … }` branch. Tapping "Sign in" set `showingLogin = true`, but the presenter lived in a structurally unstable `if`, so SwiftUI tore down and re-established that branch on the next re-render and dropped the in-flight presentation — modal appears, then immediately dismisses; the second tap "sticks" because the binding is already true. **Fix:** hoist `.sheet` onto a stably-mounted `VStack` that always exists (banner content stays conditional inside). Empty VStack collapses to zero height, so the top `safeAreaInset` reserves no space when hidden. Modal now appears on the first tap.

## "Sync now" flushes the outbox
"Sync now" only polled the inbox; pending completed workouts never pushed on a manual sync, and the auto-flush honors the `next_attempt_after` backoff. **Fix:**
- `OutboxPendingQueueRepository.allItems()` — all rows oldest-first, ignoring backoff.
- `OutboxPusherService.flushIfAuthenticated(force:)` — uses `allItems()` when forced (manual sync ignores the retry timer); automatic flushes stay `force:false` (eligible-only).
- "Sync now" now runs the inbox poll **and** `flushIfAuthenticated(force: true)`.

Spec-first: `spec/services/workout-outbox.md` (automatic vs forced flush).

## Tests
`OutboxPusherServiceTests.testForcedFlushPushesItemParkedBehindBackoff` — parks an item 1h in the future, asserts the normal flush skips it and the forced flush pushes it + drains the queue. Build green (iPhone 17 Pro); 5/5 outbox tests pass; SwiftLint no error-severity violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)