### PR TITLE
fix(ios): clear auth tokens on --reset-data for e2e isolation (#137)

### DIFF
--- a/mobile-apps/ios/LiftMark/App/LiftMarkApp.swift
+++ b/mobile-apps/ios/LiftMark/App/LiftMarkApp.swift
@@ -60,6 +60,13 @@ struct LiftMarkApp: App {
             if let bundleId = Bundle.main.bundleIdentifier {
                 UserDefaults.standard.removePersistentDomain(forName: bundleId)
             }
+            // Clear Keychain auth tokens too, so each scenario starts signed
+            // out. The DB + UserDefaults wipe above doesn't touch the Keychain,
+            // so under --live-backend a session from a previous scenario would
+            // auto-restore and the device would launch already signed in — the
+            // Layer-3 beta e2e needs a clean signed-out start per scenario
+            // (GH #137). No-op for scenarios that never sign in.
+            TokenStore().clear()
         }
 
         Self.seedMigratorFailureFromLaunchArgs()


### PR DESCRIPTION
On the last beta e2e run, **testBetaInbox passed** (full login + inbox round-trip against live beta), but testBetaLogin/testBetaOutbox failed at `account-sign-in not found`. Root cause: tests share one seeded account; `--reset-data` wipes DB + UserDefaults but **not the Keychain**, so under `--live-backend` the next scenario auto-restored testBetaInbox's session and launched already signed in.

Fix: clear Keychain tokens in the `--reset-data` test seam → each scenario starts signed out. No-op for the 19 existing scenarios (they never sign in). Build verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)