### PR TITLE
feat(cdk): beta cutover Phase 3 — go live on beta.getlift.md (#248 beta)

### DIFF
--- a/.github/workflows/validator-ci.yml
+++ b/.github/workflows/validator-ci.yml
@@ -271,7 +271,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: beta
-      url: https://beta.liftmark.app
+      url: https://beta.getlift.md
     env:
       AWS_DEFAULT_REGION: us-west-2
       AWS_REGION: us-west-2
@@ -335,7 +335,7 @@ jobs:
       - name: Smoke test beta
         run: |
           chmod +x validator/scripts/smoke-test-live.sh
-          validator/scripts/smoke-test-live.sh https://beta.liftmark.app "${{ github.sha }}"
+          validator/scripts/smoke-test-live.sh https://beta.getlift.md "${{ github.sha }}"
 
   # ── Stage 4.5: e2e-beta ────────────────────────────────────────────────
   # Browser-driven E2E suite against the live beta hostname. Uses the
@@ -394,10 +394,10 @@ jobs:
       - name: Warm beta Lambda
         run: |
           set -uo pipefail
-          echo "==> warming https://beta.liftmark.app"
+          echo "==> warming https://beta.getlift.md"
           for round in 1 2 3; do
             for i in $(seq 1 8); do
-              curl -s -o /dev/null --max-time 30 https://beta.liftmark.app/version &
+              curl -s -o /dev/null --max-time 30 https://beta.getlift.md/version &
             done
             wait
           done
@@ -406,7 +406,7 @@ jobs:
         working-directory: validator/e2e
         env:
           LMWF_E2E_MODE: remote
-          LMWF_E2E_BASE_URL: https://beta.liftmark.app
+          LMWF_E2E_BASE_URL: https://beta.getlift.md
           LMWF_E2E_TEST_SECRET: ${{ steps.get-secret.outputs.secret }}
         run: npx playwright test
       - name: Upload Playwright report on failure

--- a/validator/cdk/config.ts
+++ b/validator/cdk/config.ts
@@ -147,7 +147,7 @@ export const ENVS: Record<EnvName, EnvConfig> = {
     account: '323146837100',
     region: 'us-west-2',
     domainName: 'beta.liftmark.app',
-    betaCutoverPhase: 'zone-only', // GH #248 beta cutover — Phase 1: mint NS
+    betaCutoverPhase: 'live', // GH #248 beta cutover — Phase 3: serve beta.getlift.md
     stripeMode: 'test',
     // No sesMailFromSubdomain / dmarcPolicy: beta has an in-flight SES
     // production-access support case (177985180300561). Avoid changing


### PR DESCRIPTION
**Phase 3 — the cutover.** Flips `betaCutoverPhase: 'live'`: beta edge issues the `beta.getlift.md` cert (zone is delegated + DNS resolves, so it validates), and the beta validator stack serves canonically from `beta.getlift.md` while `beta.liftmark.app` becomes 301/308 redirect + AASA. `APP_BASE_URL`/CORS flip automatically.

Also flips the `smoke-beta`/`e2e-beta`/warm-up/environment URLs in `validator-ci.yml` to `https://beta.getlift.md` — **required in this commit**, since the smoke script doesn't follow redirects and a stale URL would 308-fail the gate.

Verified: `cdk synth` (live) — beta cert + canonical distribution for `beta.getlift.md`, `APP_BASE_URL=https://beta.getlift.md`. `deploy-beta` has no custom timeout (360-min default) so ACM validation + CloudFront propagation have headroom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)