### PR TITLE
fix(auth): GET /v1/me withholds account PII from PAT callers

### DIFF
--- a/spec/services/authentication.md
+++ b/spec/services/authentication.md
@@ -77,15 +77,32 @@ via the `REFRESH_GRACE_MS` env var (read per-request) for testing.
 Returns the authenticated caller's own profile. Accepts **either** a session
 JWT **or** a PAT (resource-endpoint convention — same combined auth middleware
 the workout outbox/tokens resource routes use); no scope is required beyond
-authentication, since it is the caller's own data.
+authentication.
 
-`200` JSON:
+**PII is shaped by auth modality (least privilege).** A PAT is a credential a
+user may hand to a third-party agent (Claude Code, ChatGPT, scripts), so a
+PAT-authenticated `/v1/me` must **not** expose the account email/name. The
+non-PII subset (`tier`, `trial_ends_at`) is still returned so an agent can gate
+on plan state.
+
+Session JWT (the user inspecting their own account) — `200` JSON, **full**
+profile:
 
 ```json
 {
   "user_id": "…",
+  "tier": "trial",
+  "trial_ends_at": "…",
   "primary_email": "…",
-  "display_name": "…",
+  "display_name": "…"
+}
+```
+
+PAT — `200` JSON, **non-PII subset** (no `primary_email`, no `display_name`):
+
+```json
+{
+  "user_id": "…",
   "tier": "trial",
   "trial_ends_at": "…"
 }

--- a/validator/src/routes/me.ts
+++ b/validator/src/routes/me.ts
@@ -3,9 +3,16 @@
  *
  * Accepts EITHER a session JWT OR a PAT (resource-endpoint convention — the
  * same combined `auth` middleware the workout outbox / tokens resource routes
- * use). No scope is required beyond authentication: it is the caller's own
- * data, so any authenticated token may read it. See
- * `spec/services/authentication.md` → `GET /v1/me`.
+ * use). No scope is required beyond authentication.
+ *
+ * PII is response-shaped by auth modality (least privilege):
+ *   - **Session JWT** (the user inspecting their own account in the app /
+ *     dashboard) → full profile incl. `primary_email` + `display_name`.
+ *   - **PAT** (a least-privilege credential a user may hand to a third-party
+ *     agent — Claude Code, ChatGPT, scripts) → non-PII subset only
+ *     (`user_id`, `tier`, `trial_ends_at`). A workouts-scoped agent token must
+ *     not be able to read the account email/name. See
+ *     `spec/services/authentication.md` → `GET /v1/me`.
  */
 import { Hono } from 'hono';
 import { auth, type AuthVariables } from '../middleware/auth.js';
@@ -23,13 +30,27 @@ meRouter.get('/', auth, async (c) => {
   if (!user) {
     return c.json({ error: 'User not found' }, 404);
   }
+
+  // Non-PII base — safe for any authenticated caller, enough to gate features
+  // (e.g. an agent checking the user is on a paid/trial plan).
+  const base = {
+    user_id: user.user_id,
+    tier: user.tier,
+    trial_ends_at: user.trial_ends_at,
+  };
+
+  // `c.var.token` is set ONLY on the PAT path (the session path leaves it
+  // undefined). Withhold account PII (email/name) from PAT callers.
+  const isPat = c.var.token != null;
+  if (isPat) {
+    return c.json(base, 200);
+  }
+
   return c.json(
     {
-      user_id: user.user_id,
+      ...base,
       primary_email: user.primary_email,
       display_name: user.display_name,
-      tier: user.tier,
-      trial_ends_at: user.trial_ends_at,
     },
     200,
   );

--- a/validator/tests/routes/me.test.ts
+++ b/validator/tests/routes/me.test.ts
@@ -5,8 +5,8 @@ const live = process.env.DDB_ENDPOINT ? describe : describe.skip;
 
 interface MeBody {
   user_id: string;
-  primary_email: string;
-  display_name: string;
+  primary_email?: string;
+  display_name?: string;
   tier: string;
   trial_ends_at: string;
 }
@@ -64,7 +64,7 @@ live('GET /v1/me', () => {
     expect(typeof body.trial_ends_at).toBe('string');
   });
 
-  it('returns the authenticated user profile (PAT)', async () => {
+  it('returns a non-PII profile for a PAT (no email / display_name)', async () => {
     const user = await createUser({
       display_name: 'PAT Me',
       primary_email: uniqueEmail('me-pat'),
@@ -81,8 +81,14 @@ live('GET /v1/me', () => {
     });
     expect(res.status).toBe(200);
     const body = (await res.json()) as MeBody;
+    // Non-PII fields ARE present (enough to gate features).
     expect(body.user_id).toBe(user.user_id);
-    expect(body.display_name).toBe('PAT Me');
+    expect(body.tier).toBe('trial');
+    expect(typeof body.trial_ends_at).toBe('string');
+    // PII is withheld from a PAT — a least-privilege agent token must not be
+    // able to read the account email/name.
+    expect(body.primary_email).toBeUndefined();
+    expect(body.display_name).toBeUndefined();
   });
 
   it('unauthenticated → 401', async () => {


### PR DESCRIPTION
## Why (security review follow-up)
`/v1/me` used base `auth` with **no scope**, so any valid PAT — including a `workouts:read`-only token a user hands to a third-party agent (Claude Code, ChatGPT, scripts) — could read the account `primary_email` and `display_name`. That's broader than a least-privilege agent token should see.

## Change
Shape the response by auth modality:
- **Session JWT** (user inspecting their own account) → **full** profile incl. `primary_email` + `display_name` *(unchanged — the iOS app uses a session JWT, so profile restore is unaffected)*.
- **PAT** → **non-PII subset**: `{ user_id, tier, trial_ends_at }` — enough for an agent to gate on plan state, no email/name.

Disambiguated by `c.var.token` (set only on the PAT auth path). Spec: `authentication.md → GET /v1/me` documents both shapes.

## Tests
`me.test.ts`: PAT response asserts `primary_email`/`display_name` are **absent** while `tier`/`trial_ends_at` are present; session response unchanged. **4/4 pass** against local DynamoDB; typecheck clean. Auto-deploys via validator-ci on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)