### PR TITLE
test(ios): Layer 3 e2e against deployed beta backend (#137)

### DIFF
--- a/.github/workflows/swift-e2e-beta.yml
+++ b/.github/workflows/swift-e2e-beta.yml
@@ -1,0 +1,225 @@
+name: '[iOS] E2E (beta)'
+
+# Layer-3 e2e (GH #137): drives the iOS UI against the DEPLOYED beta backend,
+# exercising the real client↔server contract (login, inbox poll, outbox push)
+# that the network-isolated PR/nightly suites never touch.
+#
+# Self-contained per run: seeds a fresh account via the beta-only
+# /v1/__test__/* backdoor (gated by lmwf-beta-e2e-test-secret; returns 404 when
+# LMWF_ENV=prod, so it can never run against prod), plants an inbox workout,
+# runs the BetaE2E test plan, verifies the outbox server-side, then deletes the
+# account. No persistent test account, no new secret.
+#
+# Targets https://beta.getlift.md. That host goes live with the beta DNS cutover
+# (GH #248); until then this workflow is red-on-run by design. The host is an
+# input/env var so it is a one-line flip if the cutover slips.
+# See spec/services/ios-e2e-beta.md.
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: 'Beta backend base URL'
+        required: false
+        default: 'https://beta.getlift.md'
+  schedule:
+    # Weekly, Monday 07:37 UTC. Odd minute — GitHub delays/drops cron at the top
+    # of the hour under load.
+    - cron: '37 7 * * 1'
+
+# A manual run during a scheduled one (or vice versa) shouldn't pile up macOS
+# jobs against the public-repo concurrency cap.
+concurrency:
+  group: ios-e2e-beta
+  cancel-in-progress: true
+
+jobs:
+  beta-e2e:
+    runs-on: macos-26
+    timeout-minutes: 75
+    # The `beta` environment scopes AWS_DEPLOY_ROLE_ARN to the beta account,
+    # exactly like validator-ci's deploy-beta / e2e-beta jobs.
+    environment:
+      name: beta
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      AWS_REGION: us-west-2
+      AWS_DEFAULT_REGION: us-west-2
+      LMWF_E2E_BASE_URL: ${{ github.event.inputs.base_url || 'https://beta.getlift.md' }}
+      # Fixed names the scenarios assert on (see e2e-spec/scenarios/beta-*.yaml).
+      INBOX_WORKOUT_NAME: 'Beta Inbox Probe'
+      OUTBOX_WORKOUT_NAME: 'Detox Flow Workout'
+    defaults:
+      run:
+        shell: bash --noprofile --norc -eo pipefail {0}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Fetch E2E test secret from beta Secrets Manager
+        id: secret
+        run: |
+          set -euo pipefail
+          SECRET=$(aws secretsmanager get-secret-value \
+            --secret-id lmwf-beta-e2e-test-secret \
+            --query SecretString --output text)
+          echo "::add-mask::$SECRET"
+          echo "secret=$SECRET" >> "$GITHUB_OUTPUT"
+
+      # Pre-warm the beta Lambda — the UI suite fires auth/poll/push calls that
+      # otherwise hit concurrent cold starts (mirrors validator-ci e2e-beta).
+      - name: Warm beta Lambda
+        run: |
+          set -uo pipefail
+          echo "==> warming $LMWF_E2E_BASE_URL"
+          for round in 1 2 3; do
+            for i in $(seq 1 8); do
+              curl -s -o /dev/null --max-time 30 "$LMWF_E2E_BASE_URL/version" &
+            done
+            wait
+          done
+          echo "==> warm-up complete"
+
+      - name: Seed beta account + plant inbox workout
+        id: seed
+        env:
+          TEST_SECRET: ${{ steps.secret.outputs.secret }}
+        run: |
+          set -euo pipefail
+          EMAIL="ios-e2e-$(date +%s)-${RANDOM}@e2e.getlift.md"
+          PASSWORD="Pw-$(openssl rand -hex 18)"
+          echo "::add-mask::$PASSWORD"
+
+          RESP=$(curl -fsS --retry 5 --retry-all-errors --retry-delay 2 \
+            -X POST "$LMWF_E2E_BASE_URL/v1/__test__/seed-user" \
+            -H 'content-type: application/json' \
+            -H "x-test-secret: $TEST_SECRET" \
+            -d "{\"email\":\"$EMAIL\",\"password\":\"$PASSWORD\",\"display_name\":\"iOS E2E\",\"tier\":\"trial\"}")
+          JWT=$(echo "$RESP" | jq -r '.session_jwt')
+          if [ -z "$JWT" ] || [ "$JWT" = "null" ]; then
+            echo "::error::seed-user returned no session_jwt: $RESP"; exit 1
+          fi
+          echo "::add-mask::$JWT"
+
+          # Plant a workout in the account's inbox for the beta-inbox scenario.
+          curl -fsS --retry 5 --retry-all-errors --retry-delay 2 \
+            -X POST "$LMWF_E2E_BASE_URL/v1/workouts" \
+            -H 'content-type: application/json' \
+            -H "authorization: Bearer $JWT" \
+            -d "{\"lmwf\":\"# $INBOX_WORKOUT_NAME\n\n## Bench Press\n\n- 135 x 5\n\"}" > /dev/null
+
+          echo "email=$EMAIL" >> "$GITHUB_OUTPUT"
+          echo "password=$PASSWORD" >> "$GITHUB_OUTPUT"
+          echo "==> seeded $EMAIL and planted inbox workout"
+
+      # ── Build the app (mirrors swift-nightly.yml) ──
+      - name: Select Xcode 26
+        run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
+
+      - name: Install XcodeGen
+        run: |
+          brew install xcodegen
+          INSTALLED=$(xcodegen --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+          MINIMUM="2.45.3"
+          if [ "$(printf '%s\n' "$MINIMUM" "$INSTALLED" | sort -V | head -n1)" != "$MINIMUM" ]; then
+            echo "::error::XcodeGen version too old: need >= $MINIMUM, got $INSTALLED"
+            exit 1
+          fi
+
+      - name: Write placeholder Sentry xcconfig
+        working-directory: mobile-apps/ios
+        run: |
+          cat > Config/Sentry.xcconfig <<'EOF'
+          // CI placeholder — no DSN. Real DSN written in deploy workflow.
+          SENTRY_DSN_REST =
+          EOF
+
+      - name: Generate SentryConfig (pre-xcodegen)
+        working-directory: mobile-apps/ios
+        run: ./scripts/gen-sentry-config.sh
+
+      - name: Generate Xcode project
+        working-directory: mobile-apps/ios
+        run: xcodegen generate
+
+      - name: Resolve Swift packages
+        working-directory: mobile-apps/ios
+        run: xcodebuild -resolvePackageDependencies -scheme LiftMark -project LiftMark.xcodeproj
+
+      # The test plan forwards these build settings into the runner process
+      # environment via $(...) expansion in BetaE2E.xctestplan; the runner
+      # interpolates them into the login scenario's replaceText values and the
+      # --api-base-url launch arg. A generous timeout scale absorbs
+      # CloudFront/Lambda edge latency on the live backend.
+      - name: Run BetaE2E plan against beta
+        working-directory: mobile-apps/ios
+        env:
+          E2E_EMAIL: ${{ steps.seed.outputs.email }}
+          E2E_PASSWORD: ${{ steps.seed.outputs.password }}
+        run: |
+          xcodebuild test \
+            -scheme LiftMark \
+            -project LiftMark.xcodeproj \
+            -testPlan BetaE2E \
+            -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=latest' \
+            -resultBundlePath TestResults.xcresult \
+            LMWF_E2E_BASE_URL="$LMWF_E2E_BASE_URL" \
+            LMWF_E2E_EMAIL="$E2E_EMAIL" \
+            LMWF_E2E_PASSWORD="$E2E_PASSWORD" \
+            UITEST_TIMEOUT_SCALE=4 \
+            | xcpretty
+
+      # The app has no in-app outbox list view, so assert the outbox round-trip
+      # server-side. Re-login fresh (the seed JWT may have expired during the
+      # build) to fetch a token, then confirm the completed workout landed.
+      - name: Verify outbox round-trip (server-side)
+        if: success()
+        env:
+          EMAIL: ${{ steps.seed.outputs.email }}
+          PASSWORD: ${{ steps.seed.outputs.password }}
+        run: |
+          set -euo pipefail
+          LOGIN=$(curl -fsS --retry 5 --retry-all-errors --retry-delay 2 \
+            -X POST "$LMWF_E2E_BASE_URL/v1/auth/password/login" \
+            -H 'content-type: application/json' \
+            -d "{\"email\":\"$EMAIL\",\"password\":\"$PASSWORD\"}")
+          JWT=$(echo "$LOGIN" | jq -r '.access_jwt')
+          echo "::add-mask::$JWT"
+          ITEMS=$(curl -fsS --retry 5 --retry-all-errors --retry-delay 2 \
+            -H "authorization: Bearer $JWT" \
+            "$LMWF_E2E_BASE_URL/v1/workouts/outbox")
+          if ! echo "$ITEMS" | jq -e --arg n "$OUTBOX_WORKOUT_NAME" \
+              '.items[] | select(.session_name == $n)' > /dev/null; then
+            echo "::error::outbox did not receive '$OUTBOX_WORKOUT_NAME'"
+            echo "$ITEMS"
+            exit 1
+          fi
+          echo "==> outbox round-trip OK"
+
+      - name: Teardown beta test account
+        if: always() && steps.seed.outputs.email != ''
+        env:
+          TEST_SECRET: ${{ steps.secret.outputs.secret }}
+          EMAIL: ${{ steps.seed.outputs.email }}
+        run: |
+          curl -fsS -X POST "$LMWF_E2E_BASE_URL/v1/__test__/delete-user-by-email" \
+            -H 'content-type: application/json' \
+            -H "x-test-secret: $TEST_SECRET" \
+            -d "{\"email\":\"$EMAIL\"}" || echo "::warning::teardown failed; row may linger"
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: beta-e2e-results
+          path: mobile-apps/ios/TestResults.xcresult
+          retention-days: 14

--- a/e2e-spec/runners/xcuitest/ActionAdapter.swift
+++ b/e2e-spec/runners/xcuitest/ActionAdapter.swift
@@ -237,6 +237,32 @@ class ActionAdapter {
         return try String(contentsOfFile: path, encoding: .utf8)
     }
 
+    /// Substitute `${VAR}` tokens with values from the test process
+    /// environment. Credentials for the Layer-3 beta e2e are minted fresh per
+    /// CI run, so static YAML references them as `${LMWF_E2E_EMAIL}` etc. An
+    /// unset variable resolves to the empty string.
+    /// See spec/services/ios-e2e-beta.md.
+    func interpolateEnv(_ value: String) -> String {
+        guard value.contains("${") else { return value }
+        let env = ProcessInfo.processInfo.environment
+        var result = ""
+        var rest = Substring(value)
+        while let open = rest.range(of: "${") {
+            result += String(rest[rest.startIndex..<open.lowerBound])
+            let afterOpen = rest[open.upperBound...]
+            guard let close = afterOpen.range(of: "}") else {
+                // Unterminated token — emit the remainder verbatim.
+                result += String(rest[open.lowerBound...])
+                return result
+            }
+            let name = String(afterOpen[afterOpen.startIndex..<close.lowerBound])
+            result += env[name] ?? ""
+            rest = afterOpen[close.upperBound...]
+        }
+        result += String(rest)
+        return result
+    }
+
     // MARK: - Action Implementations
 
     private func executeTap(_ action: TestAction) throws {
@@ -389,12 +415,13 @@ class ActionAdapter {
             return
         }
 
-        // Resolve text value — from fixture or direct value
+        // Resolve text value — from fixture or direct value. Direct values
+        // support ${ENV_VAR} interpolation (e.g. per-run beta credentials).
         let textValue: String
         if let fixture = action.fixture {
             textValue = try readFixture(fixture)
         } else if let value = action.value {
-            textValue = value
+            textValue = interpolateEnv(value)
         } else {
             throw ActionError.missingParam("value or fixture", "replaceText")
         }
@@ -417,7 +444,7 @@ class ActionAdapter {
             return
         }
         el.tap()
-        el.typeText(value)
+        el.typeText(interpolateEnv(value))
     }
 
     private func executeWaitFor(_ action: TestAction) throws {
@@ -593,11 +620,13 @@ class ActionAdapter {
             isFirstLaunch = false
         }
 
-        // Apply additional launch arguments from the YAML action
+        // Apply additional launch arguments from the YAML action. Values
+        // support ${ENV_VAR} interpolation so e.g. the beta base URL can be
+        // injected per CI run (--api-base-url=${LMWF_E2E_BASE_URL}).
         if case .array(let yamlArgs) = action.launchArgs {
             for arg in yamlArgs {
                 if case .string(let value) = arg {
-                    args.append(value)
+                    args.append(interpolateEnv(value))
                 }
             }
         }

--- a/e2e-spec/scenarios/beta-inbox.yaml
+++ b/e2e-spec/scenarios/beta-inbox.yaml
@@ -1,0 +1,54 @@
+name: "Beta — inbox surfaces a pushed workout"
+
+# Layer-3 e2e (GH #137): the CI workflow pushes a workout named
+# "Beta Inbox Probe" to the seeded user's inbox via POST /v1/workouts BEFORE
+# this runs. The app logs in, forces an inbox poll, and the pushed workout must
+# surface in the Workouts-tab inbox. See spec/services/ios-e2e-beta.md.
+
+setupOnce:
+  - action: launchApp
+    newInstance: true
+    launchArgs:
+      - "--live-backend"
+      - "--api-base-url=${LMWF_E2E_BASE_URL}"
+      - "--enable-flag=workoutInbox"
+
+tests:
+  - name: "should poll the inbox and show the API-pushed workout"
+    steps:
+      - action: tap
+        target: "tab-settings"
+      - action: waitFor
+        target: "account-sign-in"
+        timeout: 15000
+      - action: tap
+        target: "account-sign-in"
+      - action: waitFor
+        target: "login-email"
+        timeout: 15000
+      - action: replaceText
+        target: "login-email"
+        value: "${LMWF_E2E_EMAIL}"
+      - action: replaceText
+        target: "login-password"
+        value: "${LMWF_E2E_PASSWORD}"
+      - action: tap
+        target: "login-submit"
+      - action: waitFor
+        target: "account-identity"
+        timeout: 30000
+      # Force a poll (inbox + outbox) rather than waiting for a foreground tick.
+      - action: waitFor
+        target: "account-inbox-sync-now"
+        timeout: 10000
+      - action: tap
+        target: "account-inbox-sync-now"
+      # The pushed workout should land in the Workouts-tab inbox section.
+      - action: tap
+        target: "tab-workouts"
+      - action: waitFor
+        target: "inbox-section"
+        timeout: 30000
+      - action: waitForText
+        text: "Beta Inbox Probe"
+        timeout: 30000

--- a/e2e-spec/scenarios/beta-login.yaml
+++ b/e2e-spec/scenarios/beta-login.yaml
@@ -1,0 +1,55 @@
+name: "Beta — login round-trip"
+
+# Layer-3 e2e (GH #137): exercises the real auth contract against the deployed
+# beta backend. Runs ONLY under the BetaE2E test plan — credentials are injected
+# per CI run via ${LMWF_E2E_*} env interpolation, and the backend host via
+# ${LMWF_E2E_BASE_URL}. See spec/services/ios-e2e-beta.md.
+
+setupOnce:
+  - action: launchApp
+    newInstance: true
+    launchArgs:
+      - "--live-backend"
+      - "--api-base-url=${LMWF_E2E_BASE_URL}"
+      - "--enable-flag=workoutInbox"
+
+tests:
+  - name: "should sign in against beta and persist the session"
+    steps:
+      - action: tap
+        target: "tab-settings"
+      - action: waitFor
+        target: "account-sign-in"
+        timeout: 15000
+      - action: tap
+        target: "account-sign-in"
+      - action: waitFor
+        target: "login-email"
+        timeout: 15000
+      - action: replaceText
+        target: "login-email"
+        value: "${LMWF_E2E_EMAIL}"
+      - action: replaceText
+        target: "login-password"
+        value: "${LMWF_E2E_PASSWORD}"
+      - action: tap
+        target: "login-submit"
+      # Real network login → the account section flips to signed-in.
+      - action: waitFor
+        target: "account-identity"
+        timeout: 30000
+      - action: expect
+        target: "account-sign-out"
+        assertion: "toExist"
+
+  - name: "should sign out and revoke the session"
+    steps:
+      - action: waitFor
+        target: "account-sign-out"
+        timeout: 10000
+      - action: tap
+        target: "account-sign-out"
+      # logout() revokes server-side then clears local tokens → signed-out copy.
+      - action: waitFor
+        target: "account-sign-in"
+        timeout: 20000

--- a/e2e-spec/scenarios/beta-outbox.yaml
+++ b/e2e-spec/scenarios/beta-outbox.yaml
@@ -1,0 +1,126 @@
+name: "Beta — completed workout pushes to outbox"
+
+# Layer-3 e2e (GH #137): sign in, complete a workout in the UI (the proven
+# local completion flow from workout-flow.yaml), then force a sync. Under
+# --live-backend the session-complete notification enqueues + flushes to the
+# server outbox. The server-side round-trip is asserted by the CI workflow,
+# which queries GET /v1/workouts/outbox for "Detox Flow Workout" after this
+# scenario. See spec/services/ios-e2e-beta.md.
+
+setupOnce:
+  - action: launchApp
+    newInstance: true
+    launchArgs:
+      - "--live-backend"
+      - "--api-base-url=${LMWF_E2E_BASE_URL}"
+      - "--enable-flag=workoutInbox"
+
+tests:
+  - name: "should sign in, complete a workout, and flush it to the outbox"
+    steps:
+      # --- Sign in ---
+      - action: tap
+        target: "tab-settings"
+      - action: waitFor
+        target: "account-sign-in"
+        timeout: 15000
+      - action: tap
+        target: "account-sign-in"
+      - action: waitFor
+        target: "login-email"
+        timeout: 15000
+      - action: replaceText
+        target: "login-email"
+        value: "${LMWF_E2E_EMAIL}"
+      - action: replaceText
+        target: "login-password"
+        value: "${LMWF_E2E_PASSWORD}"
+      - action: tap
+        target: "login-submit"
+      - action: waitFor
+        target: "account-identity"
+        timeout: 30000
+
+      # --- Import + complete a workout (proven flow from workout-flow.yaml) ---
+      - action: tap
+        target: "tab-home"
+      - action: delay
+        ms: 500
+      - action: waitFor
+        target: "button-import-workout"
+        timeout: 10000
+      - action: tap
+        target: "button-import-workout"
+      - action: waitFor
+        target: "input-markdown"
+        timeout: 10000
+      - action: replaceText
+        target: "input-markdown"
+        fixture: "detox-flow-workout.md"
+      - action: tap
+        target: "button-import"
+      - action: waitForText
+        text: "OK"
+        timeout: 10000
+      - action: tapText
+        text: "OK"
+      - action: waitForText
+        text: "Detox Flow Workout"
+        timeout: 10000
+      - action: tapText
+        text: "Detox Flow Workout"
+      - action: waitFor
+        target: "start-workout-button"
+        timeout: 10000
+      - action: tap
+        target: "start-workout-button"
+      - action: waitFor
+        target: "active-workout-screen"
+        timeout: 10000
+      - action: waitFor
+        target: "active-workout-finish-button"
+        timeout: 10000
+      - action: tap
+        target: "active-workout-finish-button"
+      # Finish dialog — "Finish Anyway" / "Log Anyway" / "Finish".
+      - action: tryCatch
+        try:
+          - action: waitForText
+            text: "Finish Anyway"
+            timeout: 3000
+          - action: tapText
+            text: "Finish Anyway"
+        catch:
+          - action: tryCatch
+            try:
+              - action: waitForText
+                text: "Log Anyway"
+                timeout: 3000
+              - action: tapText
+                text: "Log Anyway"
+            catch:
+              - action: tryCatch
+                try:
+                  - action: waitForText
+                    text: "Finish"
+                    timeout: 3000
+                  - action: tapText
+                    text: "Finish"
+                catch: []
+      - action: waitFor
+        target: "workout-summary-done-button"
+        timeout: 15000
+      - action: tap
+        target: "workout-summary-done-button"
+
+      # --- Force the outbox flush (CI asserts the server row) ---
+      - action: tap
+        target: "tab-settings"
+      - action: waitFor
+        target: "account-inbox-sync-now"
+        timeout: 15000
+      - action: tap
+        target: "account-inbox-sync-now"
+      # Give the push time to reach the server before the CI verify step.
+      - action: delay
+        ms: 4000

--- a/mobile-apps/ios/LiftMark.xcodeproj/xcshareddata/xcschemes/LiftMark.xcscheme
+++ b/mobile-apps/ios/LiftMark.xcodeproj/xcshareddata/xcschemes/LiftMark.xcscheme
@@ -79,6 +79,9 @@
          <TestPlanReference
             reference = "container:TestPlans/Full.xctestplan">
          </TestPlanReference>
+         <TestPlanReference
+            reference = "container:TestPlans/BetaE2E.xctestplan">
+         </TestPlanReference>
       </TestPlans>
       <MacroExpansion>
          <BuildableReference

--- a/mobile-apps/ios/LiftMark/App/LiftMarkApp.swift
+++ b/mobile-apps/ios/LiftMark/App/LiftMarkApp.swift
@@ -163,10 +163,16 @@ struct LiftMarkApp: App {
                     gymStore.loadGyms()
                     handleLaunchArguments()
                     LiveActivityService.shared.cleanupOrphanedActivities()
+                    // CloudKit sync is ALWAYS off under tests (even with
+                    // --live-backend) — a beta UI run must never write to a
+                    // tester's iCloud. The network paths below run when not
+                    // testing, or under the --live-backend Layer-3 gate.
                     if !Self.isRunningTests {
                         Task {
                             await CKSyncEngineManager.shared.start()
                         }
+                    }
+                    if Self.networkPathsEnabled {
                         // Wait for launch session restoration to settle before
                         // the first authed calls, so an expired access token is
                         // refreshed first rather than tripping a premature 401
@@ -188,6 +194,8 @@ struct LiftMarkApp: App {
                             Task {
                                 await CKSyncEngineManager.shared.start()
                             }
+                        }
+                        if Self.networkPathsEnabled {
                             Task { @MainActor in
                                 await authStore.restoreSession()
                                 await inboxPoller.pollIfAuthenticated()
@@ -204,7 +212,7 @@ struct LiftMarkApp: App {
                 .onReceive(NotificationCenter.default.publisher(for: SessionStore.sessionDidComplete)) { note in
                     guard
                         let sessionId = note.userInfo?["sessionId"] as? String,
-                        !Self.isRunningTests
+                        Self.networkPathsEnabled
                     else { return }
                     outboxPusher.enqueue(clientSessionId: sessionId)
                 }
@@ -241,6 +249,17 @@ struct LiftMarkApp: App {
     }
 
     private static let isRunningTests = NSClassFromString("XCTestCase") != nil
+
+    /// Layer-3 e2e gate (GH #137). UI tests are network-isolated by default;
+    /// `--live-backend` re-enables the auth/inbox/outbox network paths so a
+    /// scenario can exercise the real client↔server contract against beta.
+    /// CloudKit sync is deliberately NOT covered by this flag — it stays off
+    /// under tests regardless. See spec/services/ios-e2e-beta.md.
+    private static let isLiveBackend = ProcessInfo.processInfo.arguments.contains("--live-backend")
+
+    /// True when the auth/inbox/outbox network startup paths should run: always
+    /// outside tests, and under tests only when `--live-backend` is passed.
+    private static var networkPathsEnabled: Bool { !isRunningTests || isLiveBackend }
 
     private func handleLaunchArguments() {
         let args = ProcessInfo.processInfo.arguments

--- a/mobile-apps/ios/LiftMark/Services/APIClient.swift
+++ b/mobile-apps/ios/LiftMark/Services/APIClient.swift
@@ -65,13 +65,17 @@ final class APIClient: APIClientProtocol, @unchecked Sendable {
     private let encoder: JSONEncoder
     private let decoder: JSONDecoder
 
-    /// - Parameter baseURL: Hard-override. When nil, the client reads
-    ///   `LMWF_API_BASE_URL` from Info.plist (also a hard-override), and
-    ///   otherwise resolves prod vs beta per request from the
-    ///   `feature_flag.useBetaApi` UserDefaults key. Default off → prod.
+    /// - Parameter baseURL: Hard-override. When nil, the client reads (in
+    ///   priority order) the `--api-base-url=<url>` launch argument (test-only,
+    ///   see spec/services/ios-e2e-beta.md) and then `LMWF_API_BASE_URL` from
+    ///   Info.plist — both hard-overrides — and otherwise resolves prod vs beta
+    ///   per request from the `feature_flag.useBetaApi` UserDefaults key.
+    ///   Default off → prod.
     init(baseURL: URL? = nil, session: URLSession = .shared) {
         if let baseURL {
             self.staticBaseURL = baseURL
+        } else if let argURL = Self.launchArgBaseURL() {
+            self.staticBaseURL = argURL
         } else if let plistValue = Bundle.main.object(forInfoDictionaryKey: "LMWF_API_BASE_URL") as? String,
                   let url = URL(string: plistValue) {
             self.staticBaseURL = url
@@ -105,6 +109,18 @@ final class APIClient: APIClientProtocol, @unchecked Sendable {
             )
         }
         self.decoder = decoder
+    }
+
+    /// Parse the test-only `--api-base-url=<url>` launch argument. Lets the
+    /// Layer-3 beta e2e plan point the client at the deployed beta backend for
+    /// the test process only, without touching the production beta-mode toggle.
+    /// See spec/services/ios-e2e-beta.md.
+    private static func launchArgBaseURL() -> URL? {
+        let prefix = "--api-base-url="
+        guard let arg = ProcessInfo.processInfo.arguments.first(where: { $0.hasPrefix(prefix) }) else {
+            return nil
+        }
+        return URL(string: String(arg.dropFirst(prefix.count)))
     }
 
     func send<Req: Encodable, Res: Decodable>(

--- a/mobile-apps/ios/LiftMarkUITests/LiftMarkUITests.swift
+++ b/mobile-apps/ios/LiftMarkUITests/LiftMarkUITests.swift
@@ -114,4 +114,25 @@ final class LiftMarkUITests: XCTestCase {
         runner.runScenario(named: "screenshots")
     }
 
+    // MARK: - Beta backend e2e (Layer 3, GH #137)
+    //
+    // These exercise the real client↔server contract against the deployed beta
+    // backend and run ONLY under the BetaE2E test plan — NOT Smoke or Full,
+    // which have no backend. They expect LMWF_E2E_BASE_URL / LMWF_E2E_EMAIL /
+    // LMWF_E2E_PASSWORD in the environment (forwarded by the test plan from the
+    // CI workflow). Run locally with those set + the beta host reachable.
+    // See spec/services/ios-e2e-beta.md.
+
+    func testBetaLogin() throws {
+        runner.runScenario(named: "beta-login")
+    }
+
+    func testBetaInbox() throws {
+        runner.runScenario(named: "beta-inbox")
+    }
+
+    func testBetaOutbox() throws {
+        runner.runScenario(named: "beta-outbox")
+    }
+
 }

--- a/mobile-apps/ios/TestPlans/BetaE2E.xctestplan
+++ b/mobile-apps/ios/TestPlans/BetaE2E.xctestplan
@@ -1,0 +1,51 @@
+{
+  "configurations" : [
+    {
+      "id" : "5A1F0003-0000-4000-8000-000000000003",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "environmentVariableEntries" : [
+      {
+        "key" : "UITEST_TIMEOUT_SCALE",
+        "value" : "$(UITEST_TIMEOUT_SCALE)"
+      },
+      {
+        "key" : "LMWF_E2E_BASE_URL",
+        "value" : "$(LMWF_E2E_BASE_URL)"
+      },
+      {
+        "key" : "LMWF_E2E_EMAIL",
+        "value" : "$(LMWF_E2E_EMAIL)"
+      },
+      {
+        "key" : "LMWF_E2E_PASSWORD",
+        "value" : "$(LMWF_E2E_PASSWORD)"
+      }
+    ],
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:LiftMark.xcodeproj",
+      "identifier" : "C85473E4DFB8A8D106D9E91F",
+      "name" : "LiftMark"
+    }
+  },
+  "testTargets" : [
+    {
+      "selectedTests" : [
+        "LiftMarkUITests\/testBetaLogin()",
+        "LiftMarkUITests\/testBetaInbox()",
+        "LiftMarkUITests\/testBetaOutbox()"
+      ],
+      "target" : {
+        "containerPath" : "container:LiftMark.xcodeproj",
+        "identifier" : "F8ECB0187FF2B538943D49D0",
+        "name" : "LiftMarkUITests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/mobile-apps/ios/project.yml
+++ b/mobile-apps/ios/project.yml
@@ -229,7 +229,10 @@ schemes:
       # Two-tier test plans. Smoke (the default) runs the full unit suite plus a
       # render-only UI subset — fast and deterministic enough to gate every PR.
       # Full runs the entire UI suite (minus screenshot capture) and is driven
-      # nightly via `xcodebuild test -testPlan Full`. See TestPlans/*.xctestplan.
+      # nightly via `xcodebuild test -testPlan Full`. BetaE2E runs the Layer-3
+      # scenarios that hit the deployed beta backend (GH #137) via the
+      # `[iOS] E2E (beta)` workflow — NOT part of the PR gate or nightly.
+      # See TestPlans/*.xctestplan and spec/services/ios-e2e-beta.md.
       #
       # The UI-test timeout multiplier (UITEST_TIMEOUT_SCALE) is plumbed into the
       # runner process from within each plan's environmentVariableEntries: the
@@ -240,6 +243,7 @@ schemes:
         - path: TestPlans/Smoke.xctestplan
           defaultPlan: true
         - path: TestPlans/Full.xctestplan
+        - path: TestPlans/BetaE2E.xctestplan
       targets:
         - LiftMarkTests
         - LiftMarkUITests

--- a/spec/services/ios-e2e-beta.md
+++ b/spec/services/ios-e2e-beta.md
@@ -1,0 +1,138 @@
+# iOS E2E against beta (Layer 3)
+
+Status: spec for GH #137 Layer 3 — iOS UI tests that exercise the real
+client↔server contract against the deployed **beta** backend.
+
+## Why this exists
+
+The 19 YAML UI scenarios under `e2e-spec/scenarios/` are **network-isolated by
+design**: the app detects XCTest (`LiftMarkApp.isRunningTests`) and skips
+session restore, inbox polling, outbox push, and CloudKit sync. Every fixture is
+seeded locally. None of those scenarios touch auth, inbox, outbox, or sync, so
+pointing them at a real backend changes nothing — there is no network call to
+redirect.
+
+Layer 3 is therefore a **new category of test**, not a URL flip: scenarios that
+log in, push, and read against the live beta API and assert on the in-app UI
+those calls drive. This document specifies the app hooks, the runner additions,
+the scenarios, the test plan, and the CI workflow that make that possible.
+
+Related: [validator-e2e.md](validator-e2e.md) (Layers 1 & 2 — backend
+integration + Playwright smoke), [authentication.md](authentication.md),
+[workout-inbox.md](workout-inbox.md), [workout-outbox.md](workout-outbox.md),
+[feature-flags.md](feature-flags.md).
+
+## App-side hooks
+
+Two launch arguments, both test-only, gate the live-backend behaviour. Neither
+changes any default (non-test) code path.
+
+### `--live-backend`
+
+`LiftMarkApp.isRunningTests` normally disables **all** network + sync startup
+paths. `--live-backend` narrows that gate so the network paths under test run,
+while **CloudKit sync stays off** (a beta UI run must not write to a tester's
+iCloud).
+
+| Startup path | default | tests (no flag) | tests + `--live-backend` |
+| --- | --- | --- | --- |
+| `CKSyncEngineManager.start()` | on | off | **off** (always off in tests) |
+| `authStore.restoreSession()` | on | off | **on** |
+| `inboxPoller.pollIfAuthenticated()` | on | off | **on** |
+| `outboxPusher.flushIfAuthenticated()` | on | off | **on** |
+| outbox enqueue on session-complete | on | off | **on** |
+
+Mechanically: `networkPathsEnabled = !isRunningTests || isLiveBackend`. CloudKit
+keeps using `!isRunningTests`; the four network paths switch to
+`networkPathsEnabled`.
+
+### `--api-base-url=<url>`
+
+`APIClient` resolves its base URL in priority order: explicit `baseURL:`
+constructor arg → **`--api-base-url=<url>` launch arg** → `LMWF_API_BASE_URL`
+Info.plist → per-request `feature_flag.useBetaApi` (prod/beta default). The
+launch arg is a hard override scoped to the test process; it does not touch the
+production beta-mode toggle. The beta workflow passes
+`--api-base-url=https://beta.getlift.md`.
+
+Inbox polling additionally requires the `workoutInbox` feature flag, enabled per
+run with the existing `--enable-flag=workoutInbox` plumbing
+([feature-flags.md](feature-flags.md)).
+
+## Runner: environment-variable interpolation
+
+Credentials are minted fresh per CI run (see below), so they cannot be baked into
+static YAML. `ActionAdapter` therefore interpolates `${VAR}` tokens in
+`replaceText` / `typeText` values from the test process environment
+(`ProcessInfo.processInfo.environment`). An unset variable interpolates to the
+empty string. A literal `${...}` is not expected in normal fixtures, so the
+substitution is unconditional and runner-wide.
+
+Example: `replaceText target: login-email, value: "${LMWF_E2E_EMAIL}"`.
+
+## Scenarios
+
+New scenarios live alongside the existing ones in `e2e-spec/scenarios/` and run
+**only** under the `BetaE2E` test plan (they are excluded from `Smoke` and
+`Full`, which have no backend).
+
+| Scenario | Exercises | Assertion surface |
+| --- | --- | --- |
+| `beta-login` | login → token persist → logout/revoke | `account-identity`, `account-sign-out`, `account-sign-in` (in-app) |
+| `beta-inbox` | API push → device poll → inbox surfaces | `inbox-section`, inbox row for the pushed workout (in-app) |
+| `beta-outbox` | complete workout in-app → outbox push | server-side `GET /v1/workouts/outbox` asserts in the workflow |
+
+`beta-login` and `beta-inbox` assert entirely on in-app UI driven by real
+network calls. `beta-outbox` drives the app to complete a workout; the
+server-side round-trip is asserted by a workflow step that queries the outbox
+with the seeded user's token, because the app has no in-app outbox list view.
+
+All three launch with `--live-backend --api-base-url=$LMWF_E2E_BASE_URL
+--enable-flag=workoutInbox` and rely on the runner's `waitFor*` polling for
+async settling (CloudFront/Lambda latency).
+
+## CI workflow — `[iOS] E2E (beta)`
+
+`.github/workflows/swift-e2e-beta.yml`. Manual `workflow_dispatch` + weekly cron.
+Reuses the beta account's existing `lmwf-beta-e2e-test-secret` and the
+`/v1/__test__/*` backdoor (beta-only; the route returns 404 when `LMWF_ENV=prod`,
+so it can never run against prod). No new secret, no persistent account.
+
+Per run:
+
+1. **Seed** — `POST /v1/__test__/seed-user` with a fresh random email + known
+   password → returns `session_jwt`. For `beta-inbox`, also
+   `POST /v1/workouts` with that token to plant a workout in the user's inbox.
+2. **Warm** — pre-warm `$LMWF_E2E_BASE_URL/version` (mirrors validator
+   `e2e-beta`) to dodge Lambda cold-start timeouts.
+3. **Run** — `xcodebuild test -testPlan BetaE2E`, passing the seeded email,
+   password, and base URL as env vars (the test plan forwards them to the app as
+   launch-arg/`replaceText` interpolation values).
+4. **Verify outbox** — `GET /v1/workouts/outbox` with the seeded token; assert
+   the completed session landed.
+5. **Teardown** — `POST /v1/__test__/delete-user-by-email` removes the run's
+   rows (no TTL accumulation).
+
+### Flake tolerance
+
+Beta sits behind CloudFront/WAF, which intermittently 403s (the validator
+`e2e-beta` job hit this). The app already has `edgeBlocked` retry semantics; the
+test plan additionally sets a generous `UITEST_TIMEOUT_SCALE` so `waitFor*`
+polling absorbs edge latency rather than failing fast.
+
+### Host dependency (GH #248)
+
+The workflow targets `https://beta.getlift.md`. That host goes live with the
+beta DNS cutover ([password-manager.md](password-manager.md) / GH #248); until
+then the workflow is red-on-run by design. The host is a workflow input/env var
+(`LMWF_E2E_BASE_URL`, default `https://beta.getlift.md`) so it is a one-line flip
+if the cutover slips.
+
+## Tests / verification
+
+- Swift compiles with the new hooks (`make build`).
+- `BetaE2E.xctestplan` selects only the three beta scenarios; `Smoke` / `Full`
+  are unchanged (no backend dependency leaks into the PR gate or nightly).
+- The launch-arg gates are unit-asserted where practical; the scenarios
+  themselves are the integration tests for this spec and run green once
+  `beta.getlift.md` is live.


### PR DESCRIPTION
Closes the remaining piece of #137 (Layers 1 & 2 already shipped): iOS UI tests that exercise the real client↔server contract against the deployed **beta** backend — the gap none of the 19 network-isolated scenarios cover.

## What
- **App hooks** (test-only, no default path touched): `--live-backend` narrows the `isRunningTests` gate (auth/inbox/outbox network on, CloudKit off); `--api-base-url=<url>` overrides the APIClient host.
- **Runner:** `${ENV_VAR}` interpolation in replaceText/typeText/launchArgs so static YAML uses per-run seeded creds + host.
- **Scenarios** (BetaE2E test plan only — excluded from Smoke/Full): `beta-login` (real login UI → persist → logout/revoke), `beta-inbox` (API push → poll → surfaces in-app), `beta-outbox` (complete workout → push, asserted server-side).
- **CI:** `[iOS] E2E (beta)` workflow (workflow_dispatch + weekly cron) seeds a fresh account per run via the beta-only `/v1/__test__/*` backdoor (reuses `lmwf-beta-e2e-test-secret`), plants an inbox workout, runs BetaE2E, verifies the outbox, deletes the account. No persistent account, no new secret.

## Notes
- Touches no `validator/**` paths → **does not trigger a deploy** (iOS CI only).
- Targets `https://beta.getlift.md` (env-configurable). The cron is **red-on-run until the #248 beta DNS cutover lands** — by design.

## Verified
`xcodebuild build-for-testing` → TEST BUILD SUCCEEDED; `xcodegen generate` accepts the BetaE2E plan. Spec: `spec/services/ios-e2e-beta.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)