### PR TITLE
feat(website): tabbed agent setup + downloadable skill on /agents (#239)

### DIFF
--- a/website/src/components/LmwfCode.astro
+++ b/website/src/components/LmwfCode.astro
@@ -1,0 +1,55 @@
+---
+// Shared lift.md "format as brand" code widget (brand book §12): muted
+// headings, orange @modifiers, light-blue set lines, on an ink surface that's
+// the same in light and dark. Highlighting happens at build time so there's no
+// client JS — keeps the strict `script-src 'self'` CSP clean.
+//
+// The token spans are injected via set:html, so they never receive Astro's
+// scoped attribute; the token CSS is therefore global.
+interface Props {
+  /** lift.md format source to render. */
+  code: string;
+}
+const { code } = Astro.props;
+
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+function highlightLmwf(src: string): string {
+  return src
+    .split('\n')
+    .map((line) => {
+      if (/^#{1,6}\s/.test(line)) {
+        return `<span class="lmwf-h">${escapeHtml(line)}</span>`;
+      }
+      // Color @key: modifiers wherever they appear (metadata + inline @rest:).
+      const atColored = escapeHtml(line).replace(
+        /@[\w-]+:/g,
+        '<span class="lmwf-at">$&</span>',
+      );
+      if (/^\s*-\s/.test(line)) {
+        return `<span class="lmwf-set">${atColored}</span>`;
+      }
+      return atColored;
+    })
+    .join('\n');
+}
+const html = highlightLmwf(code);
+---
+
+<pre class="lmwf-code"><code set:html={html} /></pre>
+
+<style is:global>
+  .lmwf-code {
+    background: var(--lm-ink);
+    color: #e6e9ee;
+    border: 1px solid var(--lm-n-800);
+    border-radius: var(--lm-radius-lg);
+    padding: 1.2rem 1.4rem;
+    line-height: 1.7;
+  }
+  .lmwf-code code { color: inherit; }
+  .lmwf-h { color: #8aa3ff; }   /* headers — brand blue */
+  .lmwf-at { color: #ff8a3d; }  /* @modifiers — orange */
+  .lmwf-set { color: #9aa4b2; } /* set lines — grey */
+</style>

--- a/website/src/pages/agents/index.astro
+++ b/website/src/pages/agents/index.astro
@@ -1,16 +1,55 @@
 ---
 import Base from '../../layouts/Base.astro';
+import LmwfCode from '../../components/LmwfCode.astro';
 
+// The agent integrations, in tab order. The id drives the radio/label/panel
+// wiring and the CSS selectors below.
+const tabs = [
+  { id: 'claude', label: 'Claude Code' },
+  { id: 'cowork', label: 'Cowork / Claude' },
+  { id: 'codex', label: 'Codex' },
+  { id: 'generic', label: 'Generic' },
+];
+
+// One-line installer for Claude Code (and any agent that can run it).
 const skillInstall = `curl -fsSL https://getlift.md/install.sh | sh`;
 
-const validateExample = `curl -sX POST https://getlift.md/validate \\
-  -H 'Content-Type: application/json' \\
-  -d '{"markdown": "# Bench Day\\n@units: lbs\\n\\n## Bench Press\\n- 135 x 5\\n- 185 x 5"}'`;
+// A minimal workout — the whole format at a glance.
+const formatExample = `# Bench Day
+@units: lbs
+
+## Bench Press
+- 135 x 5
+- 185 x 5
+- 225 x 5`;
+
+// Codex reads this from AGENTS.md (repo root or ~/.codex/AGENTS.md).
+const agentsRecipe = `# lift.md workouts
+
+When I ask you to write or edit a lift.md (LiftMark) workout:
+
+1. Read the format spec first and follow it:
+   curl -s https://getlift.md/spec.md
+2. Write the plan in lift.md format — a \`# Title\`, \`## Exercise\`
+   headings, and \`- weight x reps\` set lines.
+3. Validate before showing it to me. Save the workout to a file and POST it:
+   curl -s -X POST https://getlift.md/validate \\
+     -H 'Content-Type: text/markdown' \\
+     --data-binary @workout.md
+4. The response is JSON: {success, summary, errors, warnings}. If success is
+   false, fix everything listed in errors and re-validate. Only hand me a
+   workout that validates.`;
+
+// Raw-markdown validate call — no JSON escaping, the simplest form for any
+// tool. The validator also accepts {"markdown": "..."} as application/json.
+const validateRaw = `curl -s -X POST https://getlift.md/validate \\
+  -H 'Content-Type: text/markdown' \\
+  --data-binary @workout.md`;
 ---
 
 <Base
   title="Agents"
-  description="Use lift.md format with LLMs and coding agents — an open markdown format, a machine-readable llms.txt index, a live validator API, and a one-line Claude Code skill installer."
+  description="Use lift.md format with any LLM or coding agent — an open markdown format, a machine-readable llms.txt index, a live validator API, and a downloadable skill for Claude Code, Cowork, and claude.ai."
 >
   <h1>Built for agents</h1>
 
@@ -18,19 +57,19 @@ const validateExample = `curl -sX POST https://getlift.md/validate \\
     lift.md format is plain markdown, so any LLM can read and write workouts
     without special tooling. Bring your own model — there's nothing
     proprietary to learn, no SDK to install, and no lock-in. This page collects
-    the resources that make LiftMark easy to drive from an agent.
+    the resources that make LiftMark easy to drive from an agent, plus
+    copy-paste setup for the common ones.
   </p>
 
   <h2>The format is just markdown</h2>
 
-  <p>
-    A workout plan is a header, exercises, and lists of sets. LLMs generate
-    and edit it reliably because it looks like the markdown they already
-    produce. See the <a href="/format">format hub</a> for the pitch and a live
-    validator, or the <a href="/format/spec">full spec</a> for every modifier
-    and rule. The spec is also available as
-    <a href="/spec.md">raw markdown</a> if you want to feed it directly into a
-    model's context.
+  <p>A header, exercises, and lists of sets:</p>
+
+  <LmwfCode code={formatExample} />
+
+  <p class="muted">
+    Full <a href="/format/spec">spec</a> (or
+    <a href="/spec.md">raw markdown</a> to feed into a model's context).
   </p>
 
   <h2>llms.txt</h2>
@@ -45,24 +84,132 @@ const validateExample = `curl -sX POST https://getlift.md/validate \\
 
   <p>
     Have an agent check its own output against the live validator at
-    <code>POST https://getlift.md/validate</code>. Send a JSON body of
-    <code>&#123;"markdown": "..."&#125;</code> and you get back
-    <code>&#123;success, summary, errors, warnings&#125;</code> — feed the
-    errors back to the model to iterate.
+    <code>POST https://getlift.md/validate</code>. The simplest call is the raw
+    markdown as the request body — no JSON escaping:
   </p>
 
-  <pre class="agents-code"><code>{validateExample}</code></pre>
+  <pre class="agents-code"><code>{validateRaw}</code></pre>
 
-  <h2>Claude Code skill</h2>
+  <p class="muted">
+    Prefer JSON? Send <code>Content-Type: application/json</code> with a body of
+    <code>&#123;"markdown": "..."&#125;</code>. Either way you get back
+    <code>&#123;success, summary, errors, warnings&#125;</code> — feed the
+    errors back to the model to iterate until <code>success</code> is true.
+  </p>
+
+  <h2>The skill</h2>
 
   <p>
-    If you use <a href="https://claude.com/claude-code" rel="external noopener">Claude Code</a>,
-    install the <code>generate-workout</code> skill with one line. It teaches
-    Claude to generate lift.md format workouts and validate them against the
-    API automatically:
+    Most of the work is packaged as one <a href="https://www.anthropic.com/news/skills" rel="external noopener">Agent
+    Skill</a>, <code>generate-workout</code>: it teaches the model the format
+    and validates every workout against the API. Install it with one line, or
+    <a href="/generate-workout.zip" download>download the skill bundle</a> and
+    add it to any tool that loads skills. Pick your agent below.
   </p>
 
-  <pre class="agents-code"><code>{skillInstall}</code></pre>
+  <div class="agent-tabs">
+    {tabs.map((t, i) => (
+      <input
+        type="radio"
+        name="agent-tab"
+        id={`tab-${t.id}`}
+        class="agent-tab-input"
+        checked={i === 0}
+      />
+    ))}
+
+    <div class="agent-tablist" role="tablist" aria-label="Agent setup">
+      {tabs.map((t) => (
+        <label class="agent-tab" for={`tab-${t.id}`}>{t.label}</label>
+      ))}
+    </div>
+
+    <div class="agent-panels">
+      <section class="agent-panel" id="panel-claude" aria-label="Claude Code">
+        <p>
+          Install the <code>generate-workout</code> skill with one line. It
+          teaches <a href="https://claude.com/claude-code" rel="external noopener">Claude
+          Code</a> the format and validates every workout against the API
+          automatically:
+        </p>
+        <pre class="agents-code"><code>{skillInstall}</code></pre>
+        <p>
+          Start a new session and ask for a workout — e.g. <em>"write me a
+          push day in lift.md format"</em>. The skill fetches the spec, drafts
+          the plan, and loops on the validator until it passes. (You can also
+          just tell Claude to run that installer for you.)
+        </p>
+      </section>
+
+      <section class="agent-panel" id="panel-cowork" aria-label="Cowork / Claude">
+        <p>
+          <a href="https://www.anthropic.com/news/cowork" rel="external noopener">Cowork</a>
+          and <a href="https://claude.ai" rel="external noopener">claude.ai</a>
+          both run the same Agent Skills. Grab the bundle and add it:
+        </p>
+        <p>
+          <a class="lm-btn lm-btn-primary" href="/generate-workout.zip" download>Download the skill (.zip)</a>
+        </p>
+        <ul>
+          <li>
+            <strong>claude.ai:</strong> Customize → Skills → <strong>+</strong>
+            → Create skill, and upload the zip.
+          </li>
+          <li>
+            <strong>Cowork:</strong> add it the same way under Customize, or
+            just ask Claude to install it for you.
+          </li>
+        </ul>
+        <p class="muted">
+          The skill validates automatically wherever the sandbox is allowed to
+          reach <code>getlift.md</code> (Cowork running locally, or a claude.ai
+          workspace with outbound access enabled). If network egress is locked
+          down, the skill still writes correct lift.md — validate the result
+          yourself by pasting it into the box on the
+          <a href="/format">format hub</a>.
+        </p>
+      </section>
+
+      <section class="agent-panel" id="panel-codex" aria-label="Codex">
+        <p>
+          <a href="https://developers.openai.com/codex/cli" rel="external noopener">Codex
+          CLI</a> reads an <code>AGENTS.md</code> file from your repo root (or
+          <code>~/.codex/AGENTS.md</code> for all projects). Drop in this
+          recipe and Codex will fetch the spec and validate its own output:
+        </p>
+        <pre class="agents-code"><code>{agentsRecipe}</code></pre>
+        <p class="muted">
+          Codex runs with network access off by default — approve the network
+          prompt when it validates, or run with Full Access. No other setup
+          needed.
+        </p>
+      </section>
+
+      <section class="agent-panel" id="panel-generic" aria-label="Generic">
+        <p>
+          No special tooling — this works with any model behind the OpenAI or
+          Anthropic API, or any agent that can make an HTTP request:
+        </p>
+        <ol>
+          <li>
+            Fetch the spec once and put it in your system prompt:
+            <code>curl -s https://getlift.md/spec.md</code>. It's static, so
+            cache it (with Anthropic, mark the block for prompt caching).
+          </li>
+          <li>Have the model produce a workout in lift.md format.</li>
+          <li>
+            POST the output to the validator (raw markdown is simplest):
+            <pre class="agents-code"><code>{validateRaw}</code></pre>
+          </li>
+          <li>
+            If <code>success</code> is false, append the <code>errors</code>
+            array to the conversation and ask for a fix. Repeat — bounded to a
+            few retries — until it validates.
+          </li>
+        </ol>
+      </section>
+    </div>
+  </div>
 
   <h2>Links</h2>
 
@@ -70,6 +217,7 @@ const validateExample = `curl -sX POST https://getlift.md/validate \\
     <li><a href="/format">Format hub</a> — pitch, examples, and live validator</li>
     <li><a href="/format/spec">Full specification</a> (also <a href="/spec.md">raw markdown</a>)</li>
     <li><a href="/llms.txt">llms.txt</a> — machine-readable index for LLMs</li>
+    <li><a href="/generate-workout.zip" download>generate-workout skill</a> (.zip) — or <code>curl -fsSL https://getlift.md/install.sh | sh</code></li>
     <li>Validator API: <code>POST https://getlift.md/validate</code></li>
     <li><a href="https://github.com/vfilby/lift.md" rel="external noopener">GitHub repository</a></li>
   </ul>
@@ -83,5 +231,84 @@ const validateExample = `curl -sX POST https://getlift.md/validate \\
       overflow-x: auto;
       font-size: 0.9rem;
     }
+
+    /* ── CSS-only tabs ──────────────────────────────────────────────────
+       Radio inputs hold the selected-tab state; labels are the clickable
+       tabs; the matching panel is revealed with a general-sibling selector.
+       No JS — keeps the strict `script-src 'self'` CSP clean. */
+    /* position:relative anchors the absolutely-positioned hidden radios to
+       this container, so focusing one (on tab click) doesn't scroll the page. */
+    .agent-tabs { margin: 1.25rem 0 2rem; position: relative; }
+
+    /* Visually hidden but still focusable for keyboard tab-switching. */
+    .agent-tab-input {
+      position: absolute;
+      top: 0;
+      width: 1px;
+      height: 1px;
+      opacity: 0;
+      pointer-events: none;
+    }
+
+    .agent-tablist {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.25rem;
+      border-bottom: 1px solid var(--color-border);
+      margin-bottom: 1.25rem;
+    }
+
+    .agent-tab {
+      display: inline-flex;
+      align-items: center;
+      padding: 0.55rem 0.95rem;
+      font-family: var(--font-sans);
+      font-size: 0.95rem;
+      font-weight: var(--lm-fw-medium);
+      color: var(--color-muted);
+      cursor: pointer;
+      border: 1px solid transparent;
+      border-bottom: none;
+      border-radius: var(--lm-radius-md) var(--lm-radius-md) 0 0;
+      margin-bottom: -1px;
+      white-space: nowrap;
+    }
+    .agent-tab:hover { color: var(--color-fg); }
+
+    .agent-panel { display: none; }
+    .agent-panel > :first-child { margin-top: 0; }
+
+    /* Active tab: accent text + a connected "card" lip over the rule. */
+    #tab-claude:checked ~ .agent-tablist label[for="tab-claude"],
+    #tab-cowork:checked ~ .agent-tablist label[for="tab-cowork"],
+    #tab-codex:checked ~ .agent-tablist label[for="tab-codex"],
+    #tab-generic:checked ~ .agent-tablist label[for="tab-generic"] {
+      color: var(--color-accent);
+      border-color: var(--color-border);
+      border-bottom-color: var(--color-bg);
+      background: var(--color-bg);
+    }
+
+    /* Reveal the matching panel. */
+    #tab-claude:checked ~ .agent-panels #panel-claude,
+    #tab-cowork:checked ~ .agent-panels #panel-cowork,
+    #tab-codex:checked ~ .agent-panels #panel-codex,
+    #tab-generic:checked ~ .agent-panels #panel-generic {
+      display: block;
+    }
+
+    /* Keyboard focus ring on the active tab's label. */
+    #tab-claude:focus-visible ~ .agent-tablist label[for="tab-claude"],
+    #tab-cowork:focus-visible ~ .agent-tablist label[for="tab-cowork"],
+    #tab-codex:focus-visible ~ .agent-tablist label[for="tab-codex"],
+    #tab-generic:focus-visible ~ .agent-tablist label[for="tab-generic"] {
+      outline: 2px solid var(--color-accent);
+      outline-offset: 2px;
+    }
+
+    .agent-panel ol { margin: 0; }
+    .agent-panel li { margin-bottom: 0.6rem; }
+    .agent-panel li .agents-code { margin: 0.5rem 0 0; }
+    .agent-panel .lm-btn { margin: 0.25rem 0; }
   </style>
 </Base>

--- a/website/src/pages/format/index.astro
+++ b/website/src/pages/format/index.astro
@@ -1,5 +1,6 @@
 ---
 import Base from '../../layouts/Base.astro';
+import LmwfCode from '../../components/LmwfCode.astro';
 
 const minimalExample = `# Bench Day
 @units: lbs
@@ -63,34 +64,8 @@ Strict press, no leg drive. If the last set feels easy, add 5 lbs next session.
 - 2m
 `;
 
-// "The format as brand" (brand book §12): show lift.md format with
-// consistent token coloring — headings muted, @modifiers orange, set lines
-// light blue — on an ink surface. Highlighting happens at build time so no
-// client JS is needed (keeps the strict `script-src 'self'` CSP clean).
-function escapeHtml(s: string): string {
-  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-}
-function highlightLmwf(src: string): string {
-  return src
-    .split('\n')
-    .map((line) => {
-      if (/^#{1,6}\s/.test(line)) {
-        return `<span class="lmwf-h">${escapeHtml(line)}</span>`;
-      }
-      // Color @key: modifiers wherever they appear (metadata + inline @rest:).
-      const atColored = escapeHtml(line).replace(
-        /@[\w-]+:/g,
-        '<span class="lmwf-at">$&</span>',
-      );
-      if (/^\s*-\s/.test(line)) {
-        return `<span class="lmwf-set">${atColored}</span>`;
-      }
-      return atColored;
-    })
-    .join('\n');
-}
-const minimalHtml = highlightLmwf(minimalExample);
-const richHtml = highlightLmwf(richExample);
+// "The format as brand" code blocks use the shared <LmwfCode> widget so the
+// token coloring stays consistent across the site (format hub, agents page, …).
 ---
 
 <Base
@@ -114,7 +89,7 @@ const richHtml = highlightLmwf(richExample);
     At its simplest, a workout is a header, an exercise, and a list of sets:
   </p>
 
-  <pre class="lmwf-code"><code set:html={minimalHtml} /></pre>
+  <LmwfCode code={minimalExample} />
 
   <p>
     That's a valid lift.md format document. Most real programs need more —
@@ -122,7 +97,7 @@ const richHtml = highlightLmwf(richExample);
     time-based sets, tags, and supersets. All of it stays in plain markdown:
   </p>
 
-  <pre class="lmwf-code"><code set:html={richHtml} /></pre>
+  <LmwfCode code={richExample} />
 
   <p>
     A lift.md format document describes a workout <em>plan</em> — what you
@@ -196,22 +171,7 @@ const richHtml = highlightLmwf(richExample);
       white-space: nowrap; border: 0;
     }
 
-    /* "The format as brand" — colored lift.md format on an ink surface,
-       consistent in both light and dark themes (brand book §12).
-       The token spans are injected via set:html, so they never receive
-       Astro's scope attribute — the selectors must be :global to match. */
-    :global(.lmwf-code) {
-      background: var(--lm-ink);
-      color: #e6e9ee;
-      border: 1px solid var(--lm-n-800);
-      border-radius: var(--lm-radius-lg);
-      padding: 1.2rem 1.4rem;
-      line-height: 1.7;
-    }
-    :global(.lmwf-code code) { color: inherit; }
-    :global(.lmwf-h) { color: #9aa4b2; }
-    :global(.lmwf-at) { color: #ff8a3d; }
-    :global(.lmwf-set) { color: #8aa3ff; }
+    /* The lift.md "format as brand" code styling now lives in <LmwfCode>. */
 
     textarea {
       width: 100%;

--- a/website/src/pages/generate-workout.zip.ts
+++ b/website/src/pages/generate-workout.zip.ts
@@ -1,0 +1,127 @@
+import type { APIRoute } from 'astro';
+
+// Downloadable bundle of the `generate-workout` Agent Skill, for tools that
+// install skills by uploading a .zip (claude.ai, Cowork). Built at request
+// time from the SAME single source of truth as /install.sh and /skill/* —
+// tools/claude-skill/generate-workout/ — so the download can never drift.
+//
+// claude.ai's uploader wants the skill folder as the archive root, so the
+// entries are `generate-workout/SKILL.md` and `generate-workout/validate.sh`.
+//
+// Zip is assembled by hand (stored / no compression) to avoid pulling in a
+// zip dependency — the site keeps its dependency list to astro + marked.
+import skillSource from '../../../tools/claude-skill/generate-workout/SKILL.md?raw';
+import validateSource from '../../../tools/claude-skill/generate-workout/validate.sh?raw';
+
+const CRC_TABLE = (() => {
+  const t = new Uint32Array(256);
+  for (let n = 0; n < 256; n++) {
+    let c = n;
+    for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    t[n] = c >>> 0;
+  }
+  return t;
+})();
+
+function crc32(buf: Buffer): number {
+  let crc = 0xffffffff;
+  for (let i = 0; i < buf.length; i++) crc = CRC_TABLE[(crc ^ buf[i]) & 0xff] ^ (crc >>> 8);
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+interface Entry {
+  name: string;
+  data: Buffer;
+  /** Unix mode, e.g. 0o100644 (file) or 0o100755 (executable). */
+  mode: number;
+}
+
+function buildZip(entries: Entry[]): Buffer {
+  // Fixed DOS timestamp (2026-01-01 00:00) keeps the static build reproducible.
+  const DOS_TIME = 0;
+  const DOS_DATE = ((2026 - 1980) << 9) | (1 << 5) | 1;
+  const locals: Buffer[] = [];
+  const centrals: Buffer[] = [];
+  let offset = 0;
+
+  for (const e of entries) {
+    const name = Buffer.from(e.name, 'utf8');
+    const crc = crc32(e.data);
+    const size = e.data.length;
+
+    const local = Buffer.alloc(30);
+    local.writeUInt32LE(0x04034b50, 0); // local file header signature
+    local.writeUInt16LE(20, 4); // version needed
+    local.writeUInt16LE(0, 6); // flags
+    local.writeUInt16LE(0, 8); // method: stored
+    local.writeUInt16LE(DOS_TIME, 10);
+    local.writeUInt16LE(DOS_DATE, 12);
+    local.writeUInt32LE(crc, 14);
+    local.writeUInt32LE(size, 18); // compressed size
+    local.writeUInt32LE(size, 22); // uncompressed size
+    local.writeUInt16LE(name.length, 26);
+    local.writeUInt16LE(0, 28); // extra length
+    locals.push(local, name, e.data);
+
+    const central = Buffer.alloc(46);
+    central.writeUInt32LE(0x02014b50, 0); // central dir signature
+    central.writeUInt16LE((3 << 8) | 20, 4); // version made by: unix
+    central.writeUInt16LE(20, 6); // version needed
+    central.writeUInt16LE(0, 8); // flags
+    central.writeUInt16LE(0, 10); // method: stored
+    central.writeUInt16LE(DOS_TIME, 12);
+    central.writeUInt16LE(DOS_DATE, 14);
+    central.writeUInt32LE(crc, 16);
+    central.writeUInt32LE(size, 20);
+    central.writeUInt32LE(size, 24);
+    central.writeUInt16LE(name.length, 28);
+    central.writeUInt16LE(0, 30); // extra
+    central.writeUInt16LE(0, 32); // comment
+    central.writeUInt16LE(0, 34); // disk number
+    central.writeUInt16LE(0, 36); // internal attrs
+    central.writeUInt32LE(((e.mode & 0xffff) << 16) >>> 0, 38); // external attrs: unix mode
+    central.writeUInt32LE(offset, 42); // local header offset
+    centrals.push(central, name);
+
+    offset += local.length + name.length + e.data.length;
+  }
+
+  const centralStart = offset;
+  const centralSize = centrals.reduce((sum, b) => sum + b.length, 0);
+
+  const end = Buffer.alloc(22);
+  end.writeUInt32LE(0x06054b50, 0); // end of central dir signature
+  end.writeUInt16LE(0, 4); // disk number
+  end.writeUInt16LE(0, 6); // central dir start disk
+  end.writeUInt16LE(entries.length, 8);
+  end.writeUInt16LE(entries.length, 10);
+  end.writeUInt32LE(centralSize, 12);
+  end.writeUInt32LE(centralStart, 16);
+  end.writeUInt16LE(0, 20); // comment length
+
+  return Buffer.concat([...locals, ...centrals, end]);
+}
+
+export const GET: APIRoute = () => {
+  const zip = buildZip([
+    {
+      name: 'generate-workout/SKILL.md',
+      data: Buffer.from(skillSource, 'utf8'),
+      mode: 0o100644,
+    },
+    {
+      name: 'generate-workout/validate.sh',
+      data: Buffer.from(validateSource, 'utf8'),
+      mode: 0o100755,
+    },
+  ]);
+
+  return new Response(zip, {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/zip',
+      'Content-Disposition': 'attachment; filename="generate-workout.zip"',
+      'Cache-Control': 'public, max-age=300',
+    },
+  });
+};


### PR DESCRIPTION
Closes #239.

Makes the **Agents page** (`/agents`) clear, current, and useful for any common agent — not just Claude Code.

## What changed
- **Tabbed setup panel** (CSS-only radio tabs, no JS → keeps the strict `script-src 'self'` CSP clean) with copy-paste setup for:
  - **Claude Code** — one-line `install.sh` skill installer.
  - **Cowork / Claude** — download the skill bundle and upload it (Customize → Skills → + → Create skill), with an honest note that auto-validation only fires where the sandbox can reach `getlift.md` (Cowork local / Enterprise egress); otherwise validate manually.
  - **Codex** — paste the `AGENTS.md` recipe.
  - **Generic** — self-guided: spec in context → POST `/validate` → loop.
- **Downloadable skill bundle:** new `/generate-workout.zip` endpoint, generated at request time from the same `tools/claude-skill/generate-workout/` source as `/install.sh` (no drift). Dependency-free stored-ZIP builder (no new npm deps); skill folder at the archive root for claude.ai/Cowork upload; exec bit preserved on `validate.sh`.
- **Validator example** now leads with the raw `text/markdown` body (`--data-binary @workout.md`) — no JSON escaping; JSON form kept as a note.
- **Shared `<LmwfCode>` widget:** extracted the lift.md "format as brand" highlighter (previously inline in `/format`) into one component used by both `/agents` and `/format`. Header → brand blue, `@modifier` → orange, set lines → grey.

## Verification
- All shared primitives verified live: `/spec.md`, `/llms.txt`, `/format`, `/format/spec`, `/install.sh`, `POST /validate` (both `application/json` and `text/markdown`).
- `/generate-workout.zip` served by the dev server: HTTP 200, `unzip -t` clean, correct `generate-workout/` root, exec bit on `validate.sh`.
- `install.sh` (and the `CLAUDE_CONFIG_DIR=$HOME/.openclaw`-style override) verified in an isolated dir — real `~/.claude` untouched.
- All four tabs toggle to exactly their own panel; both pages render correctly with the shared widget.
- Per-agent config mechanisms (Codex `AGENTS.md`, claude.ai/Cowork skill upload + egress allowlist) are based on current official docs, not run end-to-end in each tool.

No spec/format change (per CLAUDE.md): this is docs + tooling only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)