### PR TITLE
fix(iam): repoint GitHub OIDC deploy trust to vfilby/lift.md

### DIFF
--- a/validator/cdk/iam/README.md
+++ b/validator/cdk/iam/README.md
@@ -20,7 +20,7 @@ The GitHub Actions deploy jobs (`.github/workflows/validator-ci.yml`) authentica
 
 - a GitHub OIDC identity provider (`token.actions.githubusercontent.com`), and
 - a role `GitHubActionsDeploy` whose trust is scoped to a single GitHub Environment `sub`
-  (`repo:vfilby/liftmark:environment:beta` / `…:environment:production`) and whose only
+  (`repo:vfilby/lift.md:environment:beta` / `…:environment:production`) and whose only
   permissions are to `sts:AssumeRole` the `cdk-lmwf-*` bootstrap roles (plus the e2e secret
   read in beta).
 
@@ -46,9 +46,9 @@ The script prints the role ARN and the `gh variable set` command to publish it t
 matching GitHub Environment, e.g.:
 
 ```bash
-gh variable set AWS_DEPLOY_ROLE_ARN --repo vfilby/liftmark --env beta \
+gh variable set AWS_DEPLOY_ROLE_ARN --repo vfilby/lift.md --env beta \
   --body "arn:aws:iam::323146837100:role/GitHubActionsDeploy"
-gh variable set AWS_DEPLOY_ROLE_ARN --repo vfilby/liftmark --env production \
+gh variable set AWS_DEPLOY_ROLE_ARN --repo vfilby/lift.md --env production \
   --body "arn:aws:iam::825347768149:role/GitHubActionsDeploy"
 ```
 

--- a/validator/cdk/iam/github-oidc-trust-beta.json
+++ b/validator/cdk/iam/github-oidc-trust-beta.json
@@ -11,7 +11,7 @@
       "Condition": {
         "StringEquals": {
           "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
-          "token.actions.githubusercontent.com:sub": "repo:vfilby/liftmark:environment:beta"
+          "token.actions.githubusercontent.com:sub": "repo:vfilby/lift.md:environment:beta"
         }
       }
     }

--- a/validator/cdk/iam/github-oidc-trust-prod.json
+++ b/validator/cdk/iam/github-oidc-trust-prod.json
@@ -11,7 +11,7 @@
       "Condition": {
         "StringEquals": {
           "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
-          "token.actions.githubusercontent.com:sub": "repo:vfilby/liftmark:environment:production"
+          "token.actions.githubusercontent.com:sub": "repo:vfilby/lift.md:environment:production"
         }
       }
     }

--- a/validator/cdk/iam/setup-oidc.sh
+++ b/validator/cdk/iam/setup-oidc.sh
@@ -17,7 +17,7 @@
 set -euo pipefail
 
 STAGE="${1:-}"
-REPO="vfilby/liftmark"
+REPO="vfilby/lift.md"
 ROLE_NAME="GitHubActionsDeploy"
 # Thumbprint is no longer security-critical for the GitHub provider (AWS
 # validates the token against its own trust store) but the create API still


### PR DESCRIPTION
## Why
The repo rename `vfilby/liftmark` → `vfilby/lift.md` broke deploys. The GitHub OIDC token's `sub` claim is now `repo:vfilby/lift.md:environment:{beta,production}`, but `GitHubActionsDeploy`'s trust policy still pinned the old slug, so every deploy job fails at the first step:

```
Could not assume role with OIDC: Not authorized to perform sts:AssumeRoleWithWebIdentity
```

This is why the website link change (#241) merged green but **never deployed** — `deploy-beta` failed on AssumeRole, `deploy-prod` was skipped.

## Changes
- `github-oidc-trust-beta.json` / `github-oidc-trust-prod.json` — `sub` claim → `vfilby/lift.md`
- `setup-oidc.sh` — `REPO` var
- `README.md` — doc references

## ⚠️ Merging is not enough — manual apply required
These are **bootstrap-tier** files (applied once per account from a privileged SSO session, deliberately not in the CDK app / not run by the pipeline — the role *is* what the pipeline authenticates as). After merge, someone with SSO admin must run, from `validator/cdk/iam/`:

```bash
./setup-oidc.sh beta
./setup-oidc.sh prod
```

Until that runs, all deploys remain blocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)