### PR TITLE
test(e2e): fix home format-CTA assertion for multiple CTAs

### DIFF
--- a/validator/e2e/tests/home.spec.ts
+++ b/validator/e2e/tests/home.spec.ts
@@ -16,9 +16,14 @@ test.describe('Marketing landing page', () => {
     ).toBeVisible();
 
     // CTA that routes to the format hub (the format content moved off home).
-    await expect(
-      page.getByRole('link', { name: /explore the format/i }),
-    ).toBeVisible();
+    // The page carries more than one "Explore the format" link now (a pillar
+    // CTA and the button below the pillars), so assert at least one is visible
+    // and that every match points at /format.
+    const formatCtas = page.getByRole('link', { name: /explore the format/i });
+    await expect(formatCtas.first()).toBeVisible();
+    for (const cta of await formatCtas.all()) {
+      await expect(cta).toHaveAttribute('href', '/format');
+    }
 
     // The marketing landing must NOT carry the format examples anymore —
     // those live on /format.


### PR DESCRIPTION
Follow-up to #225. The homepage redesign added an **"Explore the format →" pillar CTA** alongside the button below the pillars — two links matching `/explore the format/i`, which tripped Playwright's strict-mode single-match in `home.spec.ts` and turned `e2e-local` red on main.

Fix: assert the first format CTA is visible and that every match points at `/format`.

Verified locally against the built site (`npx playwright test home.spec.ts`): **1 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)