### PR TITLE
feat(cdk): beta cutover Phase 2 — delegate beta.getlift.md (#248 beta)

### DIFF
--- a/validator/cdk/config.ts
+++ b/validator/cdk/config.ts
@@ -96,7 +96,12 @@ export const BETA_CANONICAL_DOMAIN = 'beta.getlift.md';
  * values here, then deploy the prod stack to publish the delegation. While
  * empty, no delegation record is emitted. See spec/services/beta-getlift-cutover.md.
  */
-export const BETA_GETLIFT_MD_NS: readonly string[] = [];
+export const BETA_GETLIFT_MD_NS: readonly string[] = [
+  'ns-1316.awsdns-36.org.',
+  'ns-1984.awsdns-56.co.uk.',
+  'ns-681.awsdns-21.net.',
+  'ns-32.awsdns-04.com.',
+];
 
 /**
  * Browser origins permitted to make credentialed requests to the env's HTTP


### PR DESCRIPTION
**Phase 2 of the beta.getlift.md cutover.** Populates `BETA_GETLIFT_MD_NS` with the zone's name servers (minted by Phase 1). On deploy, `deploy-prod` publishes the `beta` NS record in the `getlift.md` zone, delegating the subdomain to the beta-account zone.

Still `betaCutoverPhase: 'zone-only'` — beta keeps serving `beta.liftmark.app`; no cert/serving change. After this deploys, DNS propagates and `dig NS beta.getlift.md` resolves; then Phase 3 ('live').

Verified: `cdk synth LmwfProdValidatorStack` emits the `beta.getlift.md.` NS RecordSet (TTL 300) with these 4 servers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)