### PR TITLE
feat(cdk): phased beta.getlift.md cutover IaC (#248 beta)

### DIFF
--- a/spec/services/beta-getlift-cutover.md
+++ b/spec/services/beta-getlift-cutover.md
@@ -1,0 +1,124 @@
+# beta.getlift.md cutover (GH #248 beta layer)
+
+Status: IaC authored + statically verified (typecheck + `cdk synth` for all
+phases). The cutover itself is a **credentialed, multi-phase deploy** — the
+steps below are the runbook. Prod already serves canonically from `getlift.md`;
+this brings **beta** off `beta.liftmark.app` onto `beta.getlift.md`.
+
+Unblocks the `[iOS] E2E (beta)` workflow ([ios-e2e-beta.md](ios-e2e-beta.md)),
+which targets `https://beta.getlift.md`.
+
+## Why beta is not a one-line config add
+
+Prod's canonical `getlift.md` is a `VANITY_DOMAINS` apex zone living in the prod
+account, so its zone + wildcard cert come from `LmwfDnsFoundationStack` and the
+prod main stack (same account) can attach the cert + write A-records directly.
+
+Beta's canonical `beta.getlift.md` is a **subdomain delegated into that
+prod-account `getlift.md` zone**, but beta's CloudFront distribution lives in the
+**beta account** — and a CloudFront ACM cert must live in the same account
+(us-east-1) as the distribution. So beta cannot reuse the prod-account
+`*.getlift.md` wildcard. Instead, mirroring today's `beta.liftmark.app`:
+
+- the **beta edge stack** owns a `beta.getlift.md` hosted zone **+ its own cert**
+  in the beta account, and
+- the prod `getlift.md` zone **delegates** to it via a hardcoded NS record.
+
+This also creates a chicken-and-egg: a DNS-validated cert can't validate until
+the zone is delegated, and the delegation NS aren't known until the zone exists.
+Hence the phased `EnvConfig.betaCutoverPhase` (`config.ts`): `zone-only` ships
+the zone (no cert) to mint stable NS; `live` adds the cert + canonical serving
+once delegation is up. Same shape as the `VanityDomain.issueCert` deferral.
+
+## What the IaC does per phase
+
+| | edge stack (beta acct) | beta validator | prod `getlift.md` zone |
+| --- | --- | --- | --- |
+| **undefined** (today) | env zone+cert only | serves `beta.liftmark.app` | — |
+| **'zone-only'** | + `beta.getlift.md` zone, NS output | unchanged (apex) | — |
+| **'live'** | + `beta.getlift.md` cert | canonical dist for `beta.getlift.md`; `beta.liftmark.app` → 301/308 + AASA; `APP_BASE_URL`/CORS → `beta.getlift.md` | NS delegation (once `BETA_GETLIFT_MD_NS` filled) |
+
+`APP_BASE_URL` (new Lambda env, `servingWebOrigin(env)`) makes the email-link
+host follow the phase automatically; `password.ts` `appBaseUrl()` reads it and
+falls back to the old `LMWF_ENV` hardcode if unset.
+
+## Deploy runbook (operator)
+
+This is **not a single automatic deploy.** Merging the current IaC is inert (no
+cutover); the cutover is a phased sequence of config edits. The per-phase
+`cdk deploy` IS automated by `validator-ci.yml` — every phase below is a normal
+PR/merge to `main`, and because each touches `validator/**` the pipeline runs
+`deploy-beta` (→ `LmwfBetaEdgeStack LmwfBetaValidatorStack`) then `deploy-prod`
+(→ `LmwfProd*`). What the pipeline CANNOT do, and what makes this manual:
+1. flip `betaCutoverPhase` (a code edit, 3 times: zone-only → live);
+2. read the beta zone's 4 NS values and paste them into `BETA_GETLIFT_MD_NS`
+   (Route 53 assigns NS only at zone-creation time — same hardcoded-NS pattern
+   as the existing `beta.liftmark.app` delegation); and
+3. wait for DNS propagation between delegation and 'live'.
+
+The `cdk deploy` commands below are what the pipeline runs (and what to run for an
+out-of-band manual deploy under the env's OIDC role). Stack ids:
+`LmwfBetaEdgeStack`, `LmwfBetaValidatorStack`, `LmwfProdValidatorStack`.
+
+**Phase 1 — zone-only (mint NS):**
+1. Set `ENVS.beta.betaCutoverPhase = 'zone-only'` in `validator/cdk/config.ts`;
+   merge. The pipeline's `deploy-beta` creates the `beta.getlift.md` zone.
+2. (Or out-of-band: `cdk deploy LmwfBetaEdgeStack`.)
+3. Read the `BetaCanonicalZoneNameServers` output — `deploy-beta` prints it via
+   `cat outputs-beta.json`; for a manual deploy it's a CfnOutput.
+4. Paste the 4 NS values into `BETA_GETLIFT_MD_NS` in `config.ts`.
+
+**Phase 2 — delegate (publish NS in getlift.md):**
+5. Merge the `BETA_GETLIFT_MD_NS` edit (still `betaCutoverPhase: 'zone-only'`).
+   The pipeline's `deploy-prod` publishes the `beta` NS record in the
+   `getlift.md` zone (the delegation gates on the NS array being non-empty, not
+   on beta's phase). (Out-of-band: `cdk deploy LmwfProdValidatorStack`.) Wait
+   for `dig NS beta.getlift.md` to resolve to the beta zone.
+
+**Phase 3 — live (cert + serve):** flip `betaCutoverPhase` AND the pipeline's
+own beta gate in ONE commit, because after the cutover `beta.liftmark.app/version`
+308-redirects and `smoke-test-live.sh` does NOT follow redirects (no `-L`) — a
+stale beta URL turns the post-deploy `smoke-beta`/`e2e-beta` gate red and blocks
+`deploy-prod`. In the same commit:
+6. Set `betaCutoverPhase = 'live'`.
+7. In `.github/workflows/validator-ci.yml`, point the `smoke-beta`, `e2e-beta`,
+   and Lambda warm-up URLs at `https://beta.getlift.md` (mirrors how
+   `smoke-prod` targets `getlift.md`).
+8. Merge → the pipeline deploys `LmwfBetaEdgeStack LmwfBetaValidatorStack`: the
+   cert validates (zone now delegated), the canonical distribution comes up, and
+   `beta.liftmark.app` flips to redirect-but-serve-AASA. `smoke-beta` then hits
+   `beta.getlift.md/version` (200) and passes.
+9. Manual smoke: `curl -I https://beta.getlift.md/version` (200), `curl -I
+   https://beta.liftmark.app/account` (301 → beta.getlift.md), `curl
+   https://beta.liftmark.app/.well-known/apple-app-site-association` (200, served
+   locally).
+
+**Phase 4 — run iOS e2e:**
+10. The `[iOS] E2E (beta)` workflow already targets `beta.getlift.md` — run it via
+    `workflow_dispatch` to confirm green.
+
+## Follow-up app changes (post-'live', separate commit, NOT pipeline-gated)
+
+The iOS app's hardcoded beta host is **intentionally not committed with the IaC** —
+flipping it before `beta.getlift.md` serves would break beta for current TestFlight
+testers. Once Phase 3 is live (and `beta.liftmark.app` redirects), ship in the next
+app build:
+
+- `mobile-apps/ios/.../APIClient.swift` beta base → `https://beta.getlift.md`.
+- `mobile-apps/ios/.../LoginView.swift` `accountWebBase` beta → `beta.getlift.md`.
+
+Old app builds keep working via the `beta.liftmark.app` 308/301 redirects; the
+`APP_BASE_URL` env already flips email links automatically at deploy. (The iOS
+e2e workflow does not depend on this flip — it injects the host via
+`--api-base-url`.)
+
+## Verification done here
+
+- `bun x tsc --noEmit` (cdk + validator src): clean.
+- `cdk synth` (via bun) for `undefined` / `zone-only` / `live`: all exit 0, each
+  producing exactly the resources in the table above; the prod NS delegation
+  emits only when `BETA_GETLIFT_MD_NS` is populated.
+- Off-phase (committed) diff is behaviorally neutral: the only change is the new
+  `APP_BASE_URL` env, whose value equals the prior hardcode.
+- `cdk deploy` and live DNS resolution are credentialed and remain operator
+  steps (no AWS access from CI authoring).

--- a/validator/cdk/app.ts
+++ b/validator/cdk/app.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import * as cdk from 'aws-cdk-lib';
-import { ENVS, VANITY_DOMAINS, envPrefix } from './config';
+import { BETA_CANONICAL_DOMAIN, ENVS, VANITY_DOMAINS, envPrefix } from './config';
 import { LmwfDnsFoundationStack } from './dns-stack';
 import { LmwfEdgeStack } from './edge-stack';
 import { LmwfValidatorStack } from './stack';
@@ -39,6 +39,12 @@ for (const cfg of Object.values(ENVS)) {
   const prefix = envPrefix(cfg);
   const tags = { ...commonTags, Env: cfg.name };
 
+  // Beta's canonical (beta.getlift.md) is a self-managed delegated subdomain,
+  // rolled out in phases (see EnvConfig.betaCutoverPhase). Its zone is created
+  // in the beta edge stack from the 'zone-only' phase on; its cert only at
+  // 'live'.
+  const selfCanonicalDomain = cfg.betaCutoverPhase ? BETA_CANONICAL_DOMAIN : undefined;
+
   // Edge stack — us-east-1 for CloudFront cert + hosted zone owner.
   const edge = new LmwfEdgeStack(app, `${prefix}EdgeStack`, {
     description: `LMWF ${cfg.name} edge (hosted zone + us-east-1 CloudFront cert)`,
@@ -46,14 +52,23 @@ for (const cfg of Object.values(ENVS)) {
     crossRegionReferences: true,
     tags,
     envConfig: cfg,
+    selfManagedCanonicalDomain: selfCanonicalDomain,
+    issueCanonicalCert: cfg.betaCutoverPhase === 'live',
   });
 
-  // When the env canonicalises to a vanity domain, hand the prod stack the
-  // canonical site's zone + cert plus each redirect domain's zone + cert.
-  const canonicalWeb =
-    cfg.canonicalWebDomain && cfg.canonicalWebDomain !== cfg.domainName
-      ? vanityWebDomain(cfg.canonicalWebDomain)
-      : undefined;
+  // The main stack gets a canonical {domain, zone, cert} when the env serves
+  // canonically: prod from a foundation vanity zone (getlift.md), beta from its
+  // own edge-owned zone once the cutover is 'live'.
+  let canonicalWeb;
+  if (cfg.canonicalWebDomain && cfg.canonicalWebDomain !== cfg.domainName) {
+    canonicalWeb = vanityWebDomain(cfg.canonicalWebDomain);
+  } else if (cfg.betaCutoverPhase === 'live' && edge.canonicalZone && edge.canonicalCertificate) {
+    canonicalWeb = {
+      domain: BETA_CANONICAL_DOMAIN,
+      zone: edge.canonicalZone,
+      certificate: edge.canonicalCertificate,
+    };
+  }
   const redirectWeb = canonicalWeb
     ? (cfg.redirectWebDomains ?? []).map(vanityWebDomain)
     : [];

--- a/validator/cdk/config.ts
+++ b/validator/cdk/config.ts
@@ -57,10 +57,46 @@ export interface EnvConfig {
    * env's API from `localhost` during development. Beta only — never prod.
    */
   allowLocalDevOrigin?: boolean;
+  /**
+   * Phased beta.getlift.md cutover (GH #248 beta layer). Beta's canonical zone
+   * is a SUBDOMAIN delegated into the prod-account `getlift.md` zone, so —
+   * unlike prod's getlift.md (a foundation vanity zone) — it must be owned by
+   * the beta account's edge stack and reached via NS delegation, not the
+   * `canonicalWebDomain` vanity path. This flag drives the staged rollout:
+   *   - undefined  → no cutover; serve from `domainName` (beta.liftmark.app).
+   *   - 'zone-only'→ create the `beta.getlift.md` hosted zone in the beta
+   *                  account so its NS can be delegated from getlift.md, but
+   *                  keep serving from the apex (NO cert, NO canonical
+   *                  distribution). Avoids the DNS-validated-cert deadlock: a
+   *                  cert can't validate until the zone is delegated, and the
+   *                  zone's NS aren't known until it exists.
+   *   - 'live'     → issue the `beta.getlift.md` cert + serve canonically from
+   *                  it; `beta.liftmark.app` becomes 301/308 redirect + AASA.
+   * See spec/services/beta-getlift-cutover.md. Beta only.
+   */
+  betaCutoverPhase?: 'zone-only' | 'live';
 }
 
 /** Local Astro dev-server origin, allowed only when `allowLocalDevOrigin`. */
 export const LOCAL_DEV_ORIGIN = 'http://localhost:4321';
+
+/**
+ * Beta's canonical web domain — a subdomain delegated from the prod-account
+ * `getlift.md` zone into a beta-account hosted zone. Not a `VANITY_DOMAINS`
+ * entry (those are apex zones in the prod account); see `betaCutoverPhase`.
+ */
+export const BETA_CANONICAL_DOMAIN = 'beta.getlift.md';
+
+/**
+ * Name servers of the beta-account `beta.getlift.md` hosted zone, used by the
+ * prod stack to publish the NS delegation in the `getlift.md` zone. Hardcoded
+ * (cross-account HZ lookup needs extra IAM and the NS set is stable) and
+ * deliberately EMPTY until the 'zone-only' phase has been deployed: read the
+ * `LmwfBetaEdgeStack` → `BetaCanonicalZoneNameServers` output, paste the four
+ * values here, then deploy the prod stack to publish the delegation. While
+ * empty, no delegation record is emitted. See spec/services/beta-getlift-cutover.md.
+ */
+export const BETA_GETLIFT_MD_NS: readonly string[] = [];
 
 /**
  * Browser origins permitted to make credentialed requests to the env's HTTP
@@ -76,8 +112,23 @@ export const LOCAL_DEV_ORIGIN = 'http://localhost:4321';
  * host before any script runs — so they are intentionally NOT allowlisted
  * (GH #248).
  */
+/**
+ * The single web origin that actually serves the site + makes credentialed
+ * same-origin XHR for this env: the canonical web domain when set (prod:
+ * `getlift.md`), the beta canonical once the cutover is 'live'
+ * (`beta.getlift.md`), else the env apex. Drives the CORS allowlist and the
+ * Lambda's APP_BASE_URL (email link host). Legacy redirect-only hosts never
+ * originate an XHR — their pages 301/308 before any script runs — so they are
+ * intentionally excluded (GH #248).
+ */
+export function servingWebOrigin(env: EnvConfig): string {
+  if (env.canonicalWebDomain) return env.canonicalWebDomain;
+  if (env.betaCutoverPhase === 'live') return BETA_CANONICAL_DOMAIN;
+  return env.domainName;
+}
+
 export function corsAllowedOrigins(env: EnvConfig): string[] {
-  const servingOrigin = env.canonicalWebDomain ?? env.domainName;
+  const servingOrigin = servingWebOrigin(env);
   const origins = [`https://${servingOrigin}`];
   if (env.allowLocalDevOrigin) {
     origins.push(LOCAL_DEV_ORIGIN);

--- a/validator/cdk/edge-stack.ts
+++ b/validator/cdk/edge-stack.ts
@@ -7,6 +7,18 @@ import type { EnvConfig } from './config';
 
 export interface LmwfEdgeStackProps extends cdk.StackProps {
   envConfig: EnvConfig;
+  /**
+   * A canonical web domain this env OWNS (a delegated subdomain, e.g.
+   * `beta.getlift.md`) — distinct from `domainName`. When set, the edge stack
+   * creates its hosted zone in THIS account (the prod-account `getlift.md` zone
+   * delegates to it via NS). The zone is created so its name servers can be
+   * read for the delegation; the cert is created only when `issueCanonicalCert`
+   * is true (after delegation is live), avoiding a DNS-validation deadlock.
+   * See spec/services/beta-getlift-cutover.md.
+   */
+  selfManagedCanonicalDomain?: string;
+  /** Issue the cert for `selfManagedCanonicalDomain` (cutover phase 'live'). */
+  issueCanonicalCert?: boolean;
 }
 
 /**
@@ -22,6 +34,10 @@ export class LmwfEdgeStack extends cdk.Stack {
   public readonly certificate: acm.Certificate;
   /** ARN of the CLOUDFRONT-scoped web ACL — wired to the distribution's webAclId. */
   public readonly webAclArn: string;
+  /** Hosted zone for a self-managed canonical subdomain (e.g. beta.getlift.md), if any. */
+  public readonly canonicalZone?: route53.HostedZone;
+  /** Cert for the self-managed canonical subdomain — present only at cutover 'live'. */
+  public readonly canonicalCertificate?: acm.Certificate;
 
   constructor(scope: Construct, id: string, props: LmwfEdgeStackProps) {
     super(scope, id, props);
@@ -40,6 +56,32 @@ export class LmwfEdgeStack extends cdk.Stack {
       subjectAlternativeNames: [`*.${envConfig.domainName}`],
       validation: acm.CertificateValidation.fromDns(this.hostedZone),
     });
+
+    // Self-managed canonical subdomain (beta.getlift.md). The zone lives in
+    // this (beta) account; the prod `getlift.md` zone delegates to it by NS.
+    // Created zone-first so its NS can be read for that delegation — the cert
+    // (which DNS-validates against this zone) is deferred until delegation is
+    // live, or it would block the whole stack's CREATE forever.
+    if (props.selfManagedCanonicalDomain) {
+      const canonicalZone = new route53.HostedZone(this, 'CanonicalZone', {
+        zoneName: props.selfManagedCanonicalDomain,
+        comment: `LiftMark ${envConfig.name} canonical ${props.selfManagedCanonicalDomain} — created by CDK`,
+      });
+      this.canonicalZone = canonicalZone;
+
+      new cdk.CfnOutput(this, 'BetaCanonicalZoneNameServers', {
+        value: cdk.Fn.join(',', canonicalZone.hostedZoneNameServers ?? []),
+        description: `NS for ${props.selfManagedCanonicalDomain} — paste into BETA_GETLIFT_MD_NS so the prod getlift.md zone delegates here`,
+      });
+
+      if (props.issueCanonicalCert) {
+        this.canonicalCertificate = new acm.Certificate(this, 'CanonicalCert', {
+          domainName: props.selfManagedCanonicalDomain,
+          subjectAlternativeNames: [`*.${props.selfManagedCanonicalDomain}`],
+          validation: acm.CertificateValidation.fromDns(canonicalZone),
+        });
+      }
+    }
 
     // ── WAFv2 web ACL (CLOUDFRONT scope) ──
     // CLOUDFRONT-scoped web ACLs MUST be created in us-east-1, so this lives

--- a/validator/cdk/stack.ts
+++ b/validator/cdk/stack.ts
@@ -18,7 +18,7 @@ import * as ses from 'aws-cdk-lib/aws-ses';
 import { Construct } from 'constructs';
 import * as path from 'path';
 import type { EnvConfig } from './config';
-import { corsAllowedOrigins } from './config';
+import { BETA_CANONICAL_DOMAIN, BETA_GETLIFT_MD_NS, corsAllowedOrigins, servingWebOrigin } from './config';
 import { redirectFnCode } from './redirect-fn';
 import { TABLES, type AttributeType, type TableSchema } from '../src/infra/tables';
 
@@ -264,6 +264,12 @@ export class LmwfValidatorStack extends cdk.Stack {
         SMTP_HOST: `email-smtp.${this.region}.amazonaws.com`,
         SMTP_PORT: '587',
         SMTP_FROM: `noreply@${env.domainName}`,
+        // Host for user-facing links in emails (verify, password reset). Tracks
+        // the env's serving origin so it follows the beta.getlift.md cutover
+        // automatically — beta.liftmark.app while undefined/zone-only,
+        // beta.getlift.md once 'live'. password.ts falls back to its LMWF_ENV
+        // hardcode if unset. See spec/services/beta-getlift-cutover.md.
+        APP_BASE_URL: `https://${servingWebOrigin(env)}`,
         SMTP_USER: cdk.SecretValue.secretsManager(smtpSecret.secretArn, {
           jsonField: 'user',
         }).unsafeUnwrap(),
@@ -746,6 +752,22 @@ function handler(event) {
         ],
         ttl: cdk.Duration.minutes(5),
       });
+
+      // NS delegation for beta.getlift.md → the beta-account canonical HZ
+      // (created by LmwfBetaEdgeStack). Published in the getlift.md zone
+      // (prod's canonicalWeb.zone). Same hardcoded-NS rationale as
+      // beta.liftmark.app above; emitted only once BETA_GETLIFT_MD_NS is
+      // populated from the beta edge stack's BetaCanonicalZoneNameServers
+      // output (the 'zone-only' phase). See spec/services/beta-getlift-cutover.md.
+      if (canonicalWeb && BETA_GETLIFT_MD_NS.length > 0) {
+        new route53.NsRecord(this, 'BetaGetliftMdDelegation', {
+          zone: canonicalWeb.zone,
+          // Leftmost label of beta.getlift.md, relative to the getlift.md zone.
+          recordName: BETA_CANONICAL_DOMAIN.split('.')[0],
+          values: [...BETA_GETLIFT_MD_NS],
+          ttl: cdk.Duration.minutes(5),
+        });
+      }
 
       // workoutformat.liftmark.app → same CloudFront as the apex. The legacy
       // subdomain becomes a permanent alias for the new prod stack; old prod

--- a/validator/src/routes/auth/password.ts
+++ b/validator/src/routes/auth/password.ts
@@ -150,12 +150,17 @@ function classifyEmailError(err: unknown): string {
 }
 
 function appBaseUrl(): string {
-  // Hardcoded host derivation per spec — LMWF_ENV picks beta vs prod.
-  // Prod is the canonical getlift.md, which serves both the API (verify links
-  // hit /v1/*) and the web account pages (reset links hit /account/*) directly
-  // — no redirect hop (GH #248). Beta stays on beta.liftmark.app until its
-  // beta.getlift.md cutover lands. In local dev SMTP_HOST=localhost; the link
-  // still points at the public host, fine for Mailpit inspection.
+  // The deploy sets APP_BASE_URL to the env's serving origin (CDK
+  // servingWebOrigin), so the host tracks the beta.getlift.md cutover phase
+  // automatically — beta.liftmark.app until 'live', beta.getlift.md after — and
+  // prod stays canonical getlift.md. Both serve the API (/v1/*) and account
+  // pages (/account/*) directly, no redirect hop (GH #248).
+  //
+  // Fallback (env var unset — older deploy / local dev): the previous
+  // LMWF_ENV-keyed hardcode. In local dev the link still points at the public
+  // host, fine for Mailpit inspection.
+  const fromEnv = process.env.APP_BASE_URL;
+  if (fromEnv && fromEnv.length > 0) return fromEnv;
   const env = process.env.LMWF_ENV;
   return env === 'beta' ? 'https://beta.liftmark.app' : 'https://getlift.md';
 }


### PR DESCRIPTION
Drives the beta DNS cutover that unblocks the iOS `[E2E (beta)]` workflow (#137). Prod already serves canonically from `getlift.md`; this brings **beta** off `beta.liftmark.app` onto `beta.getlift.md`, mirroring the proven prod-canonical + `beta.liftmark.app` NS-delegation patterns.

## Design
Beta's canonical is a subdomain delegated into the prod-account `getlift.md` zone, but beta's CloudFront cert must live in the beta account — so the beta edge stack owns the `beta.getlift.md` zone + cert and prod delegates via NS. A DNS-validated cert can't validate pre-delegation and the NS aren't known pre-zone, so the rollout is phased via `EnvConfig.betaCutoverPhase`:
- **undefined** → today's behavior (serve `beta.liftmark.app`).
- **'zone-only'** → create the `beta.getlift.md` zone (NS output) to mint stable NS.
- **'live'** → cert + canonical serving; `beta.liftmark.app` → 301/308 + AASA.

Also wires `APP_BASE_URL` (servingWebOrigin) into the Lambda so email-link hosts follow the phase automatically; `password.ts` `appBaseUrl()` reads it with the old `LMWF_ENV` hardcode as fallback.

## Inert by default ⚠️
With `betaCutoverPhase` undefined the **only** diff is the new `APP_BASE_URL` env, whose value equals the prior hardcode. Merging deploys this behaviorally-neutral change to beta + prod Lambdas; **no cutover happens** until an operator flips the flag. The phased rollout (config flips + a manual NS read/paste + DNS wait) is the runbook in `spec/services/beta-getlift-cutover.md`.

## Verified (node 26 + npm)
`npm run typecheck` clean; `npm run test` 190 passed / 219 skipped; `cdk synth` exits 0 for undefined/zone-only/live (each producing exactly the intended resources); redirect-fn vitest green. `cdk deploy` + live DNS remain credentialed operator steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)