### PR TITLE
fix(ios): show synced workout start times (tolerant ISO8601 parse)

### DIFF
--- a/mobile-apps/ios/LiftMark.xcodeproj/project.pbxproj
+++ b/mobile-apps/ios/LiftMark.xcodeproj/project.pbxproj
@@ -85,6 +85,7 @@
 		575D00310F4D056AE30775AA /* Logging in Frameworks */ = {isa = PBXBuildFile; productRef = 90826DB9F2BC18668081C8B3 /* Logging */; };
 		57F4F3CDD8CB3F4716902824 /* complete.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 9E064AE978D172E88F26E1DF /* complete.mp3 */; };
 		57F8502ACA1B48E1533E8EE8 /* SettingsSectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5110D42846BCE10A32F2EF2F /* SettingsSectionTests.swift */; };
+		5830E91E90C68525FBFA97E6 /* SessionDateDisplayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F50385B7B4FDD8D7D894B9BD /* SessionDateDisplayTests.swift */; };
 		589768848F8054BCABF48594 /* ShareSheetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E207DFAAFEC931BC9C910783 /* ShareSheetTests.swift */; };
 		5A42ABE16700DB181A6DF24D /* WorkoutHighlightsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C597DD1B866C5E697491391 /* WorkoutHighlightsService.swift */; };
 		5A89491A1D1631DFCA0533B2 /* CKSyncMetadataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 156873BF197F953F583CBC22 /* CKSyncMetadataStore.swift */; };
@@ -185,7 +186,9 @@
 		BBD197B5D1741C0149632CF3 /* FeatureFlag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4376CAE24293E2D766590CC3 /* FeatureFlag.swift */; };
 		BDF8B36AB77641C02F745A82 /* ShareSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD29EB730B2F397E5B80216 /* ShareSheet.swift */; };
 		BFB166AF8B5B032BF1F68F0A /* SessionRepository+Assembly.swift in Sources */ = {isa = PBXBuildFile; fileRef = D52CCE91FC19D155114865A3 /* SessionRepository+Assembly.swift */; };
+		C234BD5138FA5C72C9CB043C /* ISO8601.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A032A0CA404FD7237B3900D /* ISO8601.swift */; };
 		C356CB231094F4126BEFA796 /* HealthKitServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E4BB7CEBD7B739F748472F1 /* HealthKitServiceTests.swift */; };
+		C4F86E10BFE289E17CD01532 /* SessionDateDisplay.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6BD6CC883FDB2ECE7EE174A /* SessionDateDisplay.swift */; };
 		C5F99407BC520BB518F3F418 /* DatabaseSeeds.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38F9A6FA3792FED0C30FF203 /* DatabaseSeeds.swift */; };
 		C7B0F6465C43263B883F4638 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 790BF9E2E0D248724753225B /* Assets.xcassets */; };
 		C7F92919C9509B277B918575 /* SettingsDataSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB97D63E7F518056280BE91A /* SettingsDataSection.swift */; };
@@ -362,6 +365,7 @@
 		58BA4F2232025DD4B5E50533 /* SyncSessionGuardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncSessionGuardTests.swift; sourceTree = "<group>"; };
 		59613C15DB7D08E18367BB55 /* WorkoutHighlightsServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutHighlightsServiceTests.swift; sourceTree = "<group>"; };
 		598097ACA9731458C838AD5E /* SettingsAboutSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsAboutSection.swift; sourceTree = "<group>"; };
+		5A032A0CA404FD7237B3900D /* ISO8601.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ISO8601.swift; sourceTree = "<group>"; };
 		5A8B0A4526BD762457DD4ABF /* CloudKitSyncProtectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudKitSyncProtectionTests.swift; sourceTree = "<group>"; };
 		5AE9C7D51ED3CF2FC7D59030 /* DatabaseManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseManagerTests.swift; sourceTree = "<group>"; };
 		602B65899BCBD9026FEB621C /* OutboxPusherServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutboxPusherServiceTests.swift; sourceTree = "<group>"; };
@@ -434,6 +438,7 @@
 		A219D1B838B112723669B571 /* LiveActivityService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityService.swift; sourceTree = "<group>"; };
 		A4285B345A9C1B0810A967BD /* SessionNotesSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionNotesSheet.swift; sourceTree = "<group>"; };
 		A5E8F64AF7979970B3D836F0 /* WorkoutSessionNotesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutSessionNotesTests.swift; sourceTree = "<group>"; };
+		A6BD6CC883FDB2ECE7EE174A /* SessionDateDisplay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionDateDisplay.swift; sourceTree = "<group>"; };
 		A8488F5EFBF4053E8DE028BC /* WorkoutExportService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutExportService.swift; sourceTree = "<group>"; };
 		A9DBA645D80EF8F29BC26002 /* DisclaimerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisclaimerView.swift; sourceTree = "<group>"; };
 		A9EDB3E6457DAF77B78F2CDD /* WorkoutDetailSubviews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutDetailSubviews.swift; sourceTree = "<group>"; };
@@ -504,6 +509,7 @@
 		F33E7AC1F974FF1C4952C4B7 /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		F367406D6EAEEB16A1D945D6 /* SetRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetRowView.swift; sourceTree = "<group>"; };
 		F37B6A4D35C21B1F5A03FFCE /* DatabaseSeedLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseSeedLoader.swift; sourceTree = "<group>"; };
+		F50385B7B4FDD8D7D894B9BD /* SessionDateDisplayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionDateDisplayTests.swift; sourceTree = "<group>"; };
 		F5F4306EFB81F0C2668F42D9 /* TokenStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenStore.swift; sourceTree = "<group>"; };
 		F60A15DD48ACEE99146D8D6B /* MarkdownParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownParser.swift; sourceTree = "<group>"; };
 		FA978B791C36287F69431C8C /* CKRecordMapper+SetMeasurement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CKRecordMapper+SetMeasurement.swift"; sourceTree = "<group>"; };
@@ -589,6 +595,8 @@
 			children = (
 				9E0BE62F2191556A9EF27651 /* DeviceLayout.swift */,
 				2FAEA3C4A0613434170BEB23 /* IDGenerator.swift */,
+				5A032A0CA404FD7237B3900D /* ISO8601.swift */,
+				A6BD6CC883FDB2ECE7EE174A /* SessionDateDisplay.swift */,
 				D86A88E0EC70AC06B3C299C4 /* WeightFormatting.swift */,
 			);
 			path = Utils;
@@ -955,6 +963,7 @@
 				4406CB6F8705596A59036876 /* PlateCalculatorTests.swift */,
 				54DEB10F36ACE6291531A52C /* RestTimerTickTests.swift */,
 				0FF868F5979A1635824B2B27 /* SecureStorageTests.swift */,
+				F50385B7B4FDD8D7D894B9BD /* SessionDateDisplayTests.swift */,
 				295B37DB7BA42365973F4AEA /* SessionLMWFEncoderTests.swift */,
 				1B9F099C51166F64AE909892 /* SessionRepositoryTests.swift */,
 				15DD705455651A8CB95DA707 /* SetMeasurementTests.swift */,
@@ -1277,6 +1286,7 @@
 				D6259E2C8BECA8FA87C34DBA /* HistoryView.swift in Sources */,
 				355E1C1963C45CE3D6B9F1CF /* HomeView.swift in Sources */,
 				18381A31136AA88E47FDBB3F /* IDGenerator.swift in Sources */,
+				C234BD5138FA5C72C9CB043C /* ISO8601.swift in Sources */,
 				81292E8D3BFED539C4C74A68 /* ImportView.swift in Sources */,
 				0705F5FA06427587A436B761 /* InboxItem.swift in Sources */,
 				4FDCABA6A6634A98A80BD8F2 /* InboxItemRepository.swift in Sources */,
@@ -1307,6 +1317,7 @@
 				DE179F500208338C247CC1D7 /* ScreenshotSeed.swift in Sources */,
 				CFA76D7EC9EE9EC8195CCD9F /* SecureStorage.swift in Sources */,
 				4795C2A323A8F776D98904FE /* SentryConfig.swift in Sources */,
+				C4F86E10BFE289E17CD01532 /* SessionDateDisplay.swift in Sources */,
 				0A1408CC7EF27C2FCA9FAEF2 /* SessionLMWFEncoder.swift in Sources */,
 				DE32D2B2D0BC36737819F32E /* SessionNotesSheet.swift in Sources */,
 				BFB166AF8B5B032BF1F68F0A /* SessionRepository+Assembly.swift in Sources */,
@@ -1419,6 +1430,7 @@
 				06EE4DED95E7B9EE13AF33F1 /* RestTimerTickTests.swift in Sources */,
 				E6D563CF0821F4255F189899 /* SchemaDiff.swift in Sources */,
 				63651EB054FBB107FBF226D2 /* SecureStorageTests.swift in Sources */,
+				5830E91E90C68525FBFA97E6 /* SessionDateDisplayTests.swift in Sources */,
 				1E13DB942E2B9D247B000EEE /* SessionLMWFEncoderTests.swift in Sources */,
 				EADBB9AC425FBF39DE7CFB70 /* SessionRepositoryTests.swift in Sources */,
 				EF4E02A74682DBE3A2A2E1B1 /* SetMeasurementTests.swift in Sources */,

--- a/mobile-apps/ios/LiftMark/Utils/ISO8601.swift
+++ b/mobile-apps/ios/LiftMark/Utils/ISO8601.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// Tolerant ISO8601 timestamp parsing.
+///
+/// The app writes timestamps with a bare `ISO8601DateFormatter()` (whole seconds, e.g.
+/// "2026-06-02T16:32:00Z"), but any value that round-trips through CloudKit
+/// (`CKRecordMapper.dateToISO` serializes with `.withFractionalSeconds`) or the API
+/// comes back WITH fractional seconds (e.g. "2026-06-02T16:32:00.000Z").
+///
+/// A bare `ISO8601DateFormatter().date(from:)` returns `nil` on a fractional-second
+/// string. That silently dropped synced workout start times in the UI — the receiving
+/// device showed "Day · duration" with no time, and the detail header fell back to the
+/// raw `date` string. Always parse session/plan timestamps through this helper so both
+/// the whole-second (locally written) and fractional-second (synced) forms are accepted.
+enum ISO8601 {
+    // ISO8601DateFormatter is thread-safe for parsing; nonisolated(unsafe) silences the
+    // Swift 6 global-state check (matches the convention used elsewhere in the app).
+    private nonisolated(unsafe) static let fractional: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+
+    private nonisolated(unsafe) static let plain: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f
+    }()
+
+    /// Parse an ISO8601 timestamp, accepting both fractional- and whole-second forms.
+    static func parse(_ string: String?) -> Date? {
+        guard let string else { return nil }
+        return fractional.date(from: string) ?? plain.date(from: string)
+    }
+}

--- a/mobile-apps/ios/LiftMark/Utils/SessionDateDisplay.swift
+++ b/mobile-apps/ios/LiftMark/Utils/SessionDateDisplay.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+/// Display formatting for a completed workout session's date / time / duration header.
+///
+/// Pure functions so the fractional-seconds tolerance (via ``ISO8601``) and the
+/// date-only fallback are unit-testable and shared between the History list card and
+/// the History detail header. The detail header previously rendered the raw ISO `date`
+/// string ("2026-06-02") whenever `startTime` was missing or unparseable; these helpers
+/// always produce a human-readable date.
+enum SessionDateDisplay {
+    private static let fullDateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "EEEE, MMMM d, yyyy"
+        return f
+    }()
+
+    private static let shortTimeFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.timeStyle = .short
+        return f
+    }()
+
+    /// Parses the `date` field, which is a calendar date ("yyyy-MM-dd") with no zone.
+    private static let dateOnlyFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd"
+        f.calendar = Calendar(identifier: .gregorian)
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = TimeZone(identifier: "UTC")
+        return f
+    }()
+
+    /// Full weekday/month/day/year line, e.g. "Tuesday, June 2, 2026".
+    /// Prefers the parsed `startTime`; falls back to the `date` (yyyy-MM-dd) calendar
+    /// date; only returns the raw `date` string if neither can be parsed.
+    static func fullDateLine(startTime: String?, date: String) -> String {
+        if let parsed = ISO8601.parse(startTime) {
+            return fullDateFormatter.string(from: parsed)
+        }
+        if let dateOnly = dateOnlyFormatter.date(from: String(date.prefix(10))) {
+            return fullDateFormatter.string(from: dateOnly)
+        }
+        return date
+    }
+
+    /// Short localized start time, e.g. "4:32 PM", or `nil` when `startTime` is missing
+    /// or unparseable.
+    static func shortTime(startTime: String?) -> String? {
+        guard let parsed = ISO8601.parse(startTime) else { return nil }
+        return shortTimeFormatter.string(from: parsed)
+    }
+
+    /// Human duration from a count of seconds, e.g. "51 min" or "1h 20m". `nil` when
+    /// no duration is recorded.
+    static func duration(seconds: Int?) -> String? {
+        guard let seconds else { return nil }
+        let minutes = seconds / 60
+        if minutes < 60 {
+            return "\(minutes) min"
+        }
+        return "\(minutes / 60)h \(minutes % 60)m"
+    }
+}

--- a/mobile-apps/ios/LiftMark/Views/History/HistoryDetailView.swift
+++ b/mobile-apps/ios/LiftMark/Views/History/HistoryDetailView.swift
@@ -279,42 +279,36 @@ struct HistoryDetailView: View {
     private func statsCard(_ session: WorkoutSession) -> some View {
         // Header card
         VStack(alignment: .leading, spacing: 4) {
-            // Full date
-            if let startTime = session.startTime,
-               let date = ISO8601DateFormatter().date(from: startTime) {
-                let dateFormatter: DateFormatter = {
-                    let f = DateFormatter()
-                    f.dateFormat = "EEEE, MMMM d, yyyy"
-                    return f
-                }()
-                let timeFormatter: DateFormatter = {
-                    let f = DateFormatter()
-                    f.timeStyle = .short
-                    return f
-                }()
-                Text(dateFormatter.string(from: date))
-                    .font(.lmBody)
-                    .fontWeight(.semibold)
+            // When embedded in the iPad split view the navigation title is suppressed,
+            // so surface the workout name here. On iPhone the name is the nav title.
+            if isEmbedded {
+                Text(session.name)
+                    .font(.lmTitle3)
+                    .fontWeight(.bold)
+                    .padding(.bottom, 2)
+            }
+
+            // Full date — falls back to the calendar date when startTime is missing or
+            // unparseable, never the raw ISO string.
+            Text(SessionDateDisplay.fullDateLine(startTime: session.startTime, date: session.date))
+                .font(.lmBody)
+                .fontWeight(.semibold)
+
+            // Start time (if known) + duration, each with its own leading separator.
+            let startTime = SessionDateDisplay.shortTime(startTime: session.startTime)
+            let duration = SessionDateDisplay.duration(seconds: session.duration)
+            if startTime != nil || duration != nil {
                 HStack(spacing: 8) {
-                    Text(timeFormatter.string(from: date))
-                    if let duration = session.duration {
-                        Text("·")
-                        let minutes = duration / 60
-                        Text(minutes < 60 ? "\(minutes) min" : "\(minutes / 60)h \(minutes % 60)m")
+                    if let startTime {
+                        Text(startTime)
+                    }
+                    if let duration {
+                        if startTime != nil { Text("·") }
+                        Text(duration)
                     }
                 }
                 .font(.lmSubheadline)
                 .foregroundStyle(.secondary)
-            } else {
-                Text(session.date)
-                    .font(.lmBody)
-                    .fontWeight(.semibold)
-                if let duration = session.duration {
-                    let minutes = duration / 60
-                    Text(minutes < 60 ? "\(minutes) min" : "\(minutes / 60)h \(minutes % 60)m")
-                        .font(.lmSubheadline)
-                        .foregroundStyle(.secondary)
-                }
             }
         }
         .padding()

--- a/mobile-apps/ios/LiftMark/Views/History/HistoryView.swift
+++ b/mobile-apps/ios/LiftMark/Views/History/HistoryView.swift
@@ -280,22 +280,11 @@ private struct SessionCardView: View {
     }
 
     private var startTimeFormatted: String? {
-        guard let startTime = session.startTime,
-              let date = ISO8601DateFormatter().date(from: startTime) else { return nil }
-        let formatter = DateFormatter()
-        formatter.timeStyle = .short
-        return formatter.string(from: date)
+        SessionDateDisplay.shortTime(startTime: session.startTime)
     }
 
     private var durationFormatted: String? {
-        guard let duration = session.duration else { return nil }
-        let minutes = duration / 60
-        if minutes < 60 {
-            return "\(minutes) min"
-        }
-        let hours = minutes / 60
-        let remainingMinutes = minutes % 60
-        return "\(hours)h \(remainingMinutes)m"
+        SessionDateDisplay.duration(seconds: session.duration)
     }
 
     var body: some View {
@@ -308,15 +297,16 @@ private struct SessionCardView: View {
 
                 HStack(spacing: LiftMarkTheme.spacingSM) {
                     Text(formattedDate)
-                    if startTimeFormatted != nil || durationFormatted != nil {
+                    // Each component carries its own leading separator so a missing
+                    // start time never leaves a dangling "· ·" gap (e.g. on a synced
+                    // record whose startTime parsed to nil before the ISO8601 fix).
+                    if let time = startTimeFormatted {
                         Text("·")
-                        if let time = startTimeFormatted {
-                            Text(time)
-                        }
-                        if let duration = durationFormatted {
-                            Text("·")
-                            Text(duration)
-                        }
+                        Text(time)
+                    }
+                    if let duration = durationFormatted {
+                        Text("·")
+                        Text(duration)
                     }
                 }
                 .font(.lmSubheadline)

--- a/mobile-apps/ios/LiftMark/Views/Workout/ActiveWorkoutView.swift
+++ b/mobile-apps/ios/LiftMark/Views/Workout/ActiveWorkoutView.swift
@@ -357,8 +357,9 @@ struct ActiveWorkoutView: View {
             let nowDate = Date()
             let nowIso = ISO8601DateFormatter().string(from: nowDate)
             snap.endTime = nowIso
-            if let startTime = snap.startTime,
-               let start = ISO8601DateFormatter().date(from: startTime) {
+            // Tolerant parse: a session resumed from another device carries a
+            // fractional-second startTime that a bare ISO8601DateFormatter rejects.
+            if let start = ISO8601.parse(snap.startTime) {
                 snap.duration = Int(nowDate.timeIntervalSince(start))
             }
             snap.status = .completed

--- a/mobile-apps/ios/LiftMarkTests/SessionDateDisplayTests.swift
+++ b/mobile-apps/ios/LiftMarkTests/SessionDateDisplayTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+@testable import LiftMark
+
+/// Regression coverage for the sync round-trip timestamp bug: a `startTime` that comes
+/// back from CloudKit with fractional seconds must still parse and format, and a missing
+/// or unparseable `startTime` must fall back to a formatted calendar date — never the raw
+/// ISO string.
+final class SessionDateDisplayTests: XCTestCase {
+
+    // MARK: - ISO8601 tolerant parsing
+
+    func testParsesWholeSecondTimestamp() {
+        let date = ISO8601.parse("2026-06-02T16:32:00Z")
+        XCTAssertNotNil(date, "Whole-second ISO8601 (locally written form) must parse")
+    }
+
+    func testParsesFractionalSecondTimestamp() {
+        // This is the form produced when a timestamp round-trips through CloudKit.
+        let date = ISO8601.parse("2026-06-02T16:32:00.000Z")
+        XCTAssertNotNil(date, "Fractional-second ISO8601 (synced form) must parse")
+    }
+
+    func testWholeAndFractionalParseToSameInstant() {
+        let whole = ISO8601.parse("2026-06-02T16:32:00Z")
+        let fractional = ISO8601.parse("2026-06-02T16:32:00.000Z")
+        XCTAssertEqual(whole, fractional, "Both forms must represent the same instant")
+    }
+
+    func testNilAndGarbageReturnNil() {
+        XCTAssertNil(ISO8601.parse(nil))
+        XCTAssertNil(ISO8601.parse(""))
+        XCTAssertNil(ISO8601.parse("not a date"))
+    }
+
+    // MARK: - shortTime
+
+    func testShortTimeFromFractionalStartTime() {
+        // The regression: synced records have fractional seconds and previously yielded nil.
+        XCTAssertNotNil(SessionDateDisplay.shortTime(startTime: "2026-06-02T16:32:00.000Z"))
+    }
+
+    func testShortTimeNilWhenStartTimeMissing() {
+        XCTAssertNil(SessionDateDisplay.shortTime(startTime: nil))
+        XCTAssertNil(SessionDateDisplay.shortTime(startTime: "garbage"))
+    }
+
+    // MARK: - fullDateLine
+
+    func testFullDateLineFromStartTime() {
+        let line = SessionDateDisplay.fullDateLine(startTime: "2026-06-02T16:32:00.000Z",
+                                                   date: "2026-06-02")
+        XCTAssertTrue(line.contains("2026"))
+        XCTAssertNotEqual(line, "2026-06-02", "Must be formatted, not the raw ISO date")
+    }
+
+    func testFullDateLineFallsBackToCalendarDateWhenStartTimeMissing() {
+        let line = SessionDateDisplay.fullDateLine(startTime: nil, date: "2026-06-02")
+        XCTAssertTrue(line.contains("June"), "Expected a formatted month, got: \(line)")
+        XCTAssertNotEqual(line, "2026-06-02", "Must never show the raw ISO date string")
+    }
+
+    func testFullDateLineHandlesDateWithTimeSuffix() {
+        // `date` is documented as yyyy-MM-dd, but be defensive about a longer string.
+        let line = SessionDateDisplay.fullDateLine(startTime: nil, date: "2026-06-02T00:00:00Z")
+        XCTAssertTrue(line.contains("June"))
+    }
+
+    // MARK: - duration
+
+    func testDurationFormatting() {
+        XCTAssertEqual(SessionDateDisplay.duration(seconds: 51 * 60), "51 min")
+        XCTAssertEqual(SessionDateDisplay.duration(seconds: 80 * 60), "1h 20m")
+        XCTAssertNil(SessionDateDisplay.duration(seconds: nil))
+    }
+}

--- a/spec/screens/history-detail.md
+++ b/spec/screens/history-detail.md
@@ -49,8 +49,11 @@ Detailed view of a completed workout session showing date/time, stats, exercises
 ## HistoryDetailView Component
 
 ### Header Card
-- Full date (weekday, month, day, year)
-- Start time + duration
+- **Workout name** — rendered as the card's primary line **only in the embedded (iPad split-view) presentation**, where the navigation title is suppressed. On iPhone the name is the navigation title and is not repeated in the card.
+- **Full date** (weekday, month, day, year). Derived from `startTime` when it can be parsed; otherwise from the `date` field (`yyyy-MM-dd` calendar date). The raw ISO `date`/`startTime` string MUST NOT be shown to the user.
+- **Start time + duration**. Start time is shown only when `startTime` is present and parseable; duration is shown whenever recorded. Each present component carries its own separator so a missing start time never leaves a dangling separator gap.
+
+> **Timestamp parsing**: `startTime` is an ISO8601 string. Values written locally use whole seconds, but values that have round-tripped through CloudKit carry fractional seconds. All session date/time parsing for display MUST go through the tolerant `ISO8601.parse` helper (accepts both forms); a bare `ISO8601DateFormatter()` rejects fractional-second strings and silently drops synced start times. See `spec/services/cloudkit-sync.md` → "Timestamp Serialization".
 
 ### Stats Grid
 - Sets (completed count)

--- a/spec/services/cloudkit-sync.md
+++ b/spec/services/cloudkit-sync.md
@@ -206,6 +206,30 @@ Maps to the `WorkoutPlan` entity in the data model.
 | `createdAt` | Date | `createdAt` |
 | `updatedAt` | Date | `updatedAt` |
 
+## Timestamp Serialization
+
+Date fields are stored in CloudKit as native `TIMESTAMP` values, but locally (and in the
+app's models) they are ISO8601 **strings**. Two formats are in circulation:
+
+- **Locally written** timestamps use a bare `ISO8601DateFormatter()` → **whole seconds**, e.g. `2026-06-02T16:32:00Z`.
+- **Synced** timestamps are re-serialized by `CKRecordMapper.dateToISO` with `.withFractionalSeconds` → **fractional seconds**, e.g. `2026-06-02T16:32:00.000Z`.
+
+A bare `ISO8601DateFormatter().date(from:)` returns `nil` on a fractional-second string.
+Therefore **all parsing of these timestamps for display or logic MUST be tolerant of both
+forms** — use the shared `ISO8601.parse` helper (tries fractional, then whole seconds),
+never a bare `ISO8601DateFormatter`.
+
+**Regression history**: A workout completed on one device showed its start time correctly
+on that device but, after syncing, lost its time on the receiving device — the History list
+row collapsed to "Day · duration" (with a dangling separator) and the detail header fell
+back to the raw `date` string. Root cause was a strict (`ISO8601DateFormatter()`) parser in
+the History views choking on the fractional-second strings produced by the sync round-trip.
+The data was present; only the parse failed.
+
+**Tests** (`SessionDateDisplayTests`): a fractional-second `startTime` parses and yields a
+formatted time; a whole-second `startTime` parses; an unparseable/absent `startTime` falls
+back to the formatted calendar date (never the raw string).
+
 ## Sync Strategy
 
 ### Phase 1: Full Download-then-Upload (Current Implementation)


### PR DESCRIPTION
## Problem (from iPad testing, GH report)

After a month of data synced to a second device:
1. Every workout's **start time disappeared** — the History list row collapsed to `Day · duration` with a dangling `· ·` gap.
2. The detail header showed the **raw `2026-06-02` date string** instead of the workout name + a formatted date.

Both reproduced on the *receiving* device only; the source device was fine.

## Root cause

Timestamps written locally use a bare `ISO8601DateFormatter()` → **whole seconds** (`...T16:32:00Z`). But any value that round-trips through CloudKit is re-serialized by `CKRecordMapper.dateToISO` with `.withFractionalSeconds` → `...T16:32:00.000Z`. The History views parsed with a bare `ISO8601DateFormatter()`, which **returns nil on fractional-second strings**. So every *synced* `startTime` silently failed to parse — the data was present, only the parse failed. (The codebase already documents this exact gotcha in `APIClient`; the views never got the fix.)

## Changes

- **`ISO8601.parse`** — shared tolerant parser (fractional → whole seconds). History list card, detail header, and active-workout duration now route through it.
- **`SessionDateDisplay`** — testable date/time/duration formatting. Detail header now shows the workout **name** in the embedded iPad split view (nav title is suppressed there) and a **formatted date** instead of the raw ISO string when `startTime` is absent.
- Fixed the list-row separator so a missing start time no longer renders `· ·`.
- **Spec**: `cloudkit-sync.md` documents timestamp serialization + the tolerant-parse requirement; `history-detail.md` updated header-card behavior.
- **Tests**: `SessionDateDisplayTests` (10 cases) covers the fractional-second regression and the date fallback.

## Verification

- `make build` ✅
- `SessionDateDisplayTests` ✅ 10/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)