### PR TITLE
Migrate prod off liftmark.app to getlift.md (redirect-only) (#248)

### DIFF
--- a/.github/workflows/validator-ci.yml
+++ b/.github/workflows/validator-ci.yml
@@ -428,7 +428,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: production
-      url: https://liftmark.app
+      url: https://getlift.md
     env:
       AWS_DEFAULT_REGION: us-west-2
       AWS_REGION: us-west-2
@@ -500,18 +500,23 @@ jobs:
           set -euo pipefail
           fail() { echo "FAIL: $1" >&2; exit 2; }
 
-          # liftmark.app site page must 302 to getlift.md (preserving path).
+          # liftmark.app is redirect-only (GH #248): site pages 301, API 308,
+          # AASA served as the sole exception. Mirrors the topology table in
+          # spec/services/lmwf-validator.md + validator-e2e.md.
+
+          # 1) Site page: 301 to getlift.md (path preserved).
           loc=$(curl -s -o /dev/null -w '%{http_code} %{redirect_url}' https://liftmark.app/format)
           echo "liftmark.app/format -> $loc"
-          [ "$loc" = "302 https://getlift.md/format" ] || fail "liftmark.app/format should 302 to getlift.md/format, got: $loc"
+          [ "$loc" = "301 https://getlift.md/format" ] || fail "liftmark.app/format should 301 to getlift.md/format, got: $loc"
 
-          # liftmark.app must STILL serve the API directly (no redirect).
-          code=$(curl -s -o /dev/null -w '%{http_code}' -X POST -H 'Content-Type: application/json' \
+          # 2) API: 308 (method + body preserved) to getlift.md — NOT served.
+          api=$(curl -s -o /dev/null -w '%{http_code} %{redirect_url}' -X POST -H 'Content-Type: application/json' \
             -d '{"markdown":"# T\n## Squat\n- 100 lbs x 5\n"}' https://liftmark.app/validate)
-          echo "liftmark.app/validate -> $code"
-          [ "$code" = "200" ] || fail "liftmark.app/validate should be 200 (API not redirected), got: $code"
+          echo "liftmark.app/validate -> $api"
+          [ "$api" = "308 https://getlift.md/validate" ] || fail "liftmark.app/validate should 308 to getlift.md/validate, got: $api"
 
-          # AASA must be served directly (Apple does not follow redirects).
+          # 3) AASA: served directly (200, no redirect) — Apple does not follow
+          #    redirects, and installed apps are pinned to liftmark.app.
           aasa=$(curl -s -o /dev/null -w '%{http_code} %{content_type} [%{redirect_url}]' https://liftmark.app/.well-known/apple-app-site-association)
           echo "liftmark.app AASA -> $aasa"
           case "$aasa" in
@@ -519,9 +524,20 @@ jobs:
             *) fail "AASA must be 200/application/json with no redirect, got: $aasa" ;;
           esac
 
-          # liftmd.app must 302 everything to getlift.md.
+          # 4) Canonical getlift.md serves the API directly (not a redirect).
+          gcode=$(curl -s -o /dev/null -w '%{http_code}' -X POST -H 'Content-Type: application/json' \
+            -d '{"markdown":"# T\n## Squat\n- 100 lbs x 5\n"}' https://getlift.md/validate)
+          echo "getlift.md/validate -> $gcode"
+          [ "$gcode" = "200" ] || fail "getlift.md/validate should be 200 (API served), got: $gcode"
+
+          # 5) Legacy spec host: 301 path-preserving to getlift.md/spec.md.
+          loc=$(curl -s -o /dev/null -w '%{http_code} %{redirect_url}' https://workoutformat.liftmark.app/spec.md)
+          echo "workoutformat.liftmark.app/spec.md -> $loc"
+          [ "$loc" = "301 https://getlift.md/spec.md" ] || fail "workoutformat.liftmark.app/spec.md should 301 to getlift.md/spec.md, got: $loc"
+
+          # 6) liftmd.app: 301 everything to getlift.md.
           loc=$(curl -s -o /dev/null -w '%{http_code} %{redirect_url}' https://liftmd.app/)
           echo "liftmd.app/ -> $loc"
-          [ "$loc" = "302 https://getlift.md/" ] || fail "liftmd.app/ should 302 to getlift.md/, got: $loc"
+          [ "$loc" = "301 https://getlift.md/" ] || fail "liftmd.app/ should 301 to getlift.md/, got: $loc"
 
           echo "✓ canonical redirect topology verified"

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ help:
 	@echo "  make tools-validate   - Validate JSON export (FILE=path.json)"
 	@echo "  make tools-generate   - Generate export fixture (ARGS='--single -o out.json')"
 	@echo ""
-	@echo "Website (workoutformat.liftmark.app):"
+	@echo "Website (getlift.md):"
 	@echo "  make website-install  - Install Astro dependencies"
 	@echo "  make website-dev      - Start local dev server"
 	@echo "  make website-build    - Build static site into website/dist/"
@@ -78,7 +78,7 @@ tools-validate:
 tools-generate:
 	python tools/generate_export.py $(ARGS)
 
-# ── Website (workoutformat.liftmark.app) ──
+# ── Website (getlift.md) ──
 # Infrastructure (S3 bucket + CloudFront distribution) is managed by
 # validator/cdk. Deploy infra with `cd validator && make deploy`. The
 # targets below only handle the static site content.

--- a/mobile-apps/ios/LiftMark/Services/APIClient.swift
+++ b/mobile-apps/ios/LiftMark/Services/APIClient.swift
@@ -163,8 +163,12 @@ final class APIClient: APIClientProtocol, @unchecked Sendable {
             useBeta = false
         }
         return useBeta
+            // Beta env. Migration to beta.getlift.md is a follow-up (GH #248);
+            // beta.liftmark.app still serves directly until then.
             ? URL(string: "https://beta.liftmark.app")!
-            : URL(string: "https://liftmark.app")!
+            // Canonical prod host (GH #248). liftmark.app now 308-redirects
+            // /v1/* here, but we target getlift.md directly to skip the hop.
+            : URL(string: "https://getlift.md")!
     }
 
     private func perform<Req: Encodable>(

--- a/mobile-apps/ios/LiftMark/Services/WorkoutGenerationService.swift
+++ b/mobile-apps/ios/LiftMark/Services/WorkoutGenerationService.swift
@@ -63,7 +63,7 @@ struct WorkoutValidationResult {
 
 enum WorkoutGenerationService {
 
-    static let lmwfSpecURL = "https://workoutformat.liftmark.app/spec.md"
+    static let lmwfSpecURL = "https://getlift.md/spec.md"
 
     // MARK: - Prompt Building
 

--- a/mobile-apps/ios/LiftMark/Views/Auth/LoginView.swift
+++ b/mobile-apps/ios/LiftMark/Views/Auth/LoginView.swift
@@ -7,8 +7,8 @@ import SwiftUI
 /// Account → Sign in.
 ///
 /// Password reset and account creation are deferred to the web
-/// (beta.liftmark.app) for now, so this view only handles login + the
-/// "Resend verification email" remediation path.
+/// (getlift.md; beta env in beta mode), so this view only handles login +
+/// the "Resend verification email" remediation path.
 struct LoginView: View {
     @Environment(AuthenticationStore.self) private var authStore
     @Environment(\.dismiss) private var dismiss
@@ -30,8 +30,17 @@ struct LoginView: View {
         case failed(String)
     }
 
-    private static let forgotPasswordURL = URL(string: "https://beta.liftmark.app/account/forgot")!
-    private static let signupURL = URL(string: "https://beta.liftmark.app/account/signup")!
+    /// Web host for the account pages, mirroring the API host the app talks
+    /// to (so a session created on the web is on the same origin the API
+    /// uses). Prod is canonical `getlift.md` (GH #248); beta mode keeps the
+    /// beta env until its `beta.getlift.md` cutover lands.
+    private static var accountWebBase: String {
+        let useBeta = UserDefaults.standard.object(forKey: "feature_flag.useBetaApi") != nil
+            && UserDefaults.standard.bool(forKey: "feature_flag.useBetaApi")
+        return useBeta ? "https://beta.liftmark.app" : "https://getlift.md"
+    }
+    private static var forgotPasswordURL: URL { URL(string: "\(accountWebBase)/account/forgot")! }
+    private static var signupURL: URL { URL(string: "\(accountWebBase)/account/signup")! }
 
     private var canSubmit: Bool {
         !isSubmitting

--- a/spec/data/import-export-schema.md
+++ b/spec/data/import-export-schema.md
@@ -4,6 +4,15 @@
 >
 > Source of truth: `src/services/workoutExportService.ts`, `src/services/fileImportService.ts`, `src/services/databaseBackupService.ts`
 
+> **Schema `$id` migration (GH #248)**: the export schemas' `$id` URLs moved
+> from `https://liftmark.app/schemas/…` to `https://getlift.md/schemas/…`. The
+> `$id` is a JSON-Schema *identifier*, not a fetch location — every consumer
+> (`tools/validate_export.py`, the iOS `WorkoutExportIntegrationTests`) loads the
+> schema by local file path, so the rename is brand-only and breaks no resolver.
+> For any external party that did dereference the old URL, the redirect topology
+> (see `services/lmwf-validator.md`) 301-redirects `liftmark.app/schemas/*` to
+> `getlift.md/schemas/*`, so the old identifier still resolves to the same file.
+
 ---
 
 ## JSON Export Format

--- a/spec/data/schemas/liftmark-export-multi.schema.json
+++ b/spec/data/schemas/liftmark-export-multi.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://liftmark.app/schemas/liftmark-export-multi.schema.json",
+  "$id": "https://getlift.md/schemas/liftmark-export-multi.schema.json",
   "title": "LiftMark Multi-Session Export",
   "description": "Export format for multiple completed workout sessions.",
   "type": "object",

--- a/spec/data/schemas/liftmark-export-single.schema.json
+++ b/spec/data/schemas/liftmark-export-single.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://liftmark.app/schemas/liftmark-export-single.schema.json",
+  "$id": "https://getlift.md/schemas/liftmark-export-single.schema.json",
   "title": "LiftMark Single-Session Export",
   "description": "Export format for a single completed workout session.",
   "type": "object",

--- a/spec/data/schemas/liftmark-export-unified.schema.json
+++ b/spec/data/schemas/liftmark-export-unified.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://liftmark.app/schemas/liftmark-export-unified.schema.json",
+  "$id": "https://getlift.md/schemas/liftmark-export-unified.schema.json",
   "title": "LiftMark Unified Export",
   "description": "Unified export format containing plans, sessions, gyms, and settings for backup/transfer.",
   "type": "object",

--- a/spec/services/lmwf-validator.md
+++ b/spec/services/lmwf-validator.md
@@ -145,19 +145,38 @@ The TypeScript parser MUST pass the same test cases as the native iOS parser (`M
 
 ## Domains & Hosting Topology
 
-The service is fronted by CloudFront. As of the canonical-domain change, the
-public website lives at **`getlift.md`**; `liftmark.app` and `liftmd.app` are
-retained for the iOS app's API + password-autofill needs and for redirecting
-legacy traffic to the canonical site. This is **prod-only** — beta is unaffected
-and continues to serve everything (site + API) from `beta.liftmark.app`.
+The service is fronted by CloudFront. As of the canonical-domain migration
+(GH #248), **`getlift.md` is canonical and serves everything** — site, API, LMWF
+spec, export schemas, and AASA — entirely from the apex (no functional
+subdomains). The whole `liftmark.app` family is now **redirect-only**, kept alive
+solely so old links and shipped-app deep-links don't break. Beta mirrors this:
+**`beta.getlift.md`** is the all-in-one beta environment, and `beta.liftmark.app`
+redirects to it.
+
+> **Migration status (GH #248):** the **prod** cutover (table below) is
+> implemented — `getlift.md` serves everything; `liftmark.app` / `liftmd.app` /
+> `workoutformat.liftmark.app` are redirect-only. The **beta** half
+> (`beta.getlift.md`) is a tracked follow-up: it needs a cross-account DNS
+> delegation deploy (create the beta-account zone, read its NS, delegate from
+> the `getlift.md` zone, issue the cert), so until that lands beta still serves
+> from `beta.liftmark.app` and the e2e pipeline runs against it. The table and
+> the `beta.getlift.md` rows describe the target end state.
+
+The **one** exception to "liftmark.app redirects everything" is the AASA path:
+Apple does NOT follow redirects when fetching `apple-app-site-association`, and
+already-installed apps are pinned to `liftmark.app`, so `liftmark.app` MUST keep
+serving its AASA (200) for those installs to retain Universal Links + password
+autofill until they update. It is the sole thing still *served* from
+`liftmark.app`.
 
 | Domain | Role | Site pages (`/`, `/install.sh`, …) | API paths (`/validate`, `/v1/*`, `/version`) | `/.well-known/apple-app-site-association` |
 |---|---|---|---|---|
-| **`getlift.md`** | Canonical site | **Serves** (own CloudFront distribution; same S3 `website/dist` content + same API proxy behaviors) | **Serves** | Serves (200, `application/json`, no redirect) |
-| **`liftmark.app`** | App API + AASA host; legacy site → redirect | **302 → `getlift.md`** (same path) | **Serves** (unchanged — iOS app calls these) | **Serves** (unchanged — Apple does NOT follow redirects for AASA, so it must NOT be redirected) |
-| **`workoutformat.liftmark.app`** | Legacy alias of `liftmark.app` | **302 → `getlift.md`** | Serves | Serves |
-| **`liftmd.app`** | Legacy short domain | **302 → `getlift.md`** (everything) | 302 → `getlift.md` | 302 → `getlift.md` |
-| **`beta.liftmark.app`** | Beta (all-in-one) | Serves | Serves | Serves |
+| **`getlift.md`** | **Canonical (prod)** — serves everything | **Serves** (own CloudFront distribution; S3 `website/dist` + API proxy behaviors + spec/schemas) | **Serves** | **Serves** (200, `application/json`, no redirect) |
+| **`liftmark.app`** | Legacy → redirect-only (AASA excepted) | **301 → `getlift.md`** (same path) | **308 → `getlift.md`** (method + body preserved; shipped apps replay then reauth) | **Serves** (200 — sole exception; Apple does NOT follow AASA redirects, old installs pinned here) |
+| **`workoutformat.liftmark.app`** | Legacy spec alias → redirect | **301 → `getlift.md`** (path-preserving: `/spec.md` → `getlift.md/spec.md`) | 308 → `getlift.md` | 301 → `getlift.md` (no shipped app pins this host's AASA) |
+| **`liftmd.app`** | Legacy short domain | **301 → `getlift.md`** (everything) | 301 → `getlift.md` | 301 → `getlift.md` |
+| **`beta.getlift.md`** | **Beta (all-in-one)** | Serves | Serves | Serves |
+| **`beta.liftmark.app`** | Legacy beta → redirect | **301 → `beta.getlift.md`** | **308 → `beta.getlift.md`** | 301 → `beta.getlift.md` (test installs only; reauth acceptable) |
 
 ### CloudFront WAF (body-size policy)
 
@@ -187,24 +206,30 @@ attached to **both** region exec roles by `iam/refresh-deploy-policy.sh`.
 
 Redirect semantics:
 
-- Redirects are **302 (temporary)** initially; they are to be promoted to **301
-  (permanent)** once the canonical move is proven stable.
-- On `liftmark.app` / `workoutformat.liftmark.app` the redirect applies **only**
-  to site pages. The API paths (`/validate`, `/v1/*`, `/version`) and the AASA
-  path (`/.well-known/apple-app-site-association`) are explicitly excluded so the
-  shipped iOS app's API calls and password autofill keep working without a new
-  build. Per-path redirect/exclusion is implemented as a CloudFront Function (not
-  a second `BucketDeployment` / Lambda@Edge — see the BucketDeployment layer-limit
+- **Site pages** (GET) redirect **301 (permanent)** to the canonical host, path
+  preserved.
+- **API paths** (`/validate`, `/v1/*`, `/version`) redirect **308 (permanent,
+  method + body preserved)** rather than 301/302 — a 301/302 on a `POST` lets the
+  client downgrade to `GET` and drop the body, which would break a shipped app's
+  workout push. With 308 the shipped iOS app replays the exact request to
+  `getlift.md`; because session/refresh cookies are scoped per-host it then
+  reauthenticates against the canonical host (accepted — see GH #248).
+- **AASA** (`/.well-known/apple-app-site-association`) is the **one path NOT
+  redirected on `liftmark.app`**: Apple does not follow redirects for it, so it
+  keeps serving 200 for already-installed apps pinned to `liftmark.app`. Every
+  other `liftmark.app` path — and *all* paths on `liftmd.app` / `beta.liftmark.app`
+  / `workoutformat.liftmark.app` — redirects.
+- Per-path redirect/exclusion is implemented as a CloudFront Function (not a
+  second `BucketDeployment` / Lambda@Edge — see the BucketDeployment layer-limit
   constraint in the AASA section of `password-manager.md`).
-- `liftmd.app` redirects **all** paths (it never hosted the app's API or AASA).
 
 ## Deployment
 - Runtime: Node.js 22 on AWS Lambda (arm64)
-- Infrastructure: AWS CDK (`validator/cdk/`) — edge stack (us-east-1: hosted zone, ACM cert, CLOUDFRONT-scoped WAFv2 web ACL) + main stack (Lambda, HTTP API, DynamoDB, CloudFront, DNS, alarms). In prod the canonical `getlift.md` distribution serves the site + API, while the `liftmark.app` / `liftmd.app` distributions handle the redirect topology above.
+- Infrastructure: AWS CDK (`validator/cdk/`) — edge stack (us-east-1: hosted zone, ACM cert, CLOUDFRONT-scoped WAFv2 web ACL) + main stack (Lambda, HTTP API, DynamoDB, CloudFront, DNS, alarms). In prod the canonical `getlift.md` distribution serves the site + API + spec + schemas, while the `liftmark.app` / `liftmd.app` / `workoutformat.liftmark.app` distributions handle the redirect topology above (liftmark.app's distribution additionally serves the AASA exception). Beta serves everything from `beta.getlift.md`, with `beta.liftmark.app` redirecting to it.
 - The public `/validate` and `/version` endpoints require no authentication; the `/v1/*` auth/PAT/workout routes are bearer-authenticated (session JWT or PAT)
 
 ### Edge security controls
-- **CORS**: explicit origin allowlist (no wildcard), derived per-env via `corsAllowedOrigins()` in `validator/cdk/config.ts` — the env site domain (prod: the canonical `getlift.md`, plus `liftmark.app` and its legacy `workoutformat.` subdomain so requests originating from the redirecting hosts still pass), and (beta only) the local Astro dev origin. `allowCredentials: true` so the SameSite refresh-token cookie flow works.
+- **CORS**: explicit origin allowlist (no wildcard), derived per-env via `corsAllowedOrigins()` in `validator/cdk/config.ts` — the canonical serving origin (prod: `getlift.md`; beta: `beta.getlift.md`) and (beta only) the local Astro dev origin. The legacy `liftmark.app` hosts are *not* in the allowlist: browser requests there get redirected (308/301) to the canonical origin before any XHR, so they never originate a cross-origin request from a legacy host. `allowCredentials: true` so the SameSite refresh-token cookie flow works.
 - **Security response headers**: a CloudFront `ResponseHeadersPolicy` is attached to every behavior — strict CSP (`default-src 'self'`, no `unsafe-inline`; inline site scripts load via CSP hashes), HSTS (1y, includeSubDomains, preload), `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY` + `frame-ancestors 'none'`, `Referrer-Policy: strict-origin-when-cross-origin`.
 - **WAF**: CLOUDFRONT-scoped WAFv2 web ACL (in the us-east-1 edge stack, wired to the distribution via `crossRegionReferences`) — AWS managed rule groups (Common, KnownBadInputs, AmazonIpReputationList), a broad per-IP rate limit, and a stricter per-IP rate-based rule scoped to `/v1/auth/*` to blunt credential stuffing. Per-account application lockout is a deferred follow-up (needs a DDB counter table).
 - **Access logging**: the HTTP API stage writes a JSON access log (source IP, route, status, auth subject/principal) to CloudWatch Logs.

--- a/spec/services/password-manager.md
+++ b/spec/services/password-manager.md
@@ -3,18 +3,25 @@
 ## Purpose
 
 Enable iCloud Keychain and third-party password managers (1Password, Bitwarden,
-etc.) to offer the user's saved `liftmark.app` credentials when the native iOS
-app shows its account sign-in form. This is Apple's
+etc.) to offer the user's saved credentials when the native iOS app shows its
+account sign-in form. This is Apple's
 [Shared Web Credentials / Associated Domains `webcredentials`](https://developer.apple.com/documentation/xcode/supporting-associated-domains)
 mechanism.
 
+The canonical domain is **`getlift.md`** (GH #248). `liftmark.app` is retained in
+the entitlement and keeps serving its AASA so credentials previously saved against
+`liftmark.app` (and already-installed apps pinned to it) keep working — see
+"Canonical domain & redirects" below.
+
 The association is bidirectional and only works when **both** halves agree:
 
-1. The **app** declares the domain it trusts via the
-   `com.apple.developer.associated-domains` entitlement (`webcredentials:liftmark.app`).
-2. The **domain** declares the app(s) it trusts via an
+1. The **app** declares the domains it trusts via the
+   `com.apple.developer.associated-domains` entitlement
+   (`webcredentials:getlift.md` + `webcredentials:liftmark.app`).
+2. Each **domain** declares the app(s) it trusts via an
    `apple-app-site-association` (AASA) file served at
-   `https://liftmark.app/.well-known/apple-app-site-association`.
+   `https://getlift.md/.well-known/apple-app-site-association` (canonical) and
+   `https://liftmark.app/.well-known/apple-app-site-association` (legacy).
 
 Apple's CDN fetches the AASA and matches the app's Team ID + bundle ID against
 the `webcredentials.apps` list. Only on a match does autofill light up.
@@ -26,7 +33,7 @@ the `webcredentials.apps` list. Only on a match does autofill light up.
 | Apple Team ID | `43DNX2P3T6` |
 | Prod app bundle ID | `com.eff3.liftmark.native-ios` |
 | Dev/debug app bundle ID | `com.eff3.liftmark.native-ios.dev` |
-| Associated domain | `liftmark.app` (apex) |
+| Associated domains | `getlift.md` (canonical) + `liftmark.app` (legacy) |
 
 The `.dev` bundle ID is included so debug/TestFlight-from-Xcode builds can be
 tested against the same AASA. Both fully-qualified app identifiers are
@@ -49,8 +56,14 @@ Required key/value (added alongside the existing HealthKit / CloudKit / iCloud
 entitlements, none of which are disturbed):
 
 ```
-com.apple.developer.associated-domains = [ "webcredentials:liftmark.app" ]
+com.apple.developer.associated-domains = [
+  "webcredentials:getlift.md",
+  "webcredentials:liftmark.app"
+]
 ```
+
+`getlift.md` is the canonical host; `liftmark.app` is retained so the QuickType
+bar still offers credentials users previously saved against `liftmark.app`.
 
 ### Login form requirements
 
@@ -61,7 +74,8 @@ must mark its fields so managers recognise them:
 - Password field → `.textContentType(.password)`
 
 There is **no native account-creation / new-password field** — signup and
-password reset are deferred to the web (`beta.liftmark.app`). If a native
+password reset are deferred to the web (`getlift.md`; `beta.getlift.md` in beta).
+If a native
 signup field is ever added, its password field must use
 `.textContentType(.newPassword)` so managers offer to generate and save a
 credential. (The Anthropic API-key `SecureField` in Settings is **not** an
@@ -81,10 +95,12 @@ lives at:
 website/public/.well-known/apple-app-site-association
 ```
 
-and is published at:
+The **same** S3 content backs both the canonical `getlift.md` distribution and
+the legacy `liftmark.app` distribution, so the identical AASA is published at:
 
 ```
-https://liftmark.app/.well-known/apple-app-site-association
+https://getlift.md/.well-known/apple-app-site-association     (canonical)
+https://liftmark.app/.well-known/apple-app-site-association   (legacy, not redirected)
 ```
 
 The file has **no extension** (Apple requires the exact filename).
@@ -147,16 +163,17 @@ routed to the `/validate`, `/v1/*`, or `/version` API origins.
 ### Canonical domain & redirects
 
 The canonical website domain is **`getlift.md`** (see "Domains & Hosting
-Topology" in `lmwf-validator.md`). `liftmark.app` now 302-redirects its **site
-pages** to `getlift.md`, but the AASA is the load-bearing exception: Apple's
-`webcredentials` fetcher does **not** follow redirects, so
+Topology" in `lmwf-validator.md`), and it serves the AASA directly. `liftmark.app`
+is now **redirect-only** — its site pages 301 and its API paths 308 to
+`getlift.md` — with **one exception**: the AASA. Apple's `webcredentials` fetcher
+does **not** follow redirects, so
 `https://liftmark.app/.well-known/apple-app-site-association` MUST keep returning
-the file directly (HTTP 200, no redirect). The same exclusion applies to the
-app's API paths (`/validate`, `/v1/*`, `/version`). The associated-domains
-entitlement still targets `webcredentials:liftmark.app`, so AASA hosting stays on
-`liftmark.app` even though the marketing site has moved. (`liftmd.app` redirects
-everything, including `/.well-known/*`, because it never hosted the app's
-entitlement.)
+the file directly (HTTP 200, no redirect) for already-installed apps still pinned
+to `liftmark.app`. It is the sole path still *served* (not redirected) from
+`liftmark.app`. The associated-domains entitlement targets both
+`webcredentials:getlift.md` (canonical) and `webcredentials:liftmark.app`
+(legacy). (`liftmd.app` and `workoutformat.liftmark.app` redirect everything,
+including `/.well-known/*`, because no installed app pins their AASA.)
 
 ## Deploy / order-of-operations
 
@@ -165,19 +182,21 @@ entitlement.)
 Committing the file under `website/public/` is therefore sufficient — it will
 be present in `website/dist` at deploy time.
 
-**Order matters.** The AASA must be LIVE on `liftmark.app` *before* (or at the
-same time as) an app build carrying the `webcredentials` entitlement reaches
-users. If the entitlement ships first, Apple's CDN caches a missing/old AASA and
-autofill stays silent until the AASA deploys and the CDN re-fetches.
+**Order matters.** The AASA must be LIVE on `getlift.md` (and still on
+`liftmark.app`) *before* (or at the same time as) an app build carrying the
+updated `webcredentials:getlift.md` entitlement reaches users. If the entitlement
+ships first, Apple's CDN caches a missing/old AASA and autofill stays silent until
+the AASA deploys and the CDN re-fetches.
 
 Recommended sequence:
 
-1. Deploy the validator/website change first (publishes the AASA):
+1. Deploy the validator/website change first (publishes the AASA on both hosts):
    `cd validator && make deploy-prod`.
-2. Verify:
-   `curl -sI https://liftmark.app/.well-known/apple-app-site-association`
-   → `200` + `content-type: application/json`, no redirect.
-3. Then ship the app build carrying the entitlement.
+2. Verify both hosts:
+   `curl -sI https://getlift.md/.well-known/apple-app-site-association`
+   and `curl -sI https://liftmark.app/.well-known/apple-app-site-association`
+   → each `200` + `content-type: application/json`, **no redirect**.
+3. Then ship the app build carrying the `getlift.md` entitlement.
 
 ## Verification
 
@@ -191,5 +210,5 @@ Recommended sequence:
 - `cd mobile-apps/ios && make generate && make build` regenerates the project
   with the entitlement and compiles cleanly.
 - Post-deploy, on device: invoke the sign-in form; iCloud Keychain / the
-  installed password manager offers saved `liftmark.app` credentials in the
-  QuickType bar.
+  installed password manager offers saved `getlift.md` (and legacy
+  `liftmark.app`) credentials in the QuickType bar.

--- a/spec/services/validator-e2e.md
+++ b/spec/services/validator-e2e.md
@@ -369,12 +369,16 @@ while the production topology stays untouched.
 
 ## Canonical-domain redirect topology (`remote:prod` only)
 
-The prod canonical site is `getlift.md`; `liftmark.app` (and its legacy
-`workoutformat.liftmark.app` alias) and `liftmd.app` redirect to it, with
-explicit non-redirect exceptions for the app's API + AASA paths (see
-"Domains & Hosting Topology" in `lmwf-validator.md`). This topology is a
-prod-only deploy concern, so it is verified only in `remote:prod` mode and
-is **not** wired into the pipeline (beta is single-origin and unaffected).
+The prod canonical site is `getlift.md`, which serves **everything** (site, API,
+spec, schemas, AASA). The entire `liftmark.app` family (`liftmark.app`, its legacy
+`workoutformat.liftmark.app` alias) and `liftmd.app` are **redirect-only**, with a
+**single** non-redirect exception: `liftmark.app`'s AASA path (Apple does not
+follow AASA redirects, old installs pinned there). See "Domains & Hosting
+Topology" in `lmwf-validator.md`. This topology is a prod-only deploy concern, so
+it is verified only in `remote:prod` mode and is **not** wired into the pipeline
+(beta still serves from `beta.liftmark.app` — its `beta.getlift.md` cutover is a
+tracked GH #248 follow-up). These checks are also enforced post-deploy by the
+`Verify canonical redirect topology` step in `validator-ci.yml`.
 
 These are HTTP-level checks (status / `Location` / `Content-Type`), run
 with redirect-following disabled so the redirect itself is observable:
@@ -383,13 +387,12 @@ with redirect-following disabled so the redirect itself is observable:
 |---|---------|-------------|
 | 1 | `GET https://getlift.md/` | 200, serves the site (canonical home page) |
 | 2 | `GET https://getlift.md/validate` (or `POST`) | reaches the validator API (not a redirect) |
-| 3 | `GET https://liftmark.app/` (a site page) | **302**, `Location: https://getlift.md/` (same path) |
-| 4 | `POST https://liftmark.app/validate` | **200** — served directly, **NOT** redirected (shipped iOS app depends on this) |
-| 5 | `GET https://liftmark.app/.well-known/apple-app-site-association` | **200**, `Content-Type: application/json`, **NOT** redirected (Apple does not follow redirects) |
-| 6 | `GET https://liftmd.app/` (and any path) | **302**, `Location: https://getlift.md/…` |
-
-Redirects are **302** today; when they are promoted to **301**, update
-the expected status in checks 3 and 6 accordingly.
+| 3 | `GET https://getlift.md/.well-known/apple-app-site-association` | **200**, `Content-Type: application/json`, no redirect (canonical AASA) |
+| 4 | `GET https://liftmark.app/` (a site page) | **301**, `Location: https://getlift.md/` (same path) |
+| 5 | `POST https://liftmark.app/validate` | **308**, `Location: https://getlift.md/validate` (method + body preserved on replay) |
+| 6 | `GET https://liftmark.app/.well-known/apple-app-site-association` | **200**, `Content-Type: application/json`, **NOT** redirected (sole exception — Apple does not follow AASA redirects) |
+| 7 | `GET https://workoutformat.liftmark.app/spec.md` | **301**, `Location: https://getlift.md/spec.md` (path preserved) |
+| 8 | `GET https://liftmd.app/` (and any path) | **301**, `Location: https://getlift.md/…` |
 
 ## Pipeline integration
 

--- a/spec/services/workout-outbox.md
+++ b/spec/services/workout-outbox.md
@@ -248,7 +248,7 @@ outboxPusher.pendingCount > 0
 
 ## Web surface
 
-Logged-in users can browse their own outbox at `liftmark.app/account/outbox` so they can see what their agents will read back. Same session JWT the rest of `/account/*` uses; PATs are not involved here.
+Logged-in users can browse their own outbox at `getlift.md/account/outbox` (beta: `beta.getlift.md/account/outbox`) so they can see what their agents will read back. Same session JWT the rest of `/account/*` uses; PATs are not involved here.
 
 ### Pages
 

--- a/tools/claude-skill/generate-workout/SKILL.md
+++ b/tools/claude-skill/generate-workout/SKILL.md
@@ -5,7 +5,7 @@ description: Generate a strength training workout plan in LMWF (LiftMark Workout
 
 # Generate a workout in LMWF
 
-LMWF is a markdown-based format for strength training **plans** (not session records). Full spec: https://workoutformat.liftmark.app/spec.md — fetch it if you need detail beyond what's below.
+LMWF is a markdown-based format for strength training **plans** (not session records). Full spec: https://getlift.md/spec.md — fetch it if you need detail beyond what's below.
 
 ## Critical semantic: plans, not records
 
@@ -91,7 +91,7 @@ Without a token, fall back to the basic workflow above — generate, validate, h
 Required scope: `workouts:read`. Returns the user's last 20 completed sessions (newest first), so you can avoid same-muscle adjacency, stage progressions on actual loads/reps, and acknowledge what they just finished.
 
 ```bash
-curl -fsS https://workoutformat.liftmark.app/v1/workouts/outbox \
+curl -fsS https://getlift.md/v1/workouts/outbox \
   -H "Authorization: Bearer $LIFTMARK_PAT"
 ```
 
@@ -114,7 +114,7 @@ Response shape (summary list):
 For per-set detail on one session (target vs actual weight, reps, time, RPE):
 
 ```bash
-curl -fsS https://workoutformat.liftmark.app/v1/workouts/outbox/<outbox_id> \
+curl -fsS https://getlift.md/v1/workouts/outbox/<outbox_id> \
   -H "Authorization: Bearer $LIFTMARK_PAT"
 ```
 
@@ -125,7 +125,7 @@ Returns `{ outbox_id, session_name, session_completed_at, payload: { session: { 
 Required scope: `workouts:write`. The workout lands in the iOS app's Plans → Inbox section for the user to review and start.
 
 ```bash
-curl -fsS -X POST https://workoutformat.liftmark.app/v1/workouts \
+curl -fsS -X POST https://getlift.md/v1/workouts \
   -H "Authorization: Bearer $LIFTMARK_PAT" \
   -H "Content-Type: text/markdown" \
   --data-binary @workout.md
@@ -134,7 +134,7 @@ curl -fsS -X POST https://workoutformat.liftmark.app/v1/workouts \
 Or with the LMWF in a JSON wrapper:
 
 ```bash
-curl -fsS -X POST https://workoutformat.liftmark.app/v1/workouts \
+curl -fsS -X POST https://getlift.md/v1/workouts \
   -H "Authorization: Bearer $LIFTMARK_PAT" \
   -H "Content-Type: application/json" \
   -d '{"lmwf": "# Push Day\n@units: lbs\n..."}'
@@ -160,12 +160,12 @@ After a successful push, surface the inbox_id + summary line to the user — "Qu
 
 - Never log or echo the token. Use `Authorization: Bearer "$LIFTMARK_PAT"` directly — don't print it into transcripts.
 - A 401 means the token is missing, malformed, revoked, or expired. A 403 means scope mismatch (e.g. trying to push with a read-only token).
-- Token management lives at https://liftmark.app/account — users mint and revoke tokens there.
+- Token management lives at https://getlift.md/account — users mint and revoke tokens there.
 
 ## Reference
 
-- Full spec (markdown): https://workoutformat.liftmark.app/spec.md
-- Human docs + in-browser validator: https://workoutformat.liftmark.app/
-- Validator API: `POST https://workoutformat.liftmark.app/validate` (Content-Type `application/json` with `{"markdown": "..."}` or `text/markdown` with the raw body)
-- Inbox API (push, requires `workouts:write` PAT): `POST https://workoutformat.liftmark.app/v1/workouts`
-- Outbox API (read recent completions, requires `workouts:read` PAT): `GET https://workoutformat.liftmark.app/v1/workouts/outbox` and `GET …/outbox/<outbox_id>`
+- Full spec (markdown): https://getlift.md/spec.md
+- Human docs + in-browser validator: https://getlift.md/
+- Validator API: `POST https://getlift.md/validate` (Content-Type `application/json` with `{"markdown": "..."}` or `text/markdown` with the raw body)
+- Inbox API (push, requires `workouts:write` PAT): `POST https://getlift.md/v1/workouts`
+- Outbox API (read recent completions, requires `workouts:read` PAT): `GET https://getlift.md/v1/workouts/outbox` and `GET …/outbox/<outbox_id>`

--- a/tools/claude-skill/generate-workout/validate.sh
+++ b/tools/claude-skill/generate-workout/validate.sh
@@ -9,7 +9,7 @@
 # Exits non-zero on HTTP failure; prints the JSON response on stdout.
 set -eu
 
-ENDPOINT='https://workoutformat.liftmark.app/validate'
+ENDPOINT='https://getlift.md/validate'
 
 if [ $# -ge 1 ]; then
   if [ ! -r "$1" ]; then

--- a/validator/README.md
+++ b/validator/README.md
@@ -2,14 +2,14 @@
 
 Validation service for the [LiftMark Workout Format (LMWF)](../liftmark-workout-format/LIFTMARK_WORKOUT_FORMAT_SPEC.md). Accepts workout markdown and returns structured validation results.
 
-**Live endpoint:** `https://workoutformat.liftmark.app/validate`
+**Live endpoint:** `https://getlift.md/validate`
 
 ## Usage
 
 ### JSON request
 
 ```bash
-curl -X POST https://workoutformat.liftmark.app/validate \
+curl -X POST https://getlift.md/validate \
   -H "Content-Type: application/json" \
   -d '{
     "markdown": "# Push Day\n@units: lbs\n\n## Bench Press [barbell]\n- 225 x 5\n- 245 x 3"
@@ -19,7 +19,7 @@ curl -X POST https://workoutformat.liftmark.app/validate \
 ### Send a file
 
 ```bash
-curl -X POST https://workoutformat.liftmark.app/validate \
+curl -X POST https://getlift.md/validate \
   -H "Content-Type: text/markdown" \
   --data-binary @my-workout.md
 ```
@@ -69,7 +69,7 @@ POST the markdown as JSON, check `success` in the response, and iterate on any `
 
 ```
 1. Generate workout markdown
-2. POST to https://workoutformat.liftmark.app/validate
+2. POST to https://getlift.md/validate
 3. If success: done
 4. If errors: fix the issues and retry from step 2
 ```
@@ -225,6 +225,6 @@ If you skip the warm-up call and go straight to `make deploy`, the Make recipe r
 
 - **Runtime:** Node.js 20 on AWS Lambda (arm64, 256MB)
 - **API:** API Gateway v2 (HTTP API) with CORS
-- **Domain:** `workoutformat.liftmark.app` (ACM cert + Route 53)
+- **Domain:** `getlift.md` (ACM cert + Route 53)
 - **Throttle:** 100 burst / 50 sustained requests per second
 - **IaC:** AWS CDK (see `cdk/`)

--- a/validator/cdk/config.ts
+++ b/validator/cdk/config.ts
@@ -66,20 +66,19 @@ export const LOCAL_DEV_ORIGIN = 'http://localhost:4321';
  * Browser origins permitted to make credentialed requests to the env's HTTP
  * API. Replaces the previous wildcard CORS: an explicit allowlist is required
  * once the refresh token moves to a SameSite cookie (credentialed CORS cannot
- * use `*`). The legacy `workoutformat.` prod subdomain is included because the
- * prod CloudFront still answers for it.
+ * use `*`).
+ *
+ * Only the host that actually *serves* the site + makes credentialed
+ * same-origin API calls is listed: the canonical web domain when set (prod:
+ * `getlift.md`), else the env apex (beta: `beta.liftmark.app`). The legacy
+ * redirect-only hosts (`liftmark.app`, `workoutformat.liftmark.app`,
+ * `liftmd.app`) never originate an XHR — their pages 301/308 to the canonical
+ * host before any script runs — so they are intentionally NOT allowlisted
+ * (GH #248).
  */
 export function corsAllowedOrigins(env: EnvConfig): string[] {
-  const origins = [`https://${env.domainName}`];
-  if (env.name === 'prod') {
-    origins.push(`https://workoutformat.${env.domainName}`);
-  }
-  // The canonical site (getlift.md) makes credentialed, same-origin API calls
-  // through its own CloudFront, so its origin must be allowed too. domainName
-  // stays in the list during the transition (it still proxies the API).
-  if (env.canonicalWebDomain && env.canonicalWebDomain !== env.domainName) {
-    origins.push(`https://${env.canonicalWebDomain}`);
-  }
+  const servingOrigin = env.canonicalWebDomain ?? env.domainName;
+  const origins = [`https://${servingOrigin}`];
   if (env.allowLocalDevOrigin) {
     origins.push(LOCAL_DEV_ORIGIN);
   }
@@ -104,9 +103,11 @@ export const ENVS: Record<EnvName, EnvConfig> = {
     account: '825347768149',
     region: 'us-west-2',
     domainName: 'liftmark.app',
-    // getlift.md is the canonical brand site; liftmark.app + liftmd.app
-    // redirect to it (liftmark.app keeps serving the API + AASA). Zones/certs
-    // for both come from the LmwfDnsFoundationStack.
+    // getlift.md is canonical and serves everything (site + API + spec +
+    // schemas + AASA). liftmark.app + liftmd.app are redirect-only (301 site /
+    // 308 API), with liftmark.app's AASA kept served as the sole exception for
+    // already-installed apps pinned to it (GH #248). Zones/certs for the
+    // canonical + redirect domains come from the LmwfDnsFoundationStack.
     canonicalWebDomain: 'getlift.md',
     redirectWebDomains: ['liftmd.app'],
     stripeMode: 'live',

--- a/validator/cdk/redirect-fn.test.ts
+++ b/validator/cdk/redirect-fn.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { redirectFnCode } from './redirect-fn';
+
+/**
+ * Evaluates a generated CloudFront-Function body and invokes its `handler`
+ * against a synthetic viewer-request event. CloudFront Functions are
+ * ECMAScript 5.1 — plain `function handler(event){…}` — so a `new Function`
+ * wrapper that returns the handler is a faithful enough harness for the pure
+ * routing logic we care about (status code, Location, well-known pass-through).
+ */
+function makeHandler(code: string): (event: any) => any {
+  // eslint-disable-next-line @typescript-eslint/no-implied-eval
+  return new Function(`${code}\nreturn handler;`)() as (event: any) => any;
+}
+
+function req(uri: string, querystring: Record<string, { value: string }> = {}) {
+  return { request: { uri, querystring } };
+}
+
+const CANON = 'getlift.md';
+
+describe('redirectFnCode — keepWellKnown (legacy apex, e.g. liftmark.app)', () => {
+  const handler = makeHandler(redirectFnCode(CANON, true));
+
+  it('301-redirects a site page to the canonical host, path preserved', () => {
+    const res = handler(req('/account'));
+    expect(res.statusCode).toBe(301);
+    expect(res.statusDescription).toBe('Moved Permanently');
+    expect(res.headers.location.value).toBe('https://getlift.md/account');
+  });
+
+  it('301-redirects the root', () => {
+    expect(handler(req('/')).headers.location.value).toBe('https://getlift.md/');
+    expect(handler(req('/')).statusCode).toBe(301);
+  });
+
+  it('308-redirects /validate (method + body preserved)', () => {
+    const res = handler(req('/validate'));
+    expect(res.statusCode).toBe(308);
+    expect(res.statusDescription).toBe('Permanent Redirect');
+    expect(res.headers.location.value).toBe('https://getlift.md/validate');
+  });
+
+  it('308-redirects /version', () => {
+    expect(handler(req('/version')).statusCode).toBe(308);
+  });
+
+  it('308-redirects /v1/* API paths', () => {
+    expect(handler(req('/v1/workouts')).statusCode).toBe(308);
+    expect(handler(req('/v1/auth/password/login')).statusCode).toBe(308);
+    expect(handler(req('/v1/workouts/outbox')).headers.location.value).toBe(
+      'https://getlift.md/v1/workouts/outbox',
+    );
+  });
+
+  it('does NOT redirect the AASA / any /.well-known path — passes through to origin', () => {
+    const aasa = handler(req('/.well-known/apple-app-site-association'));
+    // Pass-through returns the original request object itself (no statusCode),
+    // which CloudFront then forwards to the S3 origin.
+    expect(aasa.statusCode).toBeUndefined();
+    expect(aasa.uri).toBe('/.well-known/apple-app-site-association');
+  });
+
+  it('preserves the query string', () => {
+    const res = handler(req('/account', { tab: { value: 'tokens' }, x: { value: '' } }));
+    expect(res.headers.location.value).toBe('https://getlift.md/account?tab=tokens&x');
+  });
+
+  it('treats /v1 (no trailing slash) as a site page, not API', () => {
+    // Only /v1/* (with slash) is API; a bare /v1 is not a real route but must
+    // not be mis-308'd — guards the indexOf('/v1/') boundary.
+    expect(handler(req('/v1')).statusCode).toBe(301);
+  });
+});
+
+describe('redirectFnCode — redirect-all (vanity domains, e.g. liftmd.app)', () => {
+  const handler = makeHandler(redirectFnCode(CANON, false));
+
+  it('redirects /.well-known/* too (no installed app pins these hosts)', () => {
+    const res = handler(req('/.well-known/apple-app-site-association'));
+    expect(res.statusCode).toBe(301);
+    expect(res.headers.location.value).toBe(
+      'https://getlift.md/.well-known/apple-app-site-association',
+    );
+  });
+
+  it('still 308s API paths', () => {
+    expect(handler(req('/v1/workouts')).statusCode).toBe(308);
+  });
+
+  it('301s site pages', () => {
+    expect(handler(req('/format/spec')).statusCode).toBe(301);
+  });
+});

--- a/validator/cdk/redirect-fn.ts
+++ b/validator/cdk/redirect-fn.ts
@@ -1,0 +1,43 @@
+/**
+ * CloudFront viewer-request Function body that permanently redirects to the
+ * canonical host, preserving path + query (GH #248). Kept in its own module
+ * (no CDK imports) so the generated function can be unit-tested by evaluating
+ * it against sample events — see redirect-fn.test.ts.
+ *
+ * Status code is chosen per-path:
+ *   - API paths (`/validate`, `/version`, `/v1/*`) → **308** so a `POST` keeps
+ *     its method + body when the client replays against the canonical host
+ *     (a 301/302 would let the client downgrade to `GET` and drop the body).
+ *   - Everything else (site pages) → **301**.
+ *
+ * When `keepWellKnown` is true, `/.well-known/*` is served from origin instead
+ * of redirected — the AASA exception: Apple does not follow redirects when
+ * fetching `apple-app-site-association`, and already-installed apps are pinned
+ * to this host. The redirect is returned at the edge; the origin is never
+ * reached for redirected paths.
+ */
+export function redirectFnCode(canonicalHost: string, keepWellKnown: boolean): string {
+  const wellKnownGuard = keepWellKnown
+    ? "  if (request.uri.indexOf('/.well-known/') === 0) { return request; }\n"
+    : '';
+  return `
+function handler(event) {
+  var request = event.request;
+${wellKnownGuard}  var qs = '';
+  var keys = Object.keys(request.querystring);
+  if (keys.length > 0) {
+    qs = '?' + keys.map(function (k) {
+      var v = request.querystring[k];
+      return v.value !== '' ? k + '=' + v.value : k;
+    }).join('&');
+  }
+  var u = request.uri;
+  var isApi = u === '/validate' || u === '/version' || u.indexOf('/v1/') === 0;
+  return {
+    statusCode: isApi ? 308 : 301,
+    statusDescription: isApi ? 'Permanent Redirect' : 'Moved Permanently',
+    headers: { 'location': { value: 'https://${canonicalHost}' + request.uri + qs } },
+  };
+}
+`;
+}

--- a/validator/cdk/stack.ts
+++ b/validator/cdk/stack.ts
@@ -19,6 +19,7 @@ import { Construct } from 'constructs';
 import * as path from 'path';
 import type { EnvConfig } from './config';
 import { corsAllowedOrigins } from './config';
+import { redirectFnCode } from './redirect-fn';
 import { TABLES, type AttributeType, type TableSchema } from '../src/infra/tables';
 
 function toDdbAttributeType(t: AttributeType): dynamodb.AttributeType {
@@ -74,37 +75,6 @@ function createTable(
   return table;
 }
 
-/**
- * CloudFront Function (viewer-request) body that 302-redirects to
- * `canonicalHost`, preserving path + query. When `keepWellKnown` is true,
- * `/.well-known/*` is served from origin instead of redirected — required so
- * Apple can fetch the AASA file directly (it does not follow redirects).
- * The redirect is returned at the edge; the origin is never reached.
- */
-function redirectFnCode(canonicalHost: string, keepWellKnown: boolean): string {
-  const wellKnownGuard = keepWellKnown
-    ? "  if (request.uri.indexOf('/.well-known/') === 0) { return request; }\n"
-    : '';
-  return `
-function handler(event) {
-  var request = event.request;
-${wellKnownGuard}  var qs = '';
-  var keys = Object.keys(request.querystring);
-  if (keys.length > 0) {
-    qs = '?' + keys.map(function (k) {
-      var v = request.querystring[k];
-      return v.value !== '' ? k + '=' + v.value : k;
-    }).join('&');
-  }
-  return {
-    statusCode: 302,
-    statusDescription: 'Found',
-    headers: { 'location': { value: 'https://${canonicalHost}' + request.uri + qs } },
-  };
-}
-`;
-}
-
 /** A vanity domain's zone + cert (from LmwfDnsFoundationStack) for the prod stack. */
 export interface WebDomainRef {
   domain: string;
@@ -124,12 +94,14 @@ export interface LmwfValidatorStackProps extends cdk.StackProps {
   webAclArn: string;
   /**
    * When set, the site is served canonically at this domain (its own
-   * CloudFront, same S3 + API origins) and `domainName`'s default behavior
-   * 302-redirects site pages here (API paths + AASA stay). Comes from
-   * EnvConfig.canonicalWebDomain resolved against the DNS foundation stack.
+   * CloudFront, same S3 + API origins) and `domainName` (e.g. liftmark.app)
+   * becomes redirect-only: its default behavior 301-redirects site pages and
+   * 308-redirects API paths here, serving only its AASA locally (GH #248).
+   * Comes from EnvConfig.canonicalWebDomain resolved against the DNS
+   * foundation stack.
    */
   canonicalWeb?: WebDomainRef;
-  /** Domains that 302-redirect entirely to `canonicalWeb` (e.g. liftmd.app). */
+  /** Domains that 301/308-redirect entirely to `canonicalWeb` (e.g. liftmd.app). */
   redirectWeb?: readonly WebDomainRef[];
 }
 
@@ -468,18 +440,20 @@ function handler(event) {
     });
 
     // Canonical-domain redirect functions (only when the env canonicalises to a
-    // vanity domain). One keeps /.well-known/* on the source domain (so AASA +
-    // password autofill survive); the other redirects everything.
+    // vanity domain). Both redirect 301 (site) / 308 (API) to the canonical
+    // host (GH #248). One keeps /.well-known/* served from origin (the AASA
+    // exception — so password autofill survives for pinned installs); the other
+    // redirects everything including /.well-known/*.
     const redirectExceptWellKnownFn = canonicalWeb
       ? new cloudfront.Function(this, 'RedirectToCanonicalFn', {
           code: cloudfront.FunctionCode.fromInline(redirectFnCode(canonicalWeb.domain, true)),
-          comment: `302 site pages to https://${canonicalWeb.domain} (serves /.well-known/* locally)`,
+          comment: `301/308 to https://${canonicalWeb.domain} (serves /.well-known/* locally)`,
         })
       : undefined;
     const redirectAllFn = canonicalWeb
       ? new cloudfront.Function(this, 'RedirectAllToCanonicalFn', {
           code: cloudfront.FunctionCode.fromInline(redirectFnCode(canonicalWeb.domain, false)),
-          comment: `302 everything to https://${canonicalWeb.domain}`,
+          comment: `301/308 everything to https://${canonicalWeb.domain}`,
         })
       : undefined;
 
@@ -567,15 +541,24 @@ function handler(event) {
       '/version': apiBehavior(true),
     };
 
-    // Builds a full site distribution (S3 static default + API proxy).
+    // Builds a site distribution (S3 static default + API proxy).
     // `requestFn` is the default behavior's viewer-request function: the
     // pretty-URL rewriter when this distribution serves the site, or the
-    // redirect-except-/.well-known function when it only redirects.
+    // redirect function when it only redirects.
+    //
+    // `redirectMode` (true on the legacy `liftmark.app` apex in prod): the
+    // default behavior must redirect *all* methods — including the shipped
+    // app's `POST /validate` / `POST /v1/*` — so it accepts ALLOW_ALL and the
+    // API-serving `additionalBehaviors` are omitted (those paths fall through
+    // to the redirect function instead of being proxied to the API origin).
+    // The redirect is returned at the edge, so the S3 origin is never reached
+    // for them; `/.well-known/*` still passes through to S3 (AASA exception).
     const buildSiteDistribution = (
       id: string,
       aliases: string[],
       certificate: acm.ICertificate,
       requestFn: cloudfront.IFunction,
+      redirectMode: boolean,
     ): cloudfront.Distribution =>
       new cloudfront.Distribution(this, id, {
         defaultRootObject: 'index.html',
@@ -588,16 +571,22 @@ function handler(event) {
         priceClass: cloudfront.PriceClass.PRICE_CLASS_100,
         httpVersion: cloudfront.HttpVersion.HTTP2_AND_3,
         minimumProtocolVersion: cloudfront.SecurityPolicyProtocol.TLS_V1_2_2021,
-        comment: `LMWF ${env.name} — ${aliases[0]} (S3 static + /validate origin)`,
+        comment: `LMWF ${env.name} — ${aliases[0]} (${redirectMode ? 'redirect-only + AASA' : 'S3 static + /validate origin'})`,
         defaultBehavior: {
           origin: s3Origin,
           viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
           responseHeadersPolicy,
           cachePolicy:
-            env.name === 'beta'
+            redirectMode
               ? cloudfront.CachePolicy.CACHING_DISABLED
-              : cloudfront.CachePolicy.CACHING_OPTIMIZED,
-          allowedMethods: cloudfront.AllowedMethods.ALLOW_GET_HEAD_OPTIONS,
+              : env.name === 'beta'
+                ? cloudfront.CachePolicy.CACHING_DISABLED
+                : cloudfront.CachePolicy.CACHING_OPTIMIZED,
+          // Redirecting apex must accept POST/PUT/etc. so the function can
+          // 308-redirect the shipped app's API writes; the origin is never hit.
+          allowedMethods: redirectMode
+            ? cloudfront.AllowedMethods.ALLOW_ALL
+            : cloudfront.AllowedMethods.ALLOW_GET_HEAD_OPTIONS,
           compress: true,
           functionAssociations: [
             { eventType: cloudfront.FunctionEventType.VIEWER_REQUEST, function: requestFn },
@@ -605,19 +594,22 @@ function handler(event) {
             { eventType: cloudfront.FunctionEventType.VIEWER_RESPONSE, function: aasaContentTypeFunction },
           ],
         },
-        additionalBehaviors: apiBehaviors,
+        // Serve the API only when this distribution is the real origin. In
+        // redirect mode these paths fall through to the redirect function.
+        additionalBehaviors: redirectMode ? undefined : apiBehaviors,
       });
 
     // liftmark.app (+ legacy workoutformat.) distribution. Logical id stays
     // 'SiteDistribution' so this is an in-place update, not a replacement. In
-    // canonical mode its default behavior 302-redirects site pages to the
-    // canonical host (API behaviors + AASA still served locally); otherwise it
-    // serves the site (beta).
+    // canonical mode (prod) its default behavior redirects *everything* —
+    // 301 site pages, 308 API — to the canonical host, serving only the AASA
+    // locally (GH #248). Otherwise (beta) it serves the site + API.
     const distribution = buildSiteDistribution(
       'SiteDistribution',
       cfDomainNames,
       cloudFrontCertificate,
       redirectExceptWellKnownFn ?? urlRewriteFunction,
+      /* redirectMode */ Boolean(canonicalWeb),
     );
 
     // Apex + www A/AAAA alias records pointing a zone at a distribution.
@@ -649,12 +641,15 @@ function handler(event) {
         [canonicalWeb.domain, `www.${canonicalWeb.domain}`],
         canonicalWeb.certificate,
         urlRewriteFunction,
+        /* redirectMode */ false,
       );
       aliasZoneToDistribution('Canonical', canonicalWeb.zone, canonicalDistribution);
 
-      // Redirect-only vanity domains: a tiny distribution that 302s every path
-      // to the canonical host. The dummy S3 origin is never reached — the
-      // viewer-request function returns the redirect at the edge.
+      // Redirect-only vanity domains: a tiny distribution that 301/308s every
+      // path (including /.well-known/*) to the canonical host. The dummy S3
+      // origin is never reached — the viewer-request function returns the
+      // redirect at the edge. ALLOW_ALL so any method (e.g. a stray POST) is
+      // accepted and redirected rather than 405'd before the function runs.
       for (const r of redirectWeb) {
         const cid = r.domain.replace(/[^a-z0-9]+/gi, '-');
         const redirectDist = new cloudfront.Distribution(this, `Redirect-${cid}`, {
@@ -663,13 +658,13 @@ function handler(event) {
           priceClass: cloudfront.PriceClass.PRICE_CLASS_100,
           httpVersion: cloudfront.HttpVersion.HTTP2_AND_3,
           minimumProtocolVersion: cloudfront.SecurityPolicyProtocol.TLS_V1_2_2021,
-          comment: `LMWF ${env.name} — ${r.domain} → https://${canonicalWeb.domain} (302)`,
+          comment: `LMWF ${env.name} — ${r.domain} → https://${canonicalWeb.domain} (301/308)`,
           defaultBehavior: {
             origin: s3Origin,
             viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
             responseHeadersPolicy,
             cachePolicy: cloudfront.CachePolicy.CACHING_DISABLED,
-            allowedMethods: cloudfront.AllowedMethods.ALLOW_GET_HEAD_OPTIONS,
+            allowedMethods: cloudfront.AllowedMethods.ALLOW_ALL,
             functionAssociations: [
               { eventType: cloudfront.FunctionEventType.VIEWER_REQUEST, function: redirectAllFn },
             ],

--- a/validator/src/infra/email_template.ts
+++ b/validator/src/infra/email_template.ts
@@ -97,7 +97,7 @@ export function renderTransactionalEmail(input: TransactionalEmailInput): string
             </tr>
             <tr>
               <td style="padding:18px 28px 22px 28px; border-top:1px solid ${BORDER};">
-                <p style="margin:0; font-size:12px; color:${MUTED};">LiftMark &middot; <a href="https://liftmark.app" style="color:${MUTED}; text-decoration:underline;">liftmark.app</a></p>
+                <p style="margin:0; font-size:12px; color:${MUTED};">LiftMark &middot; <a href="https://getlift.md" style="color:${MUTED}; text-decoration:underline;">getlift.md</a></p>
               </td>
             </tr>
           </table>

--- a/validator/src/routes/auth/password.ts
+++ b/validator/src/routes/auth/password.ts
@@ -151,11 +151,13 @@ function classifyEmailError(err: unknown): string {
 
 function appBaseUrl(): string {
   // Hardcoded host derivation per spec — LMWF_ENV picks beta vs prod.
-  // In local dev SMTP_HOST=localhost; the link still points at the
-  // public host, which is fine for Mailpit inspection (we just read it
-  // out of the captured email rather than clicking through).
+  // Prod is the canonical getlift.md, which serves both the API (verify links
+  // hit /v1/*) and the web account pages (reset links hit /account/*) directly
+  // — no redirect hop (GH #248). Beta stays on beta.liftmark.app until its
+  // beta.getlift.md cutover lands. In local dev SMTP_HOST=localhost; the link
+  // still points at the public host, fine for Mailpit inspection.
   const env = process.env.LMWF_ENV;
-  return env === 'beta' ? 'https://beta.liftmark.app' : 'https://liftmark.app';
+  return env === 'beta' ? 'https://beta.liftmark.app' : 'https://getlift.md';
 }
 
 async function sendVerificationEmail(
@@ -170,7 +172,7 @@ async function sendVerificationEmail(
   await sendEmail({
     to: email,
     subject: 'Verify your LiftMark email',
-    text: `Welcome to LiftMark.\n\nConfirm your email by opening this link (it expires in 24 hours):\n\n${link}\n\nIf you didn't sign up, you can safely ignore this message.\n\n— LiftMark · https://liftmark.app`,
+    text: `Welcome to LiftMark.\n\nConfirm your email by opening this link (it expires in 24 hours):\n\n${link}\n\nIf you didn't sign up, you can safely ignore this message.\n\n— LiftMark · https://getlift.md`,
     html: renderTransactionalEmail({
       heading: 'Confirm your email',
       intro: 'Thanks for signing up for LiftMark. Tap the button below to confirm this email address and finish setting up your account.',
@@ -197,7 +199,7 @@ async function sendResetEmail(
   await sendEmail({
     to: email,
     subject: 'Reset your LiftMark password',
-    text: `A password reset was requested for your LiftMark account.\n\nOpen this link to choose a new password (it expires in 1 hour):\n\n${link}\n\nIf you didn't request a reset, you can safely ignore this message — your password is unchanged.\n\n— LiftMark · https://liftmark.app`,
+    text: `A password reset was requested for your LiftMark account.\n\nOpen this link to choose a new password (it expires in 1 hour):\n\n${link}\n\nIf you didn't request a reset, you can safely ignore this message — your password is unchanged.\n\n— LiftMark · https://getlift.md`,
     html: renderTransactionalEmail({
       heading: 'Reset your password',
       intro: 'A password reset was requested for your LiftMark account. Tap the button below to choose a new password.',

--- a/validator/src/routes/tokens.ts
+++ b/validator/src/routes/tokens.ts
@@ -40,7 +40,7 @@ const ALLOWED_SCOPES = new Set(['workouts:read', 'workouts:write']);
 // Generous cap — there are only two scopes today; this just bounds abuse.
 const MAX_SCOPES = 16;
 const TRIAL_MAX_ACTIVE_TOKENS = 2;
-const UPGRADE_URL = 'https://liftmark.app/account';
+const UPGRADE_URL = 'https://getlift.md/account';
 
 function patMode(): TokenMode {
   return process.env.STRIPE_MODE === 'live' ? 'live' : 'test';

--- a/website/README.md
+++ b/website/README.md
@@ -1,4 +1,4 @@
-# workoutformat.liftmark.app
+# getlift.md
 
 Static Astro site for the LiftMark Workout Format (LMWF): human landing page, full spec, validator playground, and LLM-oriented endpoints (`/llms.txt`, `/spec.md`, `/install.sh`).
 
@@ -22,7 +22,7 @@ npm install
 npm run dev
 ```
 
-Dev server runs on <http://localhost:4321>. The "Try it" widget on the landing page posts to the live production validator at <https://workoutformat.liftmark.app/validate> (CORS `*`), so you can exercise it against real infra from localhost.
+Dev server runs on <http://localhost:4321>. The "Try it" widget on the landing page posts to the live production validator at <https://getlift.md/validate> (CORS `*`), so you can exercise it against real infra from localhost.
 
 ## Build
 
@@ -34,7 +34,7 @@ Output lands in `dist/` — a fully static site that can be uploaded to any obje
 
 ## Deployment
 
-TBD. Phase 1 infra plan: S3 + CloudFront fronting both this site and the `/validate` Lambda under a single origin (`workoutformat.liftmark.app`). For now `dist/` is just built and synced manually.
+TBD. Phase 1 infra plan: S3 + CloudFront fronting both this site and the `/validate` Lambda under a single origin (`getlift.md`). For now `dist/` is just built and synced manually.
 
 ## Structure
 

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -2,11 +2,11 @@
 import { defineConfig } from 'astro/config';
 
 export default defineConfig({
-  // Canonical domain is now getlift.md; liftmark.app 302-redirects its site
-  // pages to getlift.md. The format hub lives at getlift.md/format; the
-  // legacy workoutformat.liftmark.app subdomain still resolves to the same
-  // CloudFront distribution (see validator/cdk/stack.ts), so old links keep
-  // working while canonical/OG/sitemap metadata points at getlift.md.
+  // Canonical domain is getlift.md, which serves everything. liftmark.app is
+  // redirect-only (301 site / 308 API; AASA excepted) and the legacy
+  // workoutformat.liftmark.app subdomain 301s to getlift.md (see GH #248 /
+  // validator/cdk/stack.ts), so old links keep working while canonical/OG/
+  // sitemap metadata points at getlift.md.
   site: 'https://getlift.md',
   output: 'static',
   trailingSlash: 'ignore',

--- a/website/src/pages/llms.txt.ts
+++ b/website/src/pages/llms.txt.ts
@@ -2,7 +2,7 @@ import type { APIRoute } from 'astro';
 
 const body = `# lift.md format
 
-lift.md format (formerly "LMWF") is a markdown-based format for strength training workouts. It is human-writable and machine-parseable. Used by the LiftMark iOS app (https://liftmark.app) but open for any tooling.
+lift.md format (formerly "LMWF") is a markdown-based format for strength training workouts. It is human-writable and machine-parseable. Used by the LiftMark iOS app (https://getlift.md) but open for any tooling.
 
 ## Docs
 


### PR DESCRIPTION
Closes part of #248 (prod). Beta cutover is a tracked follow-up (see below).

## What changed
`getlift.md` is now **canonical and serves everything** (site, API, spec, schemas, AASA). The whole `liftmark.app` family becomes **redirect-only**.

| Host | Behavior |
|---|---|
| `getlift.md` | Serves everything (already live via the canonical CloudFront distribution) |
| `liftmark.app` | **301** site pages / **308** API → getlift.md; **AASA still served** (sole exception) |
| `workoutformat.liftmark.app` | **301** path-preserving (`/spec.md` → `getlift.md/spec.md`) |
| `liftmd.app` | **301/308** everything |

### Why 308 for the API + the AASA exception
- **308** (not 301/302) on `/validate`, `/version`, `/v1/*` so a shipped app's `POST` keeps its method + body when it replays to getlift.md (then reauths there — cookies are per-host; accepted).
- **AASA is not redirected** on liftmark.app: Apple does not follow redirects for `apple-app-site-association`, and already-installed apps are pinned to liftmark.app. It's the only thing still *served* from liftmark.app.

## By area
- **CDK** (`stack.ts`, `config.ts`): redirect function emits 301/308 per-path; the redirecting apex accepts `ALLOW_ALL` methods and omits the API-serving behaviors (so API paths fall through to the redirect). Logic extracted to a pure **`redirect-fn.ts`** with **11 unit tests** (`redirect-fn.test.ts`). CORS tightened to the canonical serving origin only.
- **CI** (`validator-ci.yml`): post-deploy "Verify canonical redirect topology" gate rewritten to assert the new design (301 site, 308 API, AASA 200, workoutformat/liftmd 301).
- **iOS**: `APIClient` prod base + `WorkoutGenerationService` spec URL → getlift.md; `LoginView` account-web host now mirrors the API host. Entitlement already lists both `getlift.md` + `liftmark.app`. Keychain service id + bundle id deliberately unchanged.
- **Validator**: verify/reset/email links, `UPGRADE_URL`, email footer → getlift.md (prod). 
- **Schemas**: 3 export `$id`s → getlift.md. Identifier-only (every consumer loads by file path; verified `VALID` with `validate_export.py`); old URL 301-redirects.
- **Specs + docs**: `lmwf-validator.md`, `password-manager.md`, `validator-e2e.md`, `workout-outbox.md`, skill, README, Makefile.

## Verification
- `vitest run` (validator): **190 passed**, 219 skipped (live-gated), incl. the new redirect-fn tests.
- CDK `tsc --noEmit`: **0 errors**.
- iOS `make build`: **BUILD SUCCEEDED**.
- `validate_export.py` against the repointed unified schema: **VALID**.
- Website build not run locally (`sharp` native dep fails to build in sandbox); changes are comment + one URL string only — CI builds the site.

## Deferred follow-up (tracked)
**Beta → `beta.getlift.md`** is intentionally *not* in this PR. It needs a cross-account DNS dance the code can't pre-encode (create the beta-account zone → read its generated NS → hardcode them into a delegation record under the `getlift.md` zone → issue the cert). Until that lands, beta stays on `beta.liftmark.app` so the test env / prod gate doesn't break.

## Deploy note
`getlift.md` already serves the AASA + API via its canonical distribution, so there's no AASA-before-app ordering hazard for prod. Review the redirect blast radius before merging — merging triggers the validator deploy pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)