### PR TITLE
test(ios): settle + multi-retry for beta login sheet (#137)

### DIFF
--- a/e2e-spec/scenarios/beta-inbox.yaml
+++ b/e2e-spec/scenarios/beta-inbox.yaml
@@ -21,18 +21,33 @@ tests:
       - action: waitFor
         target: "account-sign-in"
         timeout: 15000
+      # The Settings → Sign-in sheet drops if it presents during launch
+      # settling: a store-load re-render tears the freshly-presented sheet down
+      # (the documented AuthSyncBannerView "needs a second tap" bug). Let the
+      # cold-launch re-renders settle first, then re-tap until login-email
+      # sticks. App-side fix (stable sheet presentation) tracked as follow-up.
+      - action: delay
+        ms: 3000
       - action: tap
         target: "account-sign-in"
-      # The Settings → Sign-in sheet can drop on the first tap (a SwiftUI
-      # re-render during launch settling tears the freshly-presented sheet
-      # down — the documented AuthSyncBannerView "needs a second tap" bug).
-      # Re-tap if login-email didn't appear. App-side fix tracked as follow-up.
       - action: tryCatch
         try:
           - action: waitFor
             target: "login-email"
-            timeout: 5000
+            timeout: 4000
         catch:
+          - action: delay
+            ms: 1500
+          - action: tap
+            target: "account-sign-in"
+      - action: tryCatch
+        try:
+          - action: waitFor
+            target: "login-email"
+            timeout: 4000
+        catch:
+          - action: delay
+            ms: 1500
           - action: tap
             target: "account-sign-in"
       - action: waitFor

--- a/e2e-spec/scenarios/beta-login.yaml
+++ b/e2e-spec/scenarios/beta-login.yaml
@@ -21,18 +21,33 @@ tests:
       - action: waitFor
         target: "account-sign-in"
         timeout: 15000
+      # The Settings → Sign-in sheet drops if it presents during launch
+      # settling: a store-load re-render tears the freshly-presented sheet down
+      # (the documented AuthSyncBannerView "needs a second tap" bug). Let the
+      # cold-launch re-renders settle first, then re-tap until login-email
+      # sticks. App-side fix (stable sheet presentation) tracked as follow-up.
+      - action: delay
+        ms: 3000
       - action: tap
         target: "account-sign-in"
-      # The Settings → Sign-in sheet can drop on the first tap (a SwiftUI
-      # re-render during launch settling tears the freshly-presented sheet
-      # down — the documented AuthSyncBannerView "needs a second tap" bug).
-      # Re-tap if login-email didn't appear. App-side fix tracked as follow-up.
       - action: tryCatch
         try:
           - action: waitFor
             target: "login-email"
-            timeout: 5000
+            timeout: 4000
         catch:
+          - action: delay
+            ms: 1500
+          - action: tap
+            target: "account-sign-in"
+      - action: tryCatch
+        try:
+          - action: waitFor
+            target: "login-email"
+            timeout: 4000
+        catch:
+          - action: delay
+            ms: 1500
           - action: tap
             target: "account-sign-in"
       - action: waitFor

--- a/e2e-spec/scenarios/beta-outbox.yaml
+++ b/e2e-spec/scenarios/beta-outbox.yaml
@@ -24,18 +24,33 @@ tests:
       - action: waitFor
         target: "account-sign-in"
         timeout: 15000
+      # The Settings → Sign-in sheet drops if it presents during launch
+      # settling: a store-load re-render tears the freshly-presented sheet down
+      # (the documented AuthSyncBannerView "needs a second tap" bug). Let the
+      # cold-launch re-renders settle first, then re-tap until login-email
+      # sticks. App-side fix (stable sheet presentation) tracked as follow-up.
+      - action: delay
+        ms: 3000
       - action: tap
         target: "account-sign-in"
-      # The Settings → Sign-in sheet can drop on the first tap (a SwiftUI
-      # re-render during launch settling tears the freshly-presented sheet
-      # down — the documented AuthSyncBannerView "needs a second tap" bug).
-      # Re-tap if login-email didn't appear. App-side fix tracked as follow-up.
       - action: tryCatch
         try:
           - action: waitFor
             target: "login-email"
-            timeout: 5000
+            timeout: 4000
         catch:
+          - action: delay
+            ms: 1500
+          - action: tap
+            target: "account-sign-in"
+      - action: tryCatch
+        try:
+          - action: waitFor
+            target: "login-email"
+            timeout: 4000
+        catch:
+          - action: delay
+            ms: 1500
           - action: tap
             target: "account-sign-in"
       - action: waitFor


### PR DESCRIPTION
Follow-up to #273. A single re-tap wasn't enough — the Settings sign-in sheet drops whenever it presents during cold-launch settling, and the first two tests in the run hit that window (the third, warmer, passed). Adds a 3s settle before the first sign-in tap + a second retry. Verified locally at `UITEST_TIMEOUT_SCALE=4` (CI's scale) across all 3 scenarios: each now reaches + fills `login-email` (zero misses), stopping only at `account-identity` which needs CI's seeded creds. Test-only. 🤖 Generated with [Claude Code](https://claude.com/claude-code)