### PR TITLE
ci(ggshield): skip secret scan on Dependabot PRs

### DIFF
--- a/.github/workflows/ggshield.yml
+++ b/.github/workflows/ggshield.yml
@@ -26,6 +26,18 @@ jobs:
   ggshield:
     name: ggshield
     runs-on: ubuntu-latest
+    # Skip on Dependabot-authored PRs. GitHub runs Dependabot PRs in a
+    # restricted context that withholds repo Actions secrets, so
+    # GITGUARDIAN_API_KEY is empty and the scan dies with "Invalid GitGuardian
+    # API key" — a false failure that blocked this required check on every
+    # dependency bump. Dependabot only edits dependency manifests/lockfiles and
+    # cannot introduce secrets, and the push-to-main scan below (which DOES have
+    # the key) still covers the merged code. Keyed off the immutable PR author
+    # (not github.actor) so it stays skipped even when a maintainer updates the
+    # branch. A job skipped by `if:` reports "skipped", which the branch ruleset
+    # counts as a passing required check (same pattern as build-and-test in
+    # swift-ci.yml).
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Problem

`ggshield` is a **required** status check, but it fails on **every Dependabot PR**:

```
Secret source: Dependabot
GITGUARDIAN_API_KEY:
Error: Invalid GitGuardian API key.
```

GitHub runs Dependabot-triggered workflows in a restricted context that withholds the repo's normal Actions secrets, so `GITGUARDIAN_API_KEY` is empty and the scan can't authenticate. This blocks merging all dependency bumps even though every real test passes.

## Fix

Skip the `ggshield` job on Dependabot-authored PRs via a job-level `if:`, keyed off the **immutable PR author** (`github.event.pull_request.user.login`) rather than `github.actor`, so it stays skipped even when a maintainer updates the branch.

This is safe because:
- Dependabot only edits dependency manifests/lockfiles — it cannot introduce secrets.
- The **push-to-main** scan (which *does* have the key) still scans the merged code.
- A job skipped by `if:` reports "skipped", which the branch ruleset counts as a passing required check — the same pattern already documented for `build-and-test` in `swift-ci.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)