### PR TITLE
feat(ios): show app mark beside the wordmark on the home header

### DIFF
--- a/mobile-apps/ios/LiftMark/Views/Home/HomeView.swift
+++ b/mobile-apps/ios/LiftMark/Views/Home/HomeView.swift
@@ -38,9 +38,15 @@ struct HomeView: View {
     var body: some View {
         ScrollView {
             VStack(spacing: LiftMarkTheme.spacingMD) {
-                // Brand wordmark — uses the logo (with the custom 'l') rather
-                // than the typeface, which renders a plain 'l'.
-                HStack {
+                // Brand lockup — the app mark beside the wordmark logo (the
+                // wordmark carries the custom 'l' the typeface lacks).
+                HStack(spacing: 10) {
+                    Image("BrandMark")
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 34, height: 34)
+                        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+                        .accessibilityHidden(true)
                     Image("BrandWordmark")
                         .resizable()
                         .scaledToFit()


### PR DESCRIPTION
Small brand follow-up to #190 (PR #223). Places the `BrandMark` icon to the left of the `BrandWordmark` logo on the Home header so the screen shows the full brand lockup (mark + wordmark) instead of the wordmark alone.

- Mark is 34×34, lightly rounded, decorative (`accessibilityHidden`).
- Wordmark keeps its `lift.md` accessibility label + `.isHeader` trait.
- No string/behavior changes.

## Verification
- `make build` green; `make test-unit` green.
- Verified on the iPhone 17 Pro simulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)