### PR TITLE
test(ios): tiered UI tests — smoke gate on PRs, full suite nightly

### DIFF
--- a/.github/workflows/swift-ci.yml
+++ b/.github/workflows/swift-ci.yml
@@ -86,20 +86,19 @@ jobs:
             -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=latest' \
             | xcpretty
 
-      - name: Run unit tests
+      # PR gate runs the Smoke test plan: the full unit suite plus a render-only
+      # UI subset (testSmoke + testTabs). Fast and deterministic enough to gate
+      # every PR. The full UI suite — slow, with known flakes (issue #106) — runs
+      # nightly via .github/workflows/swift-nightly.yml (-testPlan Full).
+      - name: Run smoke tests (unit + UI render gate)
         run: |
           xcodebuild test \
             -scheme LiftMark \
             -project LiftMark.xcodeproj \
-            -only-testing:LiftMarkTests \
+            -testPlan Smoke \
             -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=latest' \
             -resultBundlePath TestResults.xcresult \
             | xcpretty
-
-      # UI tests (LiftMarkUITests) are disabled on hosted runners until we move
-      # them to a self-hosted Mac runner — they take ~20 min on macos-26, dominate
-      # PR feedback time, and have known flakes (issue #106). Re-enable once the
-      # self-hosted runner is up.
 
       - name: Upload unit test results
         uses: actions/upload-artifact@v7

--- a/.github/workflows/swift-nightly.yml
+++ b/.github/workflows/swift-nightly.yml
@@ -1,0 +1,123 @@
+name: '[iOS] Nightly UI suite'
+
+# The full UI test suite is slow (~tens of minutes) and has a known
+# order-dependent flake (issue #106), so it is kept OUT of the PR gate. The PR
+# gate runs the Smoke test plan (unit + render checks); this workflow runs the
+# Full test plan nightly against main. Failures open/append a tracking issue so
+# a red nightly is never silently ignored.
+
+on:
+  schedule:
+    # 09:17 UTC daily. Off-peak and an odd minute — GitHub delays/drops cron at
+    # the top of the hour under load, so avoid :00.
+    - cron: '17 9 * * *'
+  workflow_dispatch: {}
+
+# A manual run during a scheduled one (or vice versa) shouldn't pile up macOS
+# jobs against the public-repo concurrency cap.
+concurrency:
+  group: ios-nightly
+  cancel-in-progress: true
+
+jobs:
+  full-ui-suite:
+    runs-on: macos-26
+    timeout-minutes: 90
+    permissions:
+      contents: read
+      issues: write
+    defaults:
+      run:
+        shell: bash --noprofile --norc -eo pipefail {0}
+        working-directory: mobile-apps/ios
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Select Xcode 26
+        run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
+
+      - name: Install XcodeGen
+        run: |
+          brew install xcodegen
+          INSTALLED=$(xcodegen --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+          MINIMUM="2.45.3"
+          if [ "$(printf '%s\n' "$MINIMUM" "$INSTALLED" | sort -V | head -n1)" != "$MINIMUM" ]; then
+            echo "::error::XcodeGen version too old: need >= $MINIMUM, got $INSTALLED"
+            exit 1
+          fi
+
+      - name: Write placeholder Sentry xcconfig
+        run: |
+          # CI builds don't need a real DSN — Sentry init no-ops on empty.
+          # But the xcconfig file must exist or xcodegen's configFiles reference fails.
+          cat > Config/Sentry.xcconfig <<'EOF'
+          // CI placeholder — no DSN. Real DSN written in deploy workflow.
+          SENTRY_DSN_REST =
+          EOF
+
+      - name: Generate SentryConfig (pre-xcodegen)
+        run: ./scripts/gen-sentry-config.sh
+
+      - name: Generate Xcode project
+        run: xcodegen generate
+
+      - name: Resolve Swift packages
+        run: xcodebuild -resolvePackageDependencies -scheme LiftMark -project LiftMark.xcodeproj
+
+      # Full test plan: entire unit + UI suite (minus screenshot capture). No
+      # -retry-tests-on-failure — flakes should surface and be fixed (issue #106),
+      # not be masked by auto-retry.
+      - name: Run full suite (-testPlan Full)
+        run: |
+          xcodebuild test \
+            -scheme LiftMark \
+            -project LiftMark.xcodeproj \
+            -testPlan Full \
+            -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=latest' \
+            -resultBundlePath TestResults.xcresult \
+            | xcpretty
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: nightly-test-results
+          path: mobile-apps/ios/TestResults.xcresult
+          retention-days: 14
+
+      # A non-gating nightly is worthless if a red run goes unnoticed. On
+      # failure, open a tracking issue (or append to the existing open one so we
+      # don't spam a new issue every night).
+      - name: Open/append failure issue
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const label = 'nightly-failure';
+            const sha = context.sha.substring(0, 7);
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = `Nightly Full UI suite failed on \`${sha}\`.\n\n[View run](${runUrl})`;
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: label,
+            });
+            if (existing.data.length > 0) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.data[0].number,
+                body,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: 'Nightly UI suite failing',
+                labels: [label],
+                body,
+              });
+            }

--- a/Makefile
+++ b/Makefile
@@ -10,14 +10,15 @@ endif
 
 AWS_VAULT ?= $(AWS_VAULT_CMD) exec liftmark-validator-deploy --
 
-.PHONY: help build test test-unit test-ui generate release-alpha tools-test tools-validate tools-generate spec-generate spec-check website-install website-dev website-build website-deploy
+.PHONY: help build test test-smoke test-unit test-ui generate release-alpha tools-test tools-validate tools-generate spec-generate spec-check website-install website-dev website-build website-deploy
 
 help:
 	@echo "LiftMark Build"
 	@echo ""
 	@echo "App (mobile-apps/ios/):"
 	@echo "  make build          - Build the app"
-	@echo "  make test           - Run all tests"
+	@echo "  make test           - Run all tests (full UI suite)"
+	@echo "  make test-smoke     - Run the PR gate (unit + render-only UI subset)"
 	@echo "  make test-unit      - Run unit tests only"
 	@echo "  make test-ui        - Run UI tests only"
 	@echo "  make generate       - Regenerate Xcode project"
@@ -43,6 +44,9 @@ build:
 
 test:
 	cd mobile-apps/ios && make test
+
+test-smoke:
+	cd mobile-apps/ios && make test-smoke
 
 test-unit:
 	cd mobile-apps/ios && make test-unit

--- a/mobile-apps/ios/LiftMark.xcodeproj/xcshareddata/xcschemes/LiftMark.xcscheme
+++ b/mobile-apps/ios/LiftMark.xcodeproj/xcshareddata/xcschemes/LiftMark.xcscheme
@@ -69,8 +69,17 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "NO"
+      shouldUseLaunchSchemeArgsEnv = "YES"
       onlyGenerateCoverageForSpecifiedTargets = "NO">
+      <TestPlans>
+         <TestPlanReference
+            default = "YES"
+            reference = "container:TestPlans/Smoke.xctestplan">
+         </TestPlanReference>
+         <TestPlanReference
+            reference = "container:TestPlans/Full.xctestplan">
+         </TestPlanReference>
+      </TestPlans>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -106,13 +115,6 @@
       </Testables>
       <CommandLineArguments>
       </CommandLineArguments>
-      <EnvironmentVariables>
-         <EnvironmentVariable
-            key = "UITEST_TIMEOUT_SCALE"
-            value = "$(UITEST_TIMEOUT_SCALE)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-      </EnvironmentVariables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/mobile-apps/ios/Makefile
+++ b/mobile-apps/ios/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test test-unit test-ui clean resolve generate release-alpha screenshots
+.PHONY: build test test-smoke test-unit test-ui clean resolve generate release-alpha screenshots
 
 SCHEME = LiftMark
 PROJECT = LiftMark.xcodeproj
@@ -30,20 +30,26 @@ Config/Sentry.xcconfig:
 build:
 	xcodebuild -scheme $(SCHEME) -project $(PROJECT) -destination $(DESTINATION) build
 
-# Run all tests (unit + UI)
+# Run the entire suite (unit + full UI) via the Full test plan. This is what
+# the nightly CI workflow runs; Smoke is the default plan, so -testPlan Full is
+# required here to avoid silently shrinking to the PR-gate subset.
 test:
-	xcodebuild test -scheme $(SCHEME) -project $(PROJECT) -destination $(DESTINATION)
+	xcodebuild test -scheme $(SCHEME) -project $(PROJECT) -testPlan Full -destination $(DESTINATION)
+
+# Run exactly the PR gate: full unit suite + render-only UI subset (fast).
+test-smoke:
+	xcodebuild test -scheme $(SCHEME) -project $(PROJECT) -testPlan Smoke -destination $(DESTINATION)
 
 # Run unit tests only (fast, no simulator UI needed)
 test-unit:
 	xcodebuild test -scheme $(SCHEME) -project $(PROJECT) \
-		-only-testing:LiftMarkTests \
+		-testPlan Full -only-testing:LiftMarkTests \
 		-destination $(DESTINATION)
 
-# Run UI tests only
+# Run UI tests only (full UI suite — Full plan, not the Smoke subset)
 test-ui:
 	xcodebuild test -scheme $(SCHEME) -project $(PROJECT) \
-		-only-testing:LiftMarkUITests \
+		-testPlan Full -only-testing:LiftMarkUITests \
 		-destination $(DESTINATION)
 
 clean:

--- a/mobile-apps/ios/TestPlans/Full.xctestplan
+++ b/mobile-apps/ios/TestPlans/Full.xctestplan
@@ -1,0 +1,44 @@
+{
+  "configurations" : [
+    {
+      "id" : "5A1F0002-0000-4000-8000-000000000002",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "environmentVariableEntries" : [
+      {
+        "key" : "UITEST_TIMEOUT_SCALE",
+        "value" : "$(UITEST_TIMEOUT_SCALE)"
+      }
+    ],
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:LiftMark.xcodeproj",
+      "identifier" : "C85473E4DFB8A8D106D9E91F",
+      "name" : "LiftMark"
+    }
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:LiftMark.xcodeproj",
+        "identifier" : "EA955531AB00AA017EFBAF52",
+        "name" : "LiftMarkTests"
+      }
+    },
+    {
+      "skippedTests" : [
+        "LiftMarkUITests\/testScreenshots()"
+      ],
+      "target" : {
+        "containerPath" : "container:LiftMark.xcodeproj",
+        "identifier" : "F8ECB0187FF2B538943D49D0",
+        "name" : "LiftMarkUITests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/mobile-apps/ios/TestPlans/Smoke.xctestplan
+++ b/mobile-apps/ios/TestPlans/Smoke.xctestplan
@@ -1,0 +1,45 @@
+{
+  "configurations" : [
+    {
+      "id" : "5A1F0001-0000-4000-8000-000000000001",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "environmentVariableEntries" : [
+      {
+        "key" : "UITEST_TIMEOUT_SCALE",
+        "value" : "$(UITEST_TIMEOUT_SCALE)"
+      }
+    ],
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:LiftMark.xcodeproj",
+      "identifier" : "C85473E4DFB8A8D106D9E91F",
+      "name" : "LiftMark"
+    }
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:LiftMark.xcodeproj",
+        "identifier" : "EA955531AB00AA017EFBAF52",
+        "name" : "LiftMarkTests"
+      }
+    },
+    {
+      "selectedTests" : [
+        "LiftMarkUITests\/testSmoke()",
+        "LiftMarkUITests\/testTabs()"
+      ],
+      "target" : {
+        "containerPath" : "container:LiftMark.xcodeproj",
+        "identifier" : "F8ECB0187FF2B538943D49D0",
+        "name" : "LiftMarkUITests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/mobile-apps/ios/project.yml
+++ b/mobile-apps/ios/project.yml
@@ -226,13 +226,20 @@ schemes:
       config: Debug
     test:
       config: Debug
-      # Plumb the UI-test timeout multiplier into the test-runner process.
-      # The runner doesn't inherit host env, so we expand a build setting:
-      # `xcodebuild test ... UITEST_TIMEOUT_SCALE=2.5` flows into the runner's
-      # environment via this $(...) expansion. Unset → empty → code defaults to
-      # 1.0. Set to ~2.5–3 on slow runners (e.g. an Intel CI box).
-      environmentVariables:
-        UITEST_TIMEOUT_SCALE: "$(UITEST_TIMEOUT_SCALE)"
+      # Two-tier test plans. Smoke (the default) runs the full unit suite plus a
+      # render-only UI subset — fast and deterministic enough to gate every PR.
+      # Full runs the entire UI suite (minus screenshot capture) and is driven
+      # nightly via `xcodebuild test -testPlan Full`. See TestPlans/*.xctestplan.
+      #
+      # The UI-test timeout multiplier (UITEST_TIMEOUT_SCALE) is plumbed into the
+      # runner process from within each plan's environmentVariableEntries: the
+      # `$(...)` expands a build setting so `xcodebuild test ... UITEST_TIMEOUT_SCALE=2.5`
+      # reaches the runner. Unset → empty → code defaults to 1.0. Set to ~2.5–3
+      # on slow runners.
+      testPlans:
+        - path: TestPlans/Smoke.xctestplan
+          defaultPlan: true
+        - path: TestPlans/Full.xctestplan
       targets:
         - LiftMarkTests
         - LiftMarkUITests


### PR DESCRIPTION
## What

Re-enable iOS UI tests in CI as two tiers using Xcode test plans:

- **Smoke** (default plan) — full unit suite + render/nav UI subset (`testSmoke`, `testTabs`). **Gates every PR** (`swift-ci.yml`). Fast + deterministic.
- **Full** — entire suite minus screenshot capture. Runs **nightly** via new `swift-nightly.yml` (cron `17 9 * * *` + manual `workflow_dispatch`) on the free public-repo `macos-26` runner.

## Why

UI tests were disabled entirely in PR CI (too slow on hosted runners, plus the known order-dependent flake #106). This restores PR-level UI coverage cheaply while moving the slow, flake-prone full suite out-of-band.

## Notes

- **No `-retry-tests-on-failure`** in nightly — flakes (e.g. #106) surface instead of being masked. Nightly failures **open/append a deduped `nightly-failure` issue** so a non-gating red run isn't ignored.
- `testDatabaseBackup` (#106) is **kept in** the Full plan deliberately (don't hide flakes). The nightly may go red until #106 is fixed.
- Generated `project.pbxproj` intentionally **not** committed — CI regenerates via `xcodegen`; committing it only dragged in unrelated package-pin drift. The `.xcscheme` (test-plan refs) is committed.
- Makefiles: `test`/`test-ui` now use `-testPlan Full`; new `make test-smoke` mirrors the PR gate.

## Verification

Both gate tests verified green locally on iPhone 17 Pro sim under the Smoke plan: `testSmoke` 44.9s, `testTabs` 23.4s. `Full` plan recognized by xcodebuild; workflows + plans parse clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)