### PR TITLE
fix(sync): persist CKRecord change tags to end the SetMeasurement conflict loop

### DIFF
--- a/mobile-apps/ios/LiftMark.xcodeproj/project.pbxproj
+++ b/mobile-apps/ios/LiftMark.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		2150D4B618283A407AF9BAC1 /* ExerciseHistoryLastSessionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD93FB1BF42DD49919B91A5D /* ExerciseHistoryLastSessionView.swift */; };
 		226D16CFBA394A8F1826506E /* AnthropicServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD2CDC4A9F0168141B6F99C9 /* AnthropicServiceTests.swift */; };
 		23287E25CE8A3CE1B1889420 /* SettingsRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 557BC7BEA37C9CC95B533600 /* SettingsRepository.swift */; };
+		239B8B672FC4D267BB431268 /* CKRecordMetadataStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C237971213AB0EEAEDED6E7 /* CKRecordMetadataStoreTests.swift */; };
 		23AF3037952B92C52B15C691 /* ExerciseHistoryRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BEB3274C4C17C07A3A27F52 /* ExerciseHistoryRepository.swift */; };
 		25930AC3BE23E8A59EF5A0F7 /* ActiveWorkoutViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DE768C209F34223C2D46AEE /* ActiveWorkoutViewModel.swift */; };
 		2683EA07E89C34E9DB15B061 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 888A9E535EF4C68643D49640 /* ContentView.swift */; };
@@ -102,6 +103,7 @@
 		63651EB054FBB107FBF226D2 /* SecureStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FF868F5979A1635824B2B27 /* SecureStorageTests.swift */; };
 		6388EFE99FB16E7CE7281640 /* MigratorBridgeAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B45DC7A3E8EAF0E19BE1083 /* MigratorBridgeAlertView.swift */; };
 		6421E3FB66672D05E8EFC771 /* JsonImportServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BC03CA247E92B49F3558D8 /* JsonImportServiceTests.swift */; };
+		64FF82FA887695EBF85C1F08 /* CKRecordMetadataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AB74310139D608AA23C9DD0 /* CKRecordMetadataStore.swift */; };
 		65DF287BCE23EABD6F60D848 /* MarkdownParserAdvancedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DBFB6A09B3686193653A62B /* MarkdownParserAdvancedTests.swift */; };
 		67F8E833AB970E7C0B0D3E7F /* SyncChange.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB0FF7A71BDC475DA488AB4 /* SyncChange.swift */; };
 		68FA9B5D53CC0AED850ACCCF /* SessionRepository+SetMutations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F661FFBD647E29D31221146 /* SessionRepository+SetMutations.swift */; };
@@ -338,6 +340,8 @@
 		349FBA06AB83786EC1071ECA /* V1Seed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = V1Seed.swift; sourceTree = "<group>"; };
 		3507D916606D7A07D255602A /* ActiveWorkoutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveWorkoutView.swift; sourceTree = "<group>"; };
 		38F9A6FA3792FED0C30FF203 /* DatabaseSeeds.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseSeeds.swift; sourceTree = "<group>"; };
+		3AB74310139D608AA23C9DD0 /* CKRecordMetadataStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CKRecordMetadataStore.swift; sourceTree = "<group>"; };
+		3C237971213AB0EEAEDED6E7 /* CKRecordMetadataStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CKRecordMetadataStoreTests.swift; sourceTree = "<group>"; };
 		3C597DD1B866C5E697491391 /* WorkoutHighlightsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutHighlightsService.swift; sourceTree = "<group>"; };
 		3E4BB7CEBD7B739F748472F1 /* HealthKitServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthKitServiceTests.swift; sourceTree = "<group>"; };
 		3F69FC1D6757DC923E65FCFF /* SecureStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureStorage.swift; sourceTree = "<group>"; };
@@ -631,6 +635,7 @@
 				D029E8EF3D26021C1DE6232F /* AudioService.swift */,
 				954B57205C002E2857EE075A /* CKRecordMapper.swift */,
 				FA978B791C36287F69431C8C /* CKRecordMapper+SetMeasurement.swift */,
+				3AB74310139D608AA23C9DD0 /* CKRecordMetadataStore.swift */,
 				B38D581107ECEEEBFDA783CD /* CKSyncConflictResolver.swift */,
 				18B78AC1165879EA49EE0A12 /* CKSyncEngineManager.swift */,
 				156873BF197F953F583CBC22 /* CKSyncMetadataStore.swift */,
@@ -940,6 +945,7 @@
 				71CC4A4FDCEB486218739935 /* AudioServiceTests.swift */,
 				6C1E8D269112E454A906DCCF /* AuthenticationStoreTests.swift */,
 				C3CB86B68F041A69E6F4E6B7 /* CKRecordMapperTests.swift */,
+				3C237971213AB0EEAEDED6E7 /* CKRecordMetadataStoreTests.swift */,
 				B79EBC001661D8B385B2F7E9 /* CKSyncConflictResolverTests.swift */,
 				EADAA4A9258171076A1B482F /* CKSyncEngineManagerTests.swift */,
 				0CA40A430E6513546C353DA5 /* CKSyncMetadataStoreTests.swift */,
@@ -1256,6 +1262,7 @@
 				D76A9B26D9C1583D5A4E7C95 /* BuildInfo.swift in Sources */,
 				427BED86761D60153C8502F0 /* CKRecordMapper+SetMeasurement.swift in Sources */,
 				D51863263DFBB6D10A1DEB3E /* CKRecordMapper.swift in Sources */,
+				64FF82FA887695EBF85C1F08 /* CKRecordMetadataStore.swift in Sources */,
 				D40C0999EBC0725D6A1270B4 /* CKSyncConflictResolver.swift in Sources */,
 				5F55ACA6E2E8C4EF04EF35EE /* CKSyncEngineManager.swift in Sources */,
 				5A89491A1D1631DFCA0533B2 /* CKSyncMetadataStore.swift in Sources */,
@@ -1406,6 +1413,7 @@
 				712B0C691B4ED8D1379D8774 /* AudioServiceTests.swift in Sources */,
 				AB59B2427C54B7DE6715E1A4 /* AuthenticationStoreTests.swift in Sources */,
 				DA40BCCFFD3A680879630392 /* CKRecordMapperTests.swift in Sources */,
+				239B8B672FC4D267BB431268 /* CKRecordMetadataStoreTests.swift in Sources */,
 				9A1587CA91B078A30A5F40B0 /* CKSyncConflictResolverTests.swift in Sources */,
 				3273B2841C34A0D2FE1F203B /* CKSyncEngineManagerTests.swift in Sources */,
 				9AB084ACC5B5E49965B0A0C8 /* CKSyncMetadataStoreTests.swift in Sources */,

--- a/mobile-apps/ios/LiftMark/App/BuildInfo.swift
+++ b/mobile-apps/ios/LiftMark/App/BuildInfo.swift
@@ -1,4 +1,4 @@
 // Auto-generated at build time — do not edit
 enum BuildInfo {
-    static let gitHash = "f64c7c9"
+    static let gitHash = "668b4d2"
 }

--- a/mobile-apps/ios/LiftMark/Database/DatabaseManager.swift
+++ b/mobile-apps/ios/LiftMark/Database/DatabaseManager.swift
@@ -11,7 +11,7 @@ final class DatabaseManager: @unchecked Sendable {
     private let dbLock = NSLock()
 
     private static let dbName = "liftmark.db"
-    static let currentSchemaVersion = 18
+    static let currentSchemaVersion = 19
 
     private init() {}
 
@@ -207,6 +207,7 @@ final class DatabaseManager: @unchecked Sendable {
         if let dbQueue = try? database() {
             try? dbQueue.write { db in
                 // Order matters: children first due to foreign keys
+                try db.execute(sql: "DELETE FROM ck_record_metadata")
                 try db.execute(sql: "DELETE FROM sync_engine_state")
                 try db.execute(sql: "DELETE FROM sync_metadata")
                 try db.execute(sql: "DELETE FROM set_measurements")
@@ -268,24 +269,19 @@ final class DatabaseManager: @unchecked Sendable {
 
         if currentVersion >= targetVersion { return }
 
-        if currentVersion < 1 && targetVersion >= 1 { try migrateToV1(db) }
-        if currentVersion < 2 && targetVersion >= 2 { try migrateToV2(db) }
-        if currentVersion < 3 && targetVersion >= 3 { try migrateToV3(db) }
-        if currentVersion < 4 && targetVersion >= 4 { try migrateToV4(db) }
-        if currentVersion < 5 && targetVersion >= 5 { try migrateToV5(db) }
-        if currentVersion < 6 && targetVersion >= 6 { try migrateToV6(db) }
-        if currentVersion < 7 && targetVersion >= 7 { try migrateToV7(db) }
-        if currentVersion < 8 && targetVersion >= 8 { try migrateToV8(db) }
-        if currentVersion < 9 && targetVersion >= 9 { try migrateToV9(db) }
-        if currentVersion < 10 && targetVersion >= 10 { try migrateToV10(db) }
-        if currentVersion < 11 && targetVersion >= 11 { try migrateToV11(db) }
-        if currentVersion < 12 && targetVersion >= 12 { try migrateToV12(db) }
-        if currentVersion < 13 && targetVersion >= 13 { try migrateToV13(db) }
-        if currentVersion < 14 && targetVersion >= 14 { try migrateToV14(db) }
-        if currentVersion < 15 && targetVersion >= 15 { try migrateToV15(db) }
-        if currentVersion < 16 && targetVersion >= 16 { try migrateToV16(db) }
-        if currentVersion < 17 && targetVersion >= 17 { try migrateToV17(db) }
-        if currentVersion < 18 && targetVersion >= 18 { try migrateToV18(db) }
+        // Ordered migration chain. Each step runs when the DB is below its version and the
+        // target reaches it. Kept as data (not an if-chain) so adding a migration is one line
+        // and the dispatch stays within cyclomatic-complexity limits.
+        let steps: [(version: Int, migrate: (Database) throws -> Void)] = [
+            (1, migrateToV1), (2, migrateToV2), (3, migrateToV3), (4, migrateToV4),
+            (5, migrateToV5), (6, migrateToV6), (7, migrateToV7), (8, migrateToV8),
+            (9, migrateToV9), (10, migrateToV10), (11, migrateToV11), (12, migrateToV12),
+            (13, migrateToV13), (14, migrateToV14), (15, migrateToV15), (16, migrateToV16),
+            (17, migrateToV17), (18, migrateToV18), (19, migrateToV19)
+        ]
+        for step in steps where currentVersion < step.version && targetVersion >= step.version {
+            try step.migrate(db)
+        }
 
         try db.execute(sql: "UPDATE schema_version SET version = ?", arguments: [targetVersion])
     }
@@ -960,6 +956,17 @@ final class DatabaseManager: @unchecked Sendable {
                 created_at_server     TEXT NOT NULL,
                 source_token_id       TEXT,
                 lmwf_text             TEXT NOT NULL
+            )
+            """)
+    }
+
+    private static func migrateToV19(_ db: Database) throws {
+        try db.execute(sql: """
+            CREATE TABLE ck_record_metadata (
+                record_name   TEXT PRIMARY KEY NOT NULL,
+                record_type   TEXT NOT NULL,
+                system_fields BLOB NOT NULL,
+                updated_at    TEXT NOT NULL
             )
             """)
     }

--- a/mobile-apps/ios/LiftMark/Database/MigratorBridge+Migrator.swift
+++ b/mobile-apps/ios/LiftMark/Database/MigratorBridge+Migrator.swift
@@ -694,6 +694,24 @@ extension MigratorBridge {
                 """)
         }
 
+        // v19: per-record CloudKit system-fields (change tag) cache. CKSyncEngine
+        // persists only change tokens + pending record IDs, not the records
+        // themselves, so the app must store each record's `encodedSystemFields`
+        // and rehydrate the CKRecord from it on every subsequent upload —
+        // otherwise updates carry a nil change tag and CloudKit rejects them with
+        // `serverRecordChanged`, producing a permanent conflict loop.
+        // See spec/services/cloudkit-sync.md.
+        m.registerMigration("v19_ck_record_metadata") { db in
+            try db.execute(sql: """
+                CREATE TABLE ck_record_metadata (
+                    record_name   TEXT PRIMARY KEY NOT NULL,
+                    record_type   TEXT NOT NULL,
+                    system_fields BLOB NOT NULL,
+                    updated_at    TEXT NOT NULL
+                )
+                """)
+        }
+
         return m
     }
 

--- a/mobile-apps/ios/LiftMark/Database/MigratorBridge.swift
+++ b/mobile-apps/ios/LiftMark/Database/MigratorBridge.swift
@@ -41,11 +41,12 @@ enum MigratorBridge {
         "v15_ai_prompt_toggles",
         "v16_workout_inbox",
         "v17_outbox_pending_queue",
-        "v18_workout_inbox_drop_preparse"
+        "v18_workout_inbox_drop_preparse",
+        "v19_ck_record_metadata"
     ]
 
     /// Highest bridge version == number of registered migrations.
-    static let currentVersion = 18
+    static let currentVersion = 19
 
     // MARK: - Outcome
 

--- a/mobile-apps/ios/LiftMark/Services/CKRecordMapper+SetMeasurement.swift
+++ b/mobile-apps/ios/LiftMark/Services/CKRecordMapper+SetMeasurement.swift
@@ -8,8 +8,7 @@ extension CKRecordMapper {
     // MARK: - To CKRecord
 
     func toCKRecord(_ m: SetMeasurementRow, zoneID: CKRecordZone.ID) -> CKRecord {
-        let recordID = CKRecord.ID(recordName: m.id, zoneID: zoneID)
-        let record = CKRecord(recordType: "SetMeasurement", recordID: recordID)
+        let record = CKRecord(recordType: "SetMeasurement", recordID: CKRecord.ID(recordName: m.id, zoneID: zoneID))
         record["setId"] = makeReference(recordName: m.setId, zoneID: zoneID) as CKRecordValue
         record["parentType"] = m.parentType as CKRecordValue
         record["role"] = m.role as CKRecordValue
@@ -22,8 +21,7 @@ extension CKRecordMapper {
     }
 
     func toCKRecord(_ ps: PlannedSetRow, measurements: [SetMeasurementRow] = [], zoneID: CKRecordZone.ID) -> CKRecord {
-        let recordID = CKRecord.ID(recordName: ps.id, zoneID: zoneID)
-        let record = CKRecord(recordType: "PlannedSet", recordID: recordID)
+        let record = CKRecord(recordType: "PlannedSet", recordID: CKRecord.ID(recordName: ps.id, zoneID: zoneID))
         record["plannedExerciseId"] = makeReference(recordName: ps.templateExerciseId, zoneID: zoneID) as CKRecordValue
         record["orderIndex"] = Int64(ps.orderIndex) as CKRecordValue
         var attrs: [String] = []
@@ -42,8 +40,7 @@ extension CKRecordMapper {
     }
 
     func toCKRecord(_ ss: SessionSetRow, measurements: [SetMeasurementRow] = [], zoneID: CKRecordZone.ID) -> CKRecord {
-        let recordID = CKRecord.ID(recordName: ss.id, zoneID: zoneID)
-        let record = CKRecord(recordType: "SessionSet", recordID: recordID)
+        let record = CKRecord(recordType: "SessionSet", recordID: CKRecord.ID(recordName: ss.id, zoneID: zoneID))
         record["sessionExerciseId"] = makeReference(recordName: ss.sessionExerciseId, zoneID: zoneID) as CKRecordValue
         record["orderIndex"] = Int64(ss.orderIndex) as CKRecordValue
         record["status"] = ss.status as CKRecordValue

--- a/mobile-apps/ios/LiftMark/Services/CKRecordMapper.swift
+++ b/mobile-apps/ios/LiftMark/Services/CKRecordMapper.swift
@@ -7,8 +7,32 @@ import GRDB
 final class CKRecordMapper {
     let dbManager: DatabaseManager
 
+    /// Per-record CloudKit system-fields (change tag) cache. Used to rehydrate CKRecords
+    /// on upload so updates carry the current change tag instead of conflicting forever.
+    let metadataStore: CKRecordMetadataStore
+
     init(dbManager: DatabaseManager = .shared) {
         self.dbManager = dbManager
+        self.metadataStore = CKRecordMetadataStore(dbManager: dbManager)
+    }
+
+    /// Rehydrate a freshly-built record onto its server-confirmed system fields (change
+    /// tag), so an upload of an already-existing record is accepted by CloudKit instead of
+    /// conflicting. If we hold stored system fields for this record, copy the fresh record's
+    /// data fields onto the decoded (metadata-only) base and return that; otherwise return
+    /// the fresh record unchanged (a genuinely new record CloudKit will create).
+    ///
+    /// Applied by `createCKRecord` *outside* any open database read — `decodedRecord` opens
+    /// its own read, so calling it inside another read would trip GRDB's non-reentrancy.
+    func applyStoredSystemFields(to record: CKRecord) -> CKRecord {
+        guard let base = metadataStore.decodedRecord(for: record.recordID.recordName),
+              base.recordType == record.recordType else {
+            return record
+        }
+        for key in record.allKeys() {
+            base[key] = record[key]
+        }
+        return base
     }
 
     // MARK: - Date Helpers
@@ -64,9 +88,11 @@ final class CKRecordMapper {
         return record[key] as? String
     }
 
-    /// Returns true if the given CKRecord's updatedAt is newer than the local record's updatedAt.
-    /// Used by conflict resolution to decide whether server or local wins.
-    /// Returns true if remote is newer or timestamps are equal (server wins tiebreaker).
+    /// Returns true if the given CKRecord's updatedAt is strictly newer than the local
+    /// record's updatedAt. Used by conflict resolution to decide whether server or local
+    /// wins. On equal timestamps this returns false — local is kept (last-writer-wins with
+    /// a local-keeps-tie rule), which is required so a recovery re-fetch can't clobber a
+    /// dirty local row that shares a timestamp with its server copy.
     func serverRecordIsNewer(_ record: CKRecord) -> Bool {
         do {
             let dbQueue = try dbManager.database()
@@ -128,8 +154,7 @@ final class CKRecordMapper {
     // MARK: - To CKRecord
 
     func toCKRecord(_ gym: GymRow, zoneID: CKRecordZone.ID) -> CKRecord {
-        let recordID = CKRecord.ID(recordName: gym.id, zoneID: zoneID)
-        let record = CKRecord(recordType: "Gym", recordID: recordID)
+        let record = CKRecord(recordType: "Gym", recordID: CKRecord.ID(recordName: gym.id, zoneID: zoneID))
         record["name"] = gym.name as CKRecordValue
         record["isDefault"] = Int64(gym.isDefault) as CKRecordValue
         if let d = parseDate(gym.createdAt) { record["createdAt"] = d as CKRecordValue }
@@ -138,8 +163,7 @@ final class CKRecordMapper {
     }
 
     func toCKRecord(_ eq: GymEquipmentRow, zoneID: CKRecordZone.ID) -> CKRecord {
-        let recordID = CKRecord.ID(recordName: eq.id, zoneID: zoneID)
-        let record = CKRecord(recordType: "GymEquipment", recordID: recordID)
+        let record = CKRecord(recordType: "GymEquipment", recordID: CKRecord.ID(recordName: eq.id, zoneID: zoneID))
         record["name"] = eq.name as CKRecordValue
         record["isAvailable"] = Int64(eq.isAvailable) as CKRecordValue
         if let gymId = eq.gymId {
@@ -152,8 +176,7 @@ final class CKRecordMapper {
     }
 
     func toCKRecord(_ plan: WorkoutPlanRow, zoneID: CKRecordZone.ID) -> CKRecord {
-        let recordID = CKRecord.ID(recordName: plan.id, zoneID: zoneID)
-        let record = CKRecord(recordType: "WorkoutPlan", recordID: recordID)
+        let record = CKRecord(recordType: "WorkoutPlan", recordID: CKRecord.ID(recordName: plan.id, zoneID: zoneID))
         record["name"] = plan.name as CKRecordValue
         record["isFavorite"] = Int64(plan.isFavorite) as CKRecordValue
         if let d = plan.description { record["planDescription"] = d as CKRecordValue }
@@ -166,8 +189,7 @@ final class CKRecordMapper {
     }
 
     func toCKRecord(_ ex: PlannedExerciseRow, zoneID: CKRecordZone.ID) -> CKRecord {
-        let recordID = CKRecord.ID(recordName: ex.id, zoneID: zoneID)
-        let record = CKRecord(recordType: "PlannedExercise", recordID: recordID)
+        let record = CKRecord(recordType: "PlannedExercise", recordID: CKRecord.ID(recordName: ex.id, zoneID: zoneID))
         record["workoutPlanId"] = makeReference(recordName: ex.workoutTemplateId, zoneID: zoneID) as CKRecordValue
         record["exerciseName"] = ex.exerciseName as CKRecordValue
         record["orderIndex"] = Int64(ex.orderIndex) as CKRecordValue
@@ -183,8 +205,7 @@ final class CKRecordMapper {
     }
 
     func toCKRecord(_ session: WorkoutSessionRow, zoneID: CKRecordZone.ID) -> CKRecord {
-        let recordID = CKRecord.ID(recordName: session.id, zoneID: zoneID)
-        let record = CKRecord(recordType: "WorkoutSession", recordID: recordID)
+        let record = CKRecord(recordType: "WorkoutSession", recordID: CKRecord.ID(recordName: session.id, zoneID: zoneID))
         record["name"] = session.name as CKRecordValue
         record["date"] = session.date as CKRecordValue
         record["status"] = session.status as CKRecordValue
@@ -198,8 +219,7 @@ final class CKRecordMapper {
     }
 
     func toCKRecord(_ se: SessionExerciseRow, zoneID: CKRecordZone.ID) -> CKRecord {
-        let recordID = CKRecord.ID(recordName: se.id, zoneID: zoneID)
-        let record = CKRecord(recordType: "SessionExercise", recordID: recordID)
+        let record = CKRecord(recordType: "SessionExercise", recordID: CKRecord.ID(recordName: se.id, zoneID: zoneID))
         record["workoutSessionId"] = makeReference(recordName: se.workoutSessionId, zoneID: zoneID) as CKRecordValue
         record["exerciseName"] = se.exerciseName as CKRecordValue
         record["orderIndex"] = Int64(se.orderIndex) as CKRecordValue
@@ -216,8 +236,7 @@ final class CKRecordMapper {
     }
 
     func toCKRecord(_ s: UserSettingsRow, zoneID: CKRecordZone.ID) -> CKRecord {
-        let recordID = CKRecord.ID(recordName: "user-settings", zoneID: zoneID)
-        let record = CKRecord(recordType: "UserSettings", recordID: recordID)
+        let record = CKRecord(recordType: "UserSettings", recordID: CKRecord.ID(recordName: "user-settings", zoneID: zoneID))
         record["defaultWeightUnit"] = s.defaultWeightUnit as CKRecordValue
         record["enableWorkoutTimer"] = Int64(s.enableWorkoutTimer) as CKRecordValue
         record["autoStartRestTimer"] = Int64(s.autoStartRestTimer) as CKRecordValue
@@ -246,6 +265,13 @@ final class CKRecordMapper {
     /// Routes an incoming CKRecord to the appropriate merge method. Returns true if local DB was updated.
     func mergeIncoming(_ record: CKRecord) throws -> Bool {
         let dbQueue = try dbManager.database()
+
+        // Persist the server's system fields UNCONDITIONALLY — before (and regardless of)
+        // the row-merge decision. Even when local wins / is unchanged, the server's change
+        // tag is the concurrency token our NEXT upload of this record must carry, or that
+        // upload will conflict. A record first learned via fetch and later edited locally
+        // depends on this.
+        metadataStore.save(record)
 
         switch record.recordType {
         case "Gym":
@@ -635,7 +661,9 @@ final class CKRecordMapper {
         let id = recordID.recordName
         do {
             let dbQueue = try dbManager.database()
-            return try dbQueue.read { db -> CKRecord? in
+            // Build the fresh record inside the read, then rehydrate its change tag OUTSIDE
+            // the read (applyStoredSystemFields opens its own read → would be reentrant here).
+            let fresh = try dbQueue.read { db -> CKRecord? in
                 if let gym = try GymRow.fetchOne(db, key: id) {
                     if gym.deletedAt != nil { return nil }
                     return self.toCKRecord(gym, zoneID: zoneID)
@@ -680,6 +708,8 @@ final class CKRecordMapper {
                 }
                 return nil
             }
+            guard let fresh else { return nil }
+            return applyStoredSystemFields(to: fresh)
         } catch {
             Logger.shared.error(.sync, "Failed to look up local record for \(id)", error: error)
             return nil

--- a/mobile-apps/ios/LiftMark/Services/CKRecordMetadataStore.swift
+++ b/mobile-apps/ios/LiftMark/Services/CKRecordMetadataStore.swift
@@ -1,0 +1,130 @@
+import CloudKit
+import Foundation
+import GRDB
+
+/// Persists each CloudKit record's system fields (the `recordChangeTag` and zone
+/// metadata) in the `ck_record_metadata` table, keyed by record name.
+///
+/// CKSyncEngine's serialized state holds only the database/zone change tokens and the
+/// set of pending record IDs — it does NOT store the records or their change tags.
+/// Persisting `encodedSystemFields` is therefore the app's responsibility: every
+/// upload of an already-existing record must be rehydrated from these stored system
+/// fields so it carries the current change tag. Without this, each upload sends a nil
+/// change tag, CloudKit rejects it with `serverRecordChanged`, and the resolver loops
+/// forever (the conflict-loop this type was introduced to fix).
+///
+/// See `spec/services/cloudkit-sync.md`.
+final class CKRecordMetadataStore: @unchecked Sendable {
+    private let dbManager: DatabaseManager
+
+    init(dbManager: DatabaseManager = .shared) {
+        self.dbManager = dbManager
+    }
+
+    private let isoFormatter: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+
+    // MARK: - Read
+
+    /// The archived system-fields blob for a record, or nil if we've never seen it confirmed.
+    func systemFields(for recordName: String) -> Data? {
+        do {
+            let dbQueue = try dbManager.database()
+            return try dbQueue.read { db in
+                try Data.fetchOne(
+                    db,
+                    sql: "SELECT system_fields FROM ck_record_metadata WHERE record_name = ?",
+                    arguments: [recordName]
+                )
+            }
+        } catch {
+            Logger.shared.error(.sync, "Failed to read CK system fields for \(recordName)", error: error)
+            return nil
+        }
+    }
+
+    /// A metadata-only CKRecord rehydrated from stored system fields (no user fields set),
+    /// carrying the last server-confirmed change tag. Returns nil when no metadata exists
+    /// (i.e. the record is genuinely new and must be created fresh).
+    func decodedRecord(for recordName: String) -> CKRecord? {
+        guard let data = systemFields(for: recordName) else { return nil }
+        do {
+            // System fields are written by `encodeSystemFields(with:)` at the archive's top
+            // level (not as a keyed root object), so they must be read back with the
+            // `CKRecord(coder:)` initializer — not `unarchivedObject(ofClass:from:)`.
+            let unarchiver = try NSKeyedUnarchiver(forReadingFrom: data)
+            unarchiver.requiresSecureCoding = true
+            let record = CKRecord(coder: unarchiver)
+            unarchiver.finishDecoding()
+            guard let record else { throw CocoaError(.coderReadCorrupt) }
+            return record
+        } catch {
+            // Corrupt/incompatible metadata: drop it so the record uploads fresh and self-heals.
+            Logger.shared.warn(.sync, "Failed to decode CK system fields for \(recordName); dropping cached metadata")
+            remove(recordName)
+            return nil
+        }
+    }
+
+    // MARK: - Write
+
+    /// Store the system fields from a server-confirmed record (after a successful save,
+    /// an incoming fetch, or a conflict's `error.serverRecord`). Idempotent upsert.
+    func save(_ record: CKRecord) {
+        do {
+            let coder = NSKeyedArchiver(requiringSecureCoding: true)
+            record.encodeSystemFields(with: coder)
+            coder.finishEncoding()
+            let data = coder.encodedData
+            let now = isoFormatter.string(from: Date())
+            let dbQueue = try dbManager.database()
+            try dbQueue.write { db in
+                try db.execute(
+                    sql: """
+                    INSERT INTO ck_record_metadata (record_name, record_type, system_fields, updated_at)
+                    VALUES (?, ?, ?, ?)
+                    ON CONFLICT(record_name) DO UPDATE SET
+                        record_type = excluded.record_type,
+                        system_fields = excluded.system_fields,
+                        updated_at = excluded.updated_at
+                    """,
+                    arguments: [record.recordID.recordName, record.recordType, data, now]
+                )
+            }
+        } catch {
+            let name = record.recordID.recordName
+            Logger.shared.error(.sync, "Failed to persist CK system fields for \(name)", error: error)
+        }
+    }
+
+    /// Drop the metadata for a record after a confirmed delete (local or remote).
+    func remove(_ recordName: String) {
+        do {
+            let dbQueue = try dbManager.database()
+            try dbQueue.write { db in
+                try db.execute(
+                    sql: "DELETE FROM ck_record_metadata WHERE record_name = ?",
+                    arguments: [recordName]
+                )
+            }
+        } catch {
+            Logger.shared.error(.sync, "Failed to remove CK system fields for \(recordName)", error: error)
+        }
+    }
+
+    /// Clear all cached system fields. Used by the v5 recovery (so a forced re-fetch
+    /// repopulates authoritative tags) and by test isolation.
+    func clearAll() {
+        do {
+            let dbQueue = try dbManager.database()
+            try dbQueue.write { db in
+                try db.execute(sql: "DELETE FROM ck_record_metadata")
+            }
+        } catch {
+            Logger.shared.error(.sync, "Failed to clear CK record metadata", error: error)
+        }
+    }
+}

--- a/mobile-apps/ios/LiftMark/Services/CKSyncConflictResolver.swift
+++ b/mobile-apps/ios/LiftMark/Services/CKSyncConflictResolver.swift
@@ -160,8 +160,11 @@ final class CKSyncConflictResolver: @unchecked Sendable {
 
     private func handleServerRecordChanged(recordName: String, recordType: String, error: CKError) {
         if let serverRecord = error.serverRecord {
-            // Always merge the server record first (to get latest changeTag into local state),
-            // then if local is newer, apply local values on top and queue for re-upload.
+            // Always merge the server record first. `mergeIncoming` persists the server's
+            // system fields (the fresh change tag) unconditionally before merging, so even a
+            // local-wins conflict leaves us holding the correct tag — our re-upload then
+            // succeeds and the conflict can't recur. If local is newer we additionally apply
+            // local values on top and cache for an immediate same-cycle re-upload.
             do {
                 _ = try mapper.mergeIncoming(serverRecord)
             } catch {

--- a/mobile-apps/ios/LiftMark/Services/CKSyncEngineManager.swift
+++ b/mobile-apps/ios/LiftMark/Services/CKSyncEngineManager.swift
@@ -76,6 +76,11 @@ final class CKSyncEngineManager: @unchecked Sendable {
             return
         }
 
+        // One-time recovery (must run before loadPersistedState): on a version bump this
+        // clears the engine's persisted state + system-fields cache so the engine restarts
+        // fresh and re-fetches every record before re-uploading. No data rows are touched.
+        prepareRecoveryIfNeeded()
+
         let serialization = loadPersistedState()
         let isFirstStart = serialization == nil
 
@@ -91,9 +96,7 @@ final class CKSyncEngineManager: @unchecked Sendable {
 
         // Don't create zone here — the engine fires .accountChange immediately,
         // which handles zone creation. Doing it here too causes a race.
-
-        // One-time recovery: re-upload all records after schema fix
-        scheduleFullUploadIfNeeded()
+        // The deferred recovery re-upload (if any) runs from `.didFetchChanges`.
     }
 
     func stop() {
@@ -192,15 +195,69 @@ final class CKSyncEngineManager: @unchecked Sendable {
 
     /// One-time recovery key. Bump the value to force a full re-upload on next launch.
     private static let fullUploadVersion = "sync.fullUploadVersion"
-    private static let currentFullUploadVersion = 4 // Bump to force re-upload
+    /// v5: heal the SetMeasurement conflict loop. Earlier builds uploaded records with no
+    /// change tag (CKRecord built fresh every time), so every update conflicted forever and
+    /// the pending queue jammed (~8.6k deep), starving completed-workout uploads. v5 resets
+    /// the engine's pending state + system-fields cache and re-fetches BEFORE re-uploading,
+    /// so the re-upload carries authoritative tags. See spec/services/cloudkit-sync.md.
+    private static let currentFullUploadVersion = 5
 
-    /// Check if a forced full re-upload is needed (schema fix recovery).
-    func scheduleFullUploadIfNeeded() {
+    /// Set during a recovery reset; the deferred local re-upload runs after the first fetch
+    /// completes (so `ck_record_metadata` is repopulated with real tags first).
+    private var pendingRecoveryUpload = false
+
+    /// One-time recovery: if the stored full-upload version is behind, reset the engine's
+    /// pending state + system-fields cache so the next sync does a clean fetch-then-upload.
+    /// MUST run before `loadPersistedState()` so the engine starts from a fresh (nil) state
+    /// and re-fetches every server record (repopulating authoritative change tags via
+    /// `mergeIncoming`). Local DB rows are never touched — no data loss. The version is NOT
+    /// bumped here; it's bumped only after the deferred upload is scheduled in
+    /// `.didFetchChanges`, so an app kill mid-recovery simply re-runs it (idempotent).
+    private func prepareRecoveryIfNeeded() {
         let current = UserDefaults.standard.integer(forKey: Self.fullUploadVersion)
         guard current < Self.currentFullUploadVersion else { return }
-        Logger.shared.info(.sync, "[sync-engine] Forcing full re-upload (version \(current) → \(Self.currentFullUploadVersion))")
+        Logger.shared.info(.sync, "[sync-engine] Recovery v\(Self.currentFullUploadVersion): resetting engine state + system-fields cache (was v\(current))")
+        CrashReporter.shared.addBreadcrumb("sync.recovery.v5.begin", category: .sync,
+                                           metadata: ["fromVersion": "\(current)"])
+        clearSyncEngineState()
+        mapper.metadataStore.clearAll()
+        pendingRecoveryUpload = true
+    }
+
+    /// Sync read of the recovery flag — safe to call from `async` contexts (the lock is
+    /// taken inside this synchronous function, not directly in the async scope).
+    private func isRecoveryUploadPending() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return pendingRecoveryUpload
+    }
+
+    /// After the first post-recovery fetch completes, re-upload local rows (now with correct
+    /// tags) and mark recovery done. Called from `.didFetchChanges`.
+    private func completeRecoveryUploadIfNeeded() {
+        lock.lock()
+        let shouldRun = pendingRecoveryUpload
+        pendingRecoveryUpload = false
+        lock.unlock()
+        guard shouldRun else { return }
+        Logger.shared.info(.sync, "[sync-engine] Recovery v\(Self.currentFullUploadVersion): fetch complete, scheduling clean re-upload of local records")
         scheduleFullUpload()
         UserDefaults.standard.set(Self.currentFullUploadVersion, forKey: Self.fullUploadVersion)
+        CrashReporter.shared.addBreadcrumb("sync.recovery.v5.end", category: .sync)
+    }
+
+    /// Delete the persisted CKSyncEngine state so the engine restarts with a fresh change
+    /// token (forcing a full re-fetch). Does not touch any data tables.
+    private func clearSyncEngineState() {
+        do {
+            let dbQueue = try DatabaseManager.shared.database()
+            try dbQueue.write { db in
+                try db.execute(sql: "DELETE FROM sync_engine_state")
+            }
+        } catch {
+            Logger.shared.error(.sync, "[sync-engine] Failed to clear sync engine state for recovery", error: error)
+            CrashReporter.shared.captureError(error, category: .sync, metadata: ["tag": "recovery-state-clear-failed"])
+        }
     }
 
     /// Classifies a CKError code from `privateCloudDatabase.save(zone)` as non-fatal.
@@ -235,6 +292,15 @@ final class CKSyncEngineManager: @unchecked Sendable {
                 }
                 CrashReporter.shared.captureError(error, category: .sync, metadata: metadata)
             }
+        }
+
+        // During a recovery reset, skip the immediate account-change upload — the deferred
+        // `.didFetchChanges` path re-uploads after tags are repopulated, avoiding a burst of
+        // (now self-healing, but noisy) conflicts in the recovery window.
+        // (Read via a sync helper: NSLock is unavailable directly in this async context.)
+        if isRecoveryUploadPending() {
+            Logger.shared.info(.sync, "[sync-engine] Deferring account-change full upload until post-recovery fetch")
+            return
         }
 
         scheduleFullUpload()
@@ -414,6 +480,7 @@ final class CKSyncEngineManager: @unchecked Sendable {
 
             do {
                 try mapper.deleteLocalRecord(id: recordId)
+                mapper.metadataStore.remove(recordId)
                 downloaded += 1
                 changedTypes.insert(recordType)
                 Logger.shared.debug(.sync, "[sync-engine] Deleted \(recordType)/\(recordId)")
@@ -444,9 +511,16 @@ final class CKSyncEngineManager: @unchecked Sendable {
     // MARK: - Sent Changes (delegated)
 
     private func handleSentChanges(_ event: CKSyncEngine.Event.SentRecordZoneChanges) {
-        // Log successful saves
+        // Log successful saves and persist their (now-advanced) system fields so the NEXT
+        // edit of each record uploads with the current change tag instead of conflicting.
         for saved in event.savedRecords {
+            mapper.metadataStore.save(saved)
             Logger.shared.info(.sync, "[sync-engine] Uploaded \(saved.recordType)/\(saved.recordID.recordName)")
+        }
+
+        // Drop metadata for confirmed deletes so a reused record name can't upload a dead tag.
+        for deletedID in event.deletedRecordIDs {
+            mapper.metadataStore.remove(deletedID.recordName)
         }
 
         let result = conflictResolver.handleSentChanges(event, removePendingType: { recordName in
@@ -610,6 +684,9 @@ extension CKSyncEngineManager: CKSyncEngineDelegate {
                     userInfo: ["changedRecordTypes": changedRecordTypes]
                 )
             }
+            // Now that the post-recovery fetch has repopulated authoritative change tags,
+            // re-upload local rows cleanly (one-time, gated by the recovery flag).
+            completeRecoveryUploadIfNeeded()
             endSyncActivity()
 
         case .willSendChanges:

--- a/mobile-apps/ios/LiftMarkTests/CKRecordMetadataStoreTests.swift
+++ b/mobile-apps/ios/LiftMarkTests/CKRecordMetadataStoreTests.swift
@@ -1,0 +1,201 @@
+import XCTest
+import CloudKit
+import GRDB
+@testable import LiftMark
+
+/// Tests for the CKRecord system-fields cache that fixes the CKSyncEngine conflict loop:
+/// records must be rehydrated from stored `encodedSystemFields` on upload (carrying the
+/// current change tag) instead of being rebuilt fresh (nil tag → permanent
+/// `serverRecordChanged`). Offline we can't mint a real server change tag, so rehydration
+/// is proven via record *identity* preservation (the stored zone wins over the passed zone).
+final class CKRecordMetadataStoreTests: XCTestCase {
+
+    private var store: CKRecordMetadataStore!
+    private var mapper: CKRecordMapper!
+    // The "real" zone a record was first confirmed in (what gets stored)…
+    private let storedZone = CKRecordZone.ID(zoneName: "StoredZone", ownerName: CKCurrentUserDefaultName)
+    // …vs. the zone a later upload call passes in. Rehydration must use the stored one.
+    private let callerZone = CKRecordZone.ID(zoneName: "CallerZone", ownerName: CKCurrentUserDefaultName)
+
+    private let isoFormatter: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+
+    override func setUp() {
+        super.setUp()
+        DatabaseManager.shared.deleteDatabase()
+        _ = Logger.shared
+        store = CKRecordMetadataStore()
+        mapper = CKRecordMapper()
+    }
+
+    override func tearDown() {
+        DatabaseManager.shared.deleteDatabase()
+        super.tearDown()
+    }
+
+    private func now() -> String { isoFormatter.string(from: Date()) }
+
+    // MARK: - Store round-trip
+
+    func testSaveAndDecodeRoundtripPreservesIdentity() {
+        let id = "rec-1"
+        let record = CKRecord(recordType: "WorkoutSession",
+                              recordID: CKRecord.ID(recordName: id, zoneID: storedZone))
+        store.save(record)
+
+        XCTAssertNotNil(store.systemFields(for: id))
+        let decoded = store.decodedRecord(for: id)
+        XCTAssertEqual(decoded?.recordID.recordName, id)
+        XCTAssertEqual(decoded?.recordType, "WorkoutSession")
+        XCTAssertEqual(decoded?.recordID.zoneID, storedZone)
+    }
+
+    func testSystemFieldsNilForUnknownRecord() {
+        XCTAssertNil(store.systemFields(for: "does-not-exist"))
+        XCTAssertNil(store.decodedRecord(for: "does-not-exist"))
+    }
+
+    func testRemoveDropsMetadata() {
+        let id = "rec-rm"
+        store.save(CKRecord(recordType: "Gym", recordID: CKRecord.ID(recordName: id, zoneID: storedZone)))
+        XCTAssertNotNil(store.systemFields(for: id))
+        store.remove(id)
+        XCTAssertNil(store.systemFields(for: id))
+    }
+
+    func testClearAllEmptiesTable() {
+        store.save(CKRecord(recordType: "Gym", recordID: CKRecord.ID(recordName: "a", zoneID: storedZone)))
+        store.save(CKRecord(recordType: "Gym", recordID: CKRecord.ID(recordName: "b", zoneID: storedZone)))
+        store.clearAll()
+        XCTAssertNil(store.systemFields(for: "a"))
+        XCTAssertNil(store.systemFields(for: "b"))
+    }
+
+    func testSaveUpsertsByRecordName() {
+        let id = "rec-upsert"
+        store.save(CKRecord(recordType: "Gym", recordID: CKRecord.ID(recordName: id, zoneID: storedZone)))
+        store.save(CKRecord(recordType: "Gym", recordID: CKRecord.ID(recordName: id, zoneID: storedZone)))
+        // Still exactly one row (PK on record_name); no error/dupe.
+        XCTAssertNotNil(store.systemFields(for: id))
+    }
+
+    // MARK: - applyStoredSystemFields (tag rehydration)
+
+    func testApplyStoredSystemFieldsRehydratesOntoStoredIdentityAndKeepsFields() {
+        let id = "rec-rehydrate"
+        // Confirmed once in storedZone.
+        store.save(CKRecord(recordType: "WorkoutSession",
+                            recordID: CKRecord.ID(recordName: id, zoneID: storedZone)))
+
+        // A later upload builds a fresh record in callerZone with data fields…
+        let fresh = CKRecord(recordType: "WorkoutSession",
+                             recordID: CKRecord.ID(recordName: id, zoneID: callerZone))
+        fresh["status"] = "completed" as CKRecordValue
+
+        // …rehydration must use the STORED identity AND carry the data fields over.
+        let result = mapper.applyStoredSystemFields(to: fresh)
+        XCTAssertEqual(result.recordID.zoneID, storedZone, "Existing record must rehydrate from stored system fields")
+        XCTAssertEqual(result["status"] as? String, "completed", "Data fields must be preserved onto the rehydrated base")
+    }
+
+    func testApplyStoredSystemFieldsReturnsFreshWhenNoMetadata() {
+        let fresh = CKRecord(recordType: "WorkoutSession",
+                             recordID: CKRecord.ID(recordName: "brand-new", zoneID: callerZone))
+        let result = mapper.applyStoredSystemFields(to: fresh)
+        XCTAssertEqual(result.recordID.zoneID, callerZone, "New record must stay fresh in the caller's zone")
+        XCTAssertNil(result.recordChangeTag)
+    }
+
+    func testApplyStoredSystemFieldsReturnsFreshOnTypeMismatch() {
+        let id = "rec-typemismatch"
+        store.save(CKRecord(recordType: "WorkoutSession",
+                            recordID: CKRecord.ID(recordName: id, zoneID: storedZone)))
+        // Wrong type for this name → ignore stale metadata, keep the fresh record.
+        let fresh = CKRecord(recordType: "SetMeasurement",
+                             recordID: CKRecord.ID(recordName: id, zoneID: callerZone))
+        let result = mapper.applyStoredSystemFields(to: fresh)
+        XCTAssertEqual(result.recordID.zoneID, callerZone)
+    }
+
+    func testCreateCKRecordRehydratesFromStoredSystemFields() throws {
+        let id = "session-rehydrate"
+        let dbQueue = try DatabaseManager.shared.database()
+        try dbQueue.write { db in
+            try db.execute(
+                sql: "INSERT INTO workout_sessions (id, name, date, status, updated_at) VALUES (?, ?, ?, ?, ?)",
+                arguments: [id, "Push", "2026-06-07", "completed", now()]
+            )
+        }
+        store.save(CKRecord(recordType: "WorkoutSession",
+                            recordID: CKRecord.ID(recordName: id, zoneID: storedZone)))
+
+        // Pass callerZone; because metadata exists, createCKRecord rehydrates onto storedZone
+        // and still populates the data fields (no GRDB reentrancy from the nested metadata read).
+        let record = mapper.createCKRecord(for: CKRecord.ID(recordName: id, zoneID: callerZone), zoneID: callerZone)
+        XCTAssertEqual(record?.recordID.zoneID, storedZone)
+        XCTAssertEqual(record?["status"] as? String, "completed")
+        XCTAssertEqual(record?["name"] as? String, "Push")
+    }
+
+    func testCreateCKRecordBuildsFreshWhenNoMetadata() throws {
+        let id = "session-fresh"
+        let dbQueue = try DatabaseManager.shared.database()
+        try dbQueue.write { db in
+            try db.execute(
+                sql: "INSERT INTO workout_sessions (id, name, date, status, updated_at) VALUES (?, ?, ?, ?, ?)",
+                arguments: [id, "Pull", "2026-06-07", "completed", now()]
+            )
+        }
+        let record = mapper.createCKRecord(for: CKRecord.ID(recordName: id, zoneID: callerZone), zoneID: callerZone)
+        XCTAssertEqual(record?.recordID.zoneID, callerZone)
+        XCTAssertNil(record?.recordChangeTag, "A record with no stored metadata uploads as a fresh create")
+    }
+
+    func testParentAndChildMeasurementHaveIndependentMetadata() {
+        let setId = "set-1"
+        let measurementId = "meas-1"
+        store.save(CKRecord(recordType: "SessionSet",
+                            recordID: CKRecord.ID(recordName: setId, zoneID: storedZone)))
+        store.save(CKRecord(recordType: "SetMeasurement",
+                            recordID: CKRecord.ID(recordName: measurementId, zoneID: storedZone)))
+
+        XCTAssertEqual(store.decodedRecord(for: setId)?.recordType, "SessionSet")
+        XCTAssertEqual(store.decodedRecord(for: measurementId)?.recordType, "SetMeasurement")
+    }
+
+    // MARK: - mergeIncoming persists tags unconditionally
+
+    func testMergeIncomingPersistsSystemFieldsEvenWhenLocalIsNewer() throws {
+        let id = "session-local-newer"
+        let dbQueue = try DatabaseManager.shared.database()
+        // Local row is NEWER than the incoming server record.
+        try dbQueue.write { db in
+            try db.execute(
+                sql: "INSERT INTO workout_sessions (id, name, date, status, updated_at) VALUES (?, ?, ?, ?, ?)",
+                arguments: [id, "Local", "2026-06-07", "completed", now()]
+            )
+        }
+
+        let incoming = CKRecord(recordType: "WorkoutSession",
+                                recordID: CKRecord.ID(recordName: id, zoneID: storedZone))
+        incoming["name"] = "Server" as CKRecordValue
+        incoming["date"] = "2026-06-07" as CKRecordValue
+        incoming["status"] = "in_progress" as CKRecordValue
+        incoming["updatedAt"] = Date(timeIntervalSinceNow: -3600) as CKRecordValue // older
+
+        let merged = try mapper.mergeIncoming(incoming)
+
+        XCTAssertFalse(merged, "Local is newer, so the row merge must be skipped")
+        XCTAssertNotNil(mapper.metadataStore.systemFields(for: id),
+                        "System fields must be persisted even when the row merge is skipped")
+
+        // And the local row must be untouched (server did not clobber it).
+        let status = try dbQueue.read { db in
+            try String.fetchOne(db, sql: "SELECT status FROM workout_sessions WHERE id = ?", arguments: [id])
+        }
+        XCTAssertEqual(status, "completed")
+    }
+}

--- a/mobile-apps/ios/LiftMarkTests/DatabaseMigrationTests.swift
+++ b/mobile-apps/ios/LiftMarkTests/DatabaseMigrationTests.swift
@@ -304,7 +304,7 @@ final class DatabaseMigrationTests: XCTestCase {
     // MARK: - Synthetic future seed: runner must not mutate a future-versioned DB
 
     func testV17SyntheticSeed_migrationRunnerIsNoOp() throws {
-        // Build a head-shaped DB with schema_version=19 to simulate "DB from the future".
+        // Build a head-shaped DB with schema_version=20 to simulate "DB from the future".
         let loaded = try DatabaseSeedLoader.load(
             ddl: DatabaseSeeds.v17SyntheticDDL,
             data: DatabaseSeeds.v17SyntheticData
@@ -316,14 +316,14 @@ final class DatabaseMigrationTests: XCTestCase {
         let beforeVersion = try q.read { try Int.fetchOne($0, sql: "SELECT version FROM schema_version LIMIT 1") }
         let beforeRows = try q.read { try Int.fetchOne($0, sql: "SELECT COUNT(*) FROM user_settings") ?? -1 }
 
-        // Runner should short-circuit: seedVersion (19) > currentVersion (18).
+        // Runner should short-circuit: seedVersion (20) > currentVersion (19).
         try DatabaseManager.runMigrations(on: q)
 
         let afterVersion = try q.read { try Int.fetchOne($0, sql: "SELECT version FROM schema_version LIMIT 1") }
         let afterRows = try q.read { try Int.fetchOne($0, sql: "SELECT COUNT(*) FROM user_settings") ?? -1 }
 
-        XCTAssertEqual(beforeVersion, 19, "seed sanity")
-        XCTAssertEqual(afterVersion, 19, "runner must not lower schema_version")
+        XCTAssertEqual(beforeVersion, 20, "seed sanity")
+        XCTAssertEqual(afterVersion, 20, "runner must not lower schema_version")
         XCTAssertEqual(beforeRows, afterRows, "runner must not mutate a future-versioned DB")
     }
 }

--- a/mobile-apps/ios/LiftMarkTests/Fixtures/MigrationGoldenShapes.swift
+++ b/mobile-apps/ios/LiftMarkTests/Fixtures/MigrationGoldenShapes.swift
@@ -11,6 +11,7 @@ enum MigrationGoldenShapes {
     /// Ordered alphabetically so it also serves as the expected set when compared against
     /// the live DB's `sqlite_master` table listing.
     static let expectedTablesAtHead: [String] = [
+        "ck_record_metadata",
         "gym_equipment",
         "gyms",
         "outbox_pending_queue",

--- a/mobile-apps/ios/LiftMarkTests/Fixtures/Seeds/V14SyntheticSeed.swift
+++ b/mobile-apps/ios/LiftMarkTests/Fixtures/Seeds/V14SyntheticSeed.swift
@@ -2,12 +2,13 @@ import Foundation
 
 extension DatabaseSeeds {
 
-    // MARK: - Synthetic future (v19) — used to verify early-return behavior
+    // MARK: - Synthetic future (v20) — used to verify early-return behavior
     //
     // File is named V14SyntheticSeed.swift for historical reasons; the seed now
-    // represents a "from the future" DB at schema_version=19. DDL matches the
-    // current head (v18, which slimmed workout_inbox) so the shape is valid —
-    // only the version marker is ahead.
+    // represents a "from the future" DB at schema_version=20. DDL matches a recent
+    // head (pre-v19, so it omits ck_record_metadata) so the shape is valid — only the
+    // version marker is ahead. The runner must short-circuit on a future version and
+    // never inspect/mutate the schema.
 
     static let v17SyntheticDDL: String = #"""
     CREATE TABLE workout_templates (
@@ -135,6 +136,6 @@ extension DatabaseSeeds {
     INSERT INTO gyms (id, name, is_default, created_at, updated_at, deleted_at) VALUES
       ('\#(gymHome)', 'Home Gym', 1, '\#(ts1)', '\#(ts1)', NULL);
 
-    INSERT INTO schema_version (version) VALUES (19);
+    INSERT INTO schema_version (version) VALUES (20);
     """#
 }

--- a/mobile-apps/ios/LiftMarkTests/MigratorBridgeTests.swift
+++ b/mobile-apps/ios/LiftMarkTests/MigratorBridgeTests.swift
@@ -329,7 +329,7 @@ final class MigratorBridgeTests: XCTestCase {
             guard case MigratorBridgeError.refusedFutureVersion(let version) = error else {
                 return XCTFail("expected refusedFutureVersion, got \(error)")
             }
-            XCTAssertEqual(version, 19)
+            XCTAssertEqual(version, 20)
         }
     }
 
@@ -346,7 +346,7 @@ final class MigratorBridgeTests: XCTestCase {
 
         XCTAssertEqual(rowsBefore, rowsAfter)
         // schema_version unchanged
-        XCTAssertEqual(try schemaVersion(queue), 19)
+        XCTAssertEqual(try schemaVersion(queue), 20)
         // grdb_migrations table should NOT have been created.
         let bridgeTablePresent = try queue.read { db in
             try Int.fetchOne(
@@ -487,7 +487,7 @@ final class MigratorBridgeTests: XCTestCase {
 
         let persisted = MigratorBridgeFailure.loadPersisted()
         XCTAssertEqual(persisted?.failure, .futureVersion)
-        XCTAssertEqual(persisted?.context.fromVersion, 19)
+        XCTAssertEqual(persisted?.context.fromVersion, 20)
     }
 
     /// A successful bridge must clear a stale lastAttemptFailed + failure case

--- a/spec/services/cloudkit-sync.md
+++ b/spec/services/cloudkit-sync.md
@@ -232,7 +232,33 @@ back to the formatted calendar date (never the raw string).
 
 ## Sync Strategy
 
-### Phase 1: Full Download-then-Upload (Current Implementation)
+### Current Implementation: CKSyncEngine + Record System-Fields
+
+The app syncs via **`CKSyncEngine`** against the private database, custom zone `LiftMarkData`. The engine drives fetch/send cycles and persists its serialized state (database/zone change tokens + the set of pending record IDs) in the `sync_engine_state` table. The Phase 1/2/3 description below predates this and is retained only for historical context.
+
+#### Record System-Fields Persistence (change tags) — REQUIRED invariant
+
+`CKSyncEngine`'s serialized state does **not** store records or their `recordChangeTag`s — persisting them is the app's responsibility. The app keeps a per-record cache:
+
+- Table `ck_record_metadata(record_name PK, record_type, system_fields BLOB, updated_at)` — one row per CloudKit record, all record types. `system_fields` is `CKRecord.encodedSystemFields` (record ID, zone, and current change tag; no user fields).
+
+Invariants:
+
+1. **Rehydrate on upload.** When building a `CKRecord` to upload (`CKRecordMapper.baseRecord` → `toCKRecord`), if a metadata row exists for the record name, the `CKRecord` MUST be reconstructed from the stored `system_fields` (so it carries the current change tag) and then have its data fields written. A fresh `CKRecord` is built ONLY when no metadata row exists (a genuinely new record CloudKit will create).
+2. **Persist on confirm.** System fields MUST be saved whenever CloudKit hands us an authoritative record: (a) each `event.savedRecords` after a successful upload, (b) **unconditionally** in `mergeIncoming` for every fetched record — even when the row-merge is skipped because local is newer/unchanged (the server tag is still the token our next upload needs), and (c) from `error.serverRecord` on a `serverRecordChanged` conflict (handled via `mergeIncoming`).
+3. **Remove on delete.** Drop the metadata row on a confirmed delete (local `event.deletedRecordIDs`, or an incoming deletion).
+
+**Why:** without this, every upload builds a fresh tagless `CKRecord`; CloudKit rejects any update to an already-existing record with `serverRecordChanged`; the resolver re-uploads (still tagless) and conflicts again — a permanent loop that jams the pending queue and starves all other uploads (observed: ~92% SetMeasurement conflict rate, an ~8.6k-deep queue with ~0 net drain, completed workouts never reaching other devices). With durable tags, `serverRecordChanged` becomes a rare true-conflict (genuine concurrent edits) that converges in one cycle.
+
+#### One-time recovery (`fullUploadVersion` = 5)
+
+Devices jammed by the pre-fix loop have a large stale pending queue and no stored system fields. On a `fullUploadVersion` bump the app performs an **ordered reset → re-fetch → re-upload** (before creating the engine, so it restarts fresh):
+
+1. `DELETE FROM sync_engine_state` and clear `ck_record_metadata`. **No data tables are touched — no data loss.**
+2. The engine restarts with nil state → full zone re-fetch → `mergeIncoming` repopulates `ck_record_metadata` with authoritative tags. Merges key on stable UUID PKs (update-in-place, no duplication); locally-newer rows survive (LWW keeps local on newer/tie).
+3. Only **after** the first fetch completes (`.didFetchChanges`) does the app re-upload local rows (`scheduleFullUpload`) — now with correct tags — and bump the stored version. The account-change full-upload is deferred during the recovery window. The version is bumped only after the deferred upload is scheduled, so an app kill mid-recovery simply re-runs it (idempotent).
+
+### Phase 1: Full Download-then-Upload (superseded — historical)
 
 The sync runs in **download-first** order to avoid an upload storm when another device (or app version) has already synced records to the CloudKit container:
 


### PR DESCRIPTION
## Problem

iPhone→iPad CloudKit sync silently stopped delivering the most-recent completed workout. Forensics on a device DB backup + its 76k-row `app_logs` table proved the cause: **every upload built a fresh `CKRecord` with a nil `recordChangeTag`**, so CloudKit rejected any update to an already-existing record with `serverRecordChanged`. The resolver re-uploaded (still tagless) → conflicted again → **permanent loop**:

- ~92% of `SetMeasurement` syncs looped (16,386 conflicts vs 1,463 ok)
- pending queue jammed ~8,600 deep, draining ~0 (8620→8370 over 1.5h)
- a completed `WorkoutSession` enqueued behind the jam was starved and never uploaded — local row was `completed`, CloudKit copy frozen at `in_progress`, so the iPad (which hides in-progress) never showed it

This is the "conflict resolver dead-end" flagged in the SetMeasurement-migration notes. It is **separate** from the WAF 8KB bug (#218) — that path worked here.

## Fix

Adopt the canonical CKSyncEngine pattern: persist each record's `encodedSystemFields` and rehydrate from them on upload so the change tag always matches the server.

- **`ck_record_metadata` table** (migration **v19**, lockstep across `MigratorBridge` + `DatabaseManager`) + new **`CKRecordMetadataStore`**.
- **`createCKRecord`** rehydrates an existing record onto its stored system fields (done *outside* the row read to avoid GRDB reentrancy); new records upload fresh.
- Tags persisted on every confirmed **save**, **unconditionally** on every incoming **fetch** (even when local is newer — the server tag is the token our next upload needs), and via the **conflict** path; removed on delete.
- **One-time data-safe recovery** (`fullUploadVersion = 5`): reset engine state + tag cache → re-fetch to repopulate authoritative tags → *then* re-upload local rows. No data rows touched; merges key on stable UUID PKs (no dup/loss); locally-newer rows survive.
- Refactor `runMigrations` to a data-driven chain (keeps cyclomatic complexity bounded as migrations grow); fix the stale `serverRecordIsNewer` tie-break comment.

## Spec & tests

- Spec-first: `spec/services/cloudkit-sync.md` documents the system-fields invariant + recovery.
- New `CKRecordMetadataStoreTests` (round-trip, rehydration, fresh-on-new / type-mismatch, merge-persists-tag-even-when-local-newer, end-to-end `createCKRecord`) + golden/synthetic-seed updates for v19.
- **937 unit tests pass, 0 failures**; build clean; 0 SwiftLint errors; no CloudKit schema drift.

## Rollout note

On first launch of this build, each existing device performs a one-time full re-fetch (bandwidth/battery) to learn authoritative change tags — the only data-safe way to heal a device already jammed by the loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)