### PR TITLE
feat(cdk): beta cutover Phase 1 — beta.getlift.md zone-only (#248 beta)

### DIFF
--- a/validator/cdk/config.ts
+++ b/validator/cdk/config.ts
@@ -142,6 +142,7 @@ export const ENVS: Record<EnvName, EnvConfig> = {
     account: '323146837100',
     region: 'us-west-2',
     domainName: 'beta.liftmark.app',
+    betaCutoverPhase: 'zone-only', // GH #248 beta cutover — Phase 1: mint NS
     stripeMode: 'test',
     // No sesMailFromSubdomain / dmarcPolicy: beta has an in-flight SES
     // production-access support case (177985180300561). Avoid changing


### PR DESCRIPTION
**Phase 1 of the beta.getlift.md cutover** (runbook: `spec/services/beta-getlift-cutover.md`).

Sets `ENVS.beta.betaCutoverPhase = 'zone-only'`. On deploy, the beta edge stack creates the `beta.getlift.md` hosted zone in the beta account — **nothing else**. No cert, no canonical distribution; beta keeps serving `beta.liftmark.app` exactly as today.

Purpose: mint the zone's stable name servers. After `deploy-beta`, read `BetaCanonicalZoneNameServers` from the job's `outputs-beta.json` and paste the 4 values into `BETA_GETLIFT_MD_NS` (Phase 2 — publishes the delegation in the `getlift.md` zone).

Verified: `cdk synth` (zone-only) creates the zone + NS output, no cert, `APP_BASE_URL` still `beta.liftmark.app`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)