### PR TITLE
feat(ios): balanced iPad plans grid + grouped superset cards in plan view

### DIFF
--- a/mobile-apps/ios/LiftMark/Views/Home/HomeView.swift
+++ b/mobile-apps/ios/LiftMark/Views/Home/HomeView.swift
@@ -168,8 +168,11 @@ struct HomeView: View {
                         .padding(LiftMarkTheme.spacingLG)
                         .accessibilityIdentifier("empty-state")
                     } else if isRegularWidth {
-                        LazyVGrid(columns: [GridItem(.adaptive(minimum: 280))], spacing: LiftMarkTheme.spacingSM) {
-                            ForEach(planStore.plans.prefix(3)) { plan in
+                        // iPad: fixed two-column grid showing up to 4 plans so the
+                        // grid fills evenly (2×2) instead of leaving a lone card on a
+                        // second row (the awkward 2+1 wrap of an odd count).
+                        LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: LiftMarkTheme.spacingSM) {
+                            ForEach(planStore.plans.prefix(4)) { plan in
                                 Button {
                                     navCoordinator.navigateToPlan(id: plan.id)
                                 } label: {

--- a/mobile-apps/ios/LiftMark/Views/Workouts/WorkoutDetailSubviews.swift
+++ b/mobile-apps/ios/LiftMark/Views/Workouts/WorkoutDetailSubviews.swift
@@ -272,26 +272,19 @@ struct PlanSupersetCard: View {
     let parent: PlannedExercise
     let children: [PlannedExercise]
     let sectionName: String?
+    /// Plan-wide 1-based number for a member exercise, so nested cards share the
+    /// same numbering scheme as standalone exercises.
+    var exerciseIndex: (PlannedExercise) -> Int = { _ in 0 }
+    /// Edit a single member exercise.
+    var onEditChild: (PlannedExercise) -> Void = { _ in }
+    /// Edit the superset grouping itself (the parent).
     var onEdit: (() -> Void)? = nil
 
-    private var interleavedSets: [(exercise: PlannedExercise, set: PlannedSet, round: Int)] {
-        let maxSets = children.map { $0.sets.count }.max() ?? 0
-        var result: [(exercise: PlannedExercise, set: PlannedSet, round: Int)] = []
-        for round in 0..<maxSets {
-            for child in children {
-                if round < child.sets.count {
-                    result.append((exercise: child, set: child.sets[round], round: round))
-                }
-            }
-        }
-        return result
-    }
-
     var body: some View {
-        let interleaved = interleavedSets
-
         VStack(alignment: .leading, spacing: LiftMarkTheme.spacingMD) {
-            // Superset header
+            // Superset header — the purple superset accent (used app-wide) tints
+            // the group frame so it reads distinctly from the neutral exercise
+            // cards nested inside it.
             HStack(spacing: LiftMarkTheme.spacingSM) {
                 Image(systemName: "arrow.triangle.2.circlepath")
                     .font(.lmCaption.bold())
@@ -301,7 +294,7 @@ struct PlanSupersetCard: View {
                     .clipShape(Circle())
 
                 VStack(alignment: .leading, spacing: 2) {
-                    Text("SUPERSET")
+                    Text("SUPERSET · \(children.count) EXERCISES")
                         .font(.lmCaption2)
                         .fontWeight(.bold)
                         .foregroundStyle(.purple)
@@ -309,10 +302,6 @@ struct PlanSupersetCard: View {
                     Text(parent.exerciseName)
                         .font(.lmCallout)
                         .fontWeight(.semibold)
-
-                    Text(children.map { $0.exerciseName }.joined(separator: " + "))
-                        .font(.lmCaption)
-                        .foregroundStyle(LiftMarkTheme.secondaryLabel)
                 }
 
                 Spacer()
@@ -332,105 +321,36 @@ struct PlanSupersetCard: View {
                 }
             }
 
-            // Per-child descriptions — only render if any child actually has notes.
-            ForEach(children, id: \.id) { child in
-                if let notes = child.notes, !notes.isEmpty {
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(child.exerciseName)
-                            .font(.lmCaption2.weight(.semibold))
-                            .foregroundStyle(LiftMarkTheme.secondaryLabel)
-                        Text(notes)
-                            .font(.lmCaption)
-                            .foregroundStyle(LiftMarkTheme.secondaryLabel)
-                            .italic()
-                    }
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                }
-            }
-
-            Divider()
-
-            // Interleaved sets
-            VStack(spacing: 0) {
-                ForEach(Array(interleaved.enumerated()), id: \.element.set.id) { idx, item in
-                    HStack(spacing: LiftMarkTheme.spacingMD) {
-                        Text("\(item.round + 1)")
-                            .font(.lmCaption)
-                            .fontWeight(.bold)
-                            .foregroundStyle(workoutSectionColor(for: sectionName ?? ""))
-                            .frame(width: 28, height: 28)
-                            .background(workoutSectionColor(for: sectionName ?? "").opacity(0.12))
-                            .clipShape(Circle())
-
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text(item.exercise.exerciseName)
-                                .font(.lmCaption2)
-                                .fontWeight(.semibold)
-                                .foregroundStyle(LiftMarkTheme.secondaryLabel)
-
-                            Text(planSetDetailString(item.set))
-                                .font(.lmBody)
-                                .foregroundStyle(LiftMarkTheme.secondaryLabel)
-                        }
-
-                        Spacer()
-
-                        if item.set.isDropset {
-                            Text("Drop")
-                                .font(.lmCaption2)
-                                .padding(.horizontal, 4)
-                                .padding(.vertical, 1)
-                                .background(LiftMarkTheme.destructive.opacity(0.15))
-                                .clipShape(Capsule())
-                        }
-                        if item.set.isPerSide {
-                            Text("/side")
-                                .font(.lmCaption2)
-                                .padding(.horizontal, 4)
-                                .padding(.vertical, 1)
-                                .background(LiftMarkTheme.primary.opacity(0.15))
-                                .clipShape(Capsule())
-                        }
-                    }
-                    .padding(.vertical, 8)
-                    .accessibilityIdentifier("set-\(item.set.id)")
-
-                    if idx < interleaved.count - 1 {
-                        Divider()
-                    }
-                }
-            }
-            .padding(.leading, 8)
-
-            // YouTube search — one link per child. Each link gets a tall row so
-            // adjacent links don't collide as tap targets.
-            Divider()
-            VStack(spacing: 16) {
+            // Each member renders with the standard PlanExerciseCard template, so
+            // set numbering, notes, badges and styling stay identical to
+            // standalone exercises. The nested cards just live inside the
+            // superset frame — sets stay grouped per exercise (no interleaving).
+            VStack(spacing: LiftMarkTheme.spacingSM) {
                 ForEach(children, id: \.id) { child in
-                    if let url = youtubeSearchURL(for: child.exerciseName) {
-                        Link(destination: url) {
-                            HStack(spacing: LiftMarkTheme.spacingSM) {
-                                Image(systemName: "play.rectangle")
-                                    .font(.lmCaption)
-                                Text("Search \"\(child.exerciseName)\" on YouTube")
-                                    .font(.lmCaption)
-                            }
-                            .foregroundStyle(LiftMarkTheme.secondaryLabel)
-                            .frame(maxWidth: .infinity, alignment: .center)
-                        }
-                        .accessibilityIdentifier("youtube-link-\(child.exerciseName)")
-                    }
+                    PlanExerciseCard(
+                        exercise: child,
+                        sectionName: sectionName,
+                        exerciseIndex: exerciseIndex(child),
+                        onEdit: { onEditChild(child) }
+                    )
+                    // Hairline border so each member card reads distinctly against
+                    // the purple tint — their pale fill alone is too close to the
+                    // tint's lightness in light mode.
+                    .overlay(
+                        RoundedRectangle(cornerRadius: LiftMarkTheme.cornerRadiusMD)
+                            .stroke(Color.purple.opacity(0.2), lineWidth: 1)
+                    )
                 }
             }
         }
         .padding()
-        .background(LiftMarkTheme.secondaryBackground)
+        .background(Color.purple.opacity(0.12))
         .clipShape(RoundedRectangle(cornerRadius: LiftMarkTheme.cornerRadiusMD))
+        .overlay(
+            RoundedRectangle(cornerRadius: LiftMarkTheme.cornerRadiusMD)
+                .stroke(Color.purple.opacity(0.5), lineWidth: 1)
+        )
+        .accessibilityElement(children: .contain)
         .accessibilityIdentifier("superset-card-\(parent.id)")
-    }
-
-    private func youtubeSearchURL(for exerciseName: String) -> URL? {
-        let query = exerciseName.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? exerciseName
-        return URL(string: "https://www.youtube.com/results?search_query=\(query)+form")
     }
 }

--- a/mobile-apps/ios/LiftMark/Views/Workouts/WorkoutDetailView.swift
+++ b/mobile-apps/ios/LiftMark/Views/Workouts/WorkoutDetailView.swift
@@ -205,6 +205,8 @@ struct WorkoutDetailView: View {
                                                 parent: parent,
                                                 children: children,
                                                 sectionName: section.name,
+                                                exerciseIndex: { globalExerciseIndex(for: $0) },
+                                                onEditChild: { editingPlanExercise = $0 },
                                                 onEdit: { editingPlanExercise = parent }
                                             )
                                         }


### PR DESCRIPTION
Two UI tweaks for the iPad home screen and the plan-detail superset rendering.

## 1. iPad Recent Plans — balanced grid
The Recent Plans section wrapped 3 plans across a 2-column adaptive grid, leaving a lone card on a second row (an awkward 2+1). It now uses a fixed two-column grid showing up to **4** plans, so it fills evenly as a 2×2. iPhone keeps its single-column list.

## 2. Plan-detail supersets — grouped, not interleaved
The plan superset card previously interleaved member sets round-robin (round 1: A, B; round 2: A, B…), which got confusing with multiple supersets on screen.

Now each superset is a **purple-tinted frame** (the existing app-wide superset accent) that nests each member exercise as a standard `PlanExerciseCard`:
- Sets stay **grouped per exercise** (no interleaving).
- Members reuse the shared template — identical set numbering, drop/side badges, notes, and plan-wide exercise numbers (e.g. Incline = 3, Lateral = 4, next exercise = 5).
- A faint purple hairline border separates each member card from the tint (the pale card fill alone was too close to the tint's lightness in light mode).

Verified live on an iPad Pro 13" simulator (seeded data) in both light and dark.

## Notes
- App Store screenshots under `Screenshots/` are unchanged here; they should be regenerated via `make screenshots` before the next App Store submission since the superset/home rendering changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)