### PR TITLE
feat(ios): seed session for beta inbox/outbox e2e (#137)

### DIFF
--- a/.github/workflows/swift-e2e-beta.yml
+++ b/.github/workflows/swift-e2e-beta.yml
@@ -117,9 +117,28 @@ jobs:
             -H "authorization: Bearer $JWT" \
             -d "{\"lmwf\":\"# $INBOX_WORKOUT_NAME\n\n## Bench Press\n\n- 135 x 5\n\"}" > /dev/null
 
+          # Mint a real session (access + refresh) for the seeded scenarios
+          # (beta-inbox / beta-outbox start signed in via --seed-session, instead
+          # of driving the login UI). seed-user only returns an access JWT, so
+          # log in to get the refresh token too.
+          LOGIN=$(curl -fsS --retry 5 --retry-all-errors --retry-delay 2 \
+            -X POST "$LMWF_E2E_BASE_URL/v1/auth/password/login" \
+            -H 'content-type: application/json' \
+            -d "{\"email\":\"$EMAIL\",\"password\":\"$PASSWORD\"}")
+          ACCESS=$(echo "$LOGIN" | jq -r '.access_jwt')
+          REFRESH=$(echo "$LOGIN" | jq -r '.refresh_token')
+          if [ -z "$ACCESS" ] || [ "$ACCESS" = "null" ] || [ -z "$REFRESH" ] || [ "$REFRESH" = "null" ]; then
+            echo "::error::login returned no tokens: $LOGIN"; exit 1
+          fi
+          echo "::add-mask::$ACCESS"
+          echo "::add-mask::$REFRESH"
+
           echo "email=$EMAIL" >> "$GITHUB_OUTPUT"
           echo "password=$PASSWORD" >> "$GITHUB_OUTPUT"
-          echo "==> seeded $EMAIL and planted inbox workout"
+          # `--seed-session` format is <accessJWT>:<refreshToken> (neither
+          # contains a colon, so the first colon is the separator).
+          echo "session=$ACCESS:$REFRESH" >> "$GITHUB_OUTPUT"
+          echo "==> seeded $EMAIL, planted inbox workout, minted session"
 
       # ── Build the app (mirrors swift-nightly.yml) ──
       - name: Select Xcode 26
@@ -165,6 +184,7 @@ jobs:
         env:
           E2E_EMAIL: ${{ steps.seed.outputs.email }}
           E2E_PASSWORD: ${{ steps.seed.outputs.password }}
+          E2E_SESSION: ${{ steps.seed.outputs.session }}
         run: |
           xcodebuild test \
             -scheme LiftMark \
@@ -175,6 +195,7 @@ jobs:
             LMWF_E2E_BASE_URL="$LMWF_E2E_BASE_URL" \
             LMWF_E2E_EMAIL="$E2E_EMAIL" \
             LMWF_E2E_PASSWORD="$E2E_PASSWORD" \
+            LMWF_E2E_SESSION="$E2E_SESSION" \
             UITEST_TIMEOUT_SCALE=4 \
             | xcpretty
 

--- a/e2e-spec/scenarios/beta-inbox.yaml
+++ b/e2e-spec/scenarios/beta-inbox.yaml
@@ -1,9 +1,12 @@
 name: "Beta — inbox surfaces a pushed workout"
 
-# Layer-3 e2e (GH #137): the CI workflow pushes a workout named
-# "Beta Inbox Probe" to the seeded user's inbox via POST /v1/workouts BEFORE
-# this runs. The app logs in, forces an inbox poll, and the pushed workout must
-# surface in the Workouts-tab inbox. See spec/services/ios-e2e-beta.md.
+# Layer-3 e2e (GH #137). The CI workflow pushes a workout named
+# "Beta Inbox Probe" to the seeded account's inbox via POST /v1/workouts before
+# this runs, and provides a ready session via ${LMWF_E2E_SESSION}. The app
+# starts signed in (--seed-session) — bypassing the flaky login sheet, which is
+# covered separately by beta-login — and under --live-backend polls the inbox at
+# launch. The pushed workout must surface in the Workouts-tab inbox.
+# See spec/services/ios-e2e-beta.md.
 
 setupOnce:
   - action: launchApp
@@ -12,67 +15,15 @@ setupOnce:
       - "--live-backend"
       - "--api-base-url=${LMWF_E2E_BASE_URL}"
       - "--enable-flag=workoutInbox"
+      - "--seed-session=${LMWF_E2E_SESSION}"
 
 tests:
-  - name: "should poll the inbox and show the API-pushed workout"
+  - name: "should surface the API-pushed workout in the inbox"
     steps:
       - action: tap
-        target: "tab-settings"
-      - action: waitFor
-        target: "account-sign-in"
-        timeout: 15000
-      # The Settings → Sign-in sheet drops if it presents during launch
-      # settling: a store-load re-render tears the freshly-presented sheet down
-      # (the documented AuthSyncBannerView "needs a second tap" bug). Let the
-      # cold-launch re-renders settle first, then re-tap until login-email
-      # sticks. App-side fix (stable sheet presentation) tracked as follow-up.
-      - action: delay
-        ms: 3000
-      - action: tap
-        target: "account-sign-in"
-      - action: tryCatch
-        try:
-          - action: waitFor
-            target: "login-email"
-            timeout: 4000
-        catch:
-          - action: delay
-            ms: 1500
-          - action: tap
-            target: "account-sign-in"
-      - action: tryCatch
-        try:
-          - action: waitFor
-            target: "login-email"
-            timeout: 4000
-        catch:
-          - action: delay
-            ms: 1500
-          - action: tap
-            target: "account-sign-in"
-      - action: waitFor
-        target: "login-email"
-        timeout: 15000
-      - action: replaceText
-        target: "login-email"
-        value: "${LMWF_E2E_EMAIL}"
-      - action: replaceText
-        target: "login-password"
-        value: "${LMWF_E2E_PASSWORD}"
-      - action: tap
-        target: "login-submit"
-      - action: waitFor
-        target: "account-identity"
-        timeout: 30000
-      # Force a poll (inbox + outbox) rather than waiting for a foreground tick.
-      - action: waitFor
-        target: "account-inbox-sync-now"
-        timeout: 10000
-      - action: tap
-        target: "account-inbox-sync-now"
-      # The pushed workout should land in the Workouts-tab inbox section.
-      - action: tap
         target: "tab-workouts"
+      # The launch-time inbox poll populates the section once it lands; the
+      # generous waits absorb CloudFront/Lambda latency.
       - action: waitFor
         target: "inbox-section"
         timeout: 30000

--- a/e2e-spec/scenarios/beta-outbox.yaml
+++ b/e2e-spec/scenarios/beta-outbox.yaml
@@ -1,11 +1,16 @@
 name: "Beta — completed workout pushes to outbox"
 
-# Layer-3 e2e (GH #137): sign in, complete a workout in the UI (the proven
-# local completion flow from workout-flow.yaml), then force a sync. Under
-# --live-backend the session-complete notification enqueues + flushes to the
-# server outbox. The server-side round-trip is asserted by the CI workflow,
-# which queries GET /v1/workouts/outbox for "Detox Flow Workout" after this
-# scenario. See spec/services/ios-e2e-beta.md.
+# Layer-3 e2e (GH #137). Starts signed in via ${LMWF_E2E_SESSION} (--seed-session,
+# bypassing the login sheet — covered by beta-login). Imports + completes a
+# workout; under --live-backend the session-complete notification enqueues it to
+# the outbox. A relaunch then fires flushIfAuthenticated (the completed session +
+# queue persist across the non-reset relaunch), pushing it to the server. The CI
+# workflow asserts the round-trip via GET /v1/workouts/outbox.
+#
+# Deliberately NO --enable-flag=workoutInbox: the outbox is flag-independent, and
+# the flag would render the home inbox card (the account's inbox holds the probe
+# workout) which pushes button-import-workout below the fold.
+# See spec/services/ios-e2e-beta.md.
 
 setupOnce:
   - action: launchApp
@@ -13,61 +18,11 @@ setupOnce:
     launchArgs:
       - "--live-backend"
       - "--api-base-url=${LMWF_E2E_BASE_URL}"
-      - "--enable-flag=workoutInbox"
+      - "--seed-session=${LMWF_E2E_SESSION}"
 
 tests:
-  - name: "should sign in, complete a workout, and flush it to the outbox"
+  - name: "should complete a workout and flush it to the outbox"
     steps:
-      # --- Sign in ---
-      - action: tap
-        target: "tab-settings"
-      - action: waitFor
-        target: "account-sign-in"
-        timeout: 15000
-      # The Settings → Sign-in sheet drops if it presents during launch
-      # settling: a store-load re-render tears the freshly-presented sheet down
-      # (the documented AuthSyncBannerView "needs a second tap" bug). Let the
-      # cold-launch re-renders settle first, then re-tap until login-email
-      # sticks. App-side fix (stable sheet presentation) tracked as follow-up.
-      - action: delay
-        ms: 3000
-      - action: tap
-        target: "account-sign-in"
-      - action: tryCatch
-        try:
-          - action: waitFor
-            target: "login-email"
-            timeout: 4000
-        catch:
-          - action: delay
-            ms: 1500
-          - action: tap
-            target: "account-sign-in"
-      - action: tryCatch
-        try:
-          - action: waitFor
-            target: "login-email"
-            timeout: 4000
-        catch:
-          - action: delay
-            ms: 1500
-          - action: tap
-            target: "account-sign-in"
-      - action: waitFor
-        target: "login-email"
-        timeout: 15000
-      - action: replaceText
-        target: "login-email"
-        value: "${LMWF_E2E_EMAIL}"
-      - action: replaceText
-        target: "login-password"
-        value: "${LMWF_E2E_PASSWORD}"
-      - action: tap
-        target: "login-submit"
-      - action: waitFor
-        target: "account-identity"
-        timeout: 30000
-
       # --- Import + complete a workout (proven flow from workout-flow.yaml) ---
       - action: tap
         target: "tab-home"
@@ -75,7 +30,7 @@ tests:
         ms: 500
       - action: waitFor
         target: "button-import-workout"
-        timeout: 10000
+        timeout: 15000
       - action: tap
         target: "button-import-workout"
       - action: waitFor
@@ -109,7 +64,6 @@ tests:
         timeout: 10000
       - action: tap
         target: "active-workout-finish-button"
-      # Finish dialog — "Finish Anyway" / "Log Anyway" / "Finish".
       - action: tryCatch
         try:
           - action: waitForText
@@ -140,14 +94,14 @@ tests:
       - action: tap
         target: "workout-summary-done-button"
 
-      # --- Force the outbox flush (CI asserts the server row) ---
-      - action: tap
-        target: "tab-settings"
-      - action: waitFor
-        target: "account-inbox-sync-now"
-        timeout: 15000
-      - action: tap
-        target: "account-inbox-sync-now"
-      # Give the push time to reach the server before the CI verify step.
+      # --- Relaunch to flush the outbox (onAppear flushIfAuthenticated under
+      # --live-backend); the completed session + queue persist (no --reset-data
+      # on a non-first launch). CI then asserts the server outbox. ---
+      - action: launchApp
+        newInstance: true
+        launchArgs:
+          - "--live-backend"
+          - "--api-base-url=${LMWF_E2E_BASE_URL}"
+          - "--seed-session=${LMWF_E2E_SESSION}"
       - action: delay
-        ms: 4000
+        ms: 6000

--- a/mobile-apps/ios/LiftMark/App/LiftMarkApp.swift
+++ b/mobile-apps/ios/LiftMark/App/LiftMarkApp.swift
@@ -69,6 +69,14 @@ struct LiftMarkApp: App {
             TokenStore().clear()
         }
 
+        // Seed a session straight into the Keychain (runs AFTER --reset-data so
+        // it isn't wiped). Lets the Layer-3 beta e2e scenarios that exercise
+        // inbox/outbox start already signed in, bypassing the flaky login sheet
+        // — the login UI itself is covered by its own scenario. Combined with
+        // --live-backend, restoreSession() rehydrates these tokens on launch.
+        // See spec/services/ios-e2e-beta.md.
+        Self.seedSessionFromLaunchArgs()
+
         Self.seedMigratorFailureFromLaunchArgs()
 
         #if DEBUG
@@ -136,6 +144,24 @@ struct LiftMarkApp: App {
         // Prevent the real bridge from running and clearing the seeded failure.
         // This arg is strictly for UI-test harness use.
         MigratorBridge.isEnabled = false
+    }
+
+    /// Test seam: `--seed-session=<accessJWT>:<refreshToken>` writes the pair
+    /// straight to the Keychain so a UI test launches already authenticated,
+    /// skipping the login sheet. The access JWT is dot-delimited and the
+    /// refresh token is opaque — neither contains a colon — so the first colon
+    /// is the unambiguous separator. See spec/services/ios-e2e-beta.md (GH #137).
+    private static func seedSessionFromLaunchArgs() {
+        let prefix = "--seed-session="
+        guard let arg = ProcessInfo.processInfo.arguments.first(where: { $0.hasPrefix(prefix) }) else {
+            return
+        }
+        let value = String(arg.dropFirst(prefix.count))
+        guard let sep = value.firstIndex(of: ":") else { return }
+        let access = String(value[value.startIndex..<sep])
+        let refresh = String(value[value.index(after: sep)...])
+        guard !access.isEmpty, !refresh.isEmpty else { return }
+        TokenStore().saveTokens(access: access, refresh: refresh)
     }
 
     /// Parse --import-content launch argument at init time so the @State

--- a/mobile-apps/ios/TestPlans/BetaE2E.xctestplan
+++ b/mobile-apps/ios/TestPlans/BetaE2E.xctestplan
@@ -25,6 +25,10 @@
       {
         "key" : "LMWF_E2E_PASSWORD",
         "value" : "$(LMWF_E2E_PASSWORD)"
+      },
+      {
+        "key" : "LMWF_E2E_SESSION",
+        "value" : "$(LMWF_E2E_SESSION)"
       }
     ],
     "targetForVariableExpansion" : {

--- a/spec/services/ios-e2e-beta.md
+++ b/spec/services/ios-e2e-beta.md
@@ -59,6 +59,21 @@ Inbox polling additionally requires the `workoutInbox` feature flag, enabled per
 run with the existing `--enable-flag=workoutInbox` plumbing
 ([feature-flags.md](feature-flags.md)).
 
+### `--seed-session=<accessJWT>:<refreshToken>`
+
+Writes a token pair straight to the Keychain at launch (after the `--reset-data`
+wipe), so a scenario starts **already signed in** — combined with
+`--live-backend`, `restoreSession()` rehydrates it. This bypasses the login
+sheet, which is genuinely flaky to drive under XCUITest on iOS 26: the
+`SettingsAccountSection` sheet drops on the re-render that the first "Sign in"
+tap triggers (the documented `AuthSyncBannerView` instability), so it can take a
+second tap to stick. The data-round-trip scenarios (`beta-inbox`, `beta-outbox`)
+therefore seed the session and never touch the login UI; `beta-login` is the one
+scenario that exercises the real sheet (with a settle + re-tap). The access JWT
+is dot-delimited and the refresh token opaque — neither contains a colon — so the
+first colon is the separator. `--reset-data` also now clears the Keychain, so
+each scenario starts from a known auth state.
+
 ## Runner: environment-variable interpolation
 
 Credentials are minted fresh per CI run (see below), so they cannot be baked into
@@ -76,20 +91,30 @@ New scenarios live alongside the existing ones in `e2e-spec/scenarios/` and run
 **only** under the `BetaE2E` test plan (they are excluded from `Smoke` and
 `Full`, which have no backend).
 
-| Scenario | Exercises | Assertion surface |
-| --- | --- | --- |
-| `beta-login` | login → token persist → logout/revoke | `account-identity`, `account-sign-out`, `account-sign-in` (in-app) |
-| `beta-inbox` | API push → device poll → inbox surfaces | `inbox-section`, inbox row for the pushed workout (in-app) |
-| `beta-outbox` | complete workout in-app → outbox push | server-side `GET /v1/workouts/outbox` asserts in the workflow |
+| Scenario | Auth | Exercises | Assertion surface |
+| --- | --- | --- | --- |
+| `beta-login` | real login UI | login → token persist → logout/revoke | `account-identity`, `account-sign-out`, `account-sign-in` (in-app) |
+| `beta-inbox` | `--seed-session` | launch-time poll surfaces an API-pushed workout | `inbox-section` + the pushed workout name (in-app) |
+| `beta-outbox` | `--seed-session` | complete workout → relaunch flush → outbox push | server-side `GET /v1/workouts/outbox` asserts in the workflow |
 
-`beta-login` and `beta-inbox` assert entirely on in-app UI driven by real
-network calls. `beta-outbox` drives the app to complete a workout; the
-server-side round-trip is asserted by a workflow step that queries the outbox
-with the seeded user's token, because the app has no in-app outbox list view.
+Only `beta-login` drives the login sheet (with a settle + re-tap for its
+instability). `beta-inbox` / `beta-outbox` start signed in via `--seed-session`
+so they test the inbox/outbox contract without depending on the flaky login UI:
 
-All three launch with `--live-backend --api-base-url=$LMWF_E2E_BASE_URL
---enable-flag=workoutInbox` and rely on the runner's `waitFor*` polling for
-async settling (CloudFront/Lambda latency).
+- `beta-inbox` launches with `--enable-flag=workoutInbox`; `--live-backend`
+  polls the inbox at launch, and the pushed "Beta Inbox Probe" must surface in
+  the Workouts-tab inbox section.
+- `beta-outbox` deliberately omits `workoutInbox` (the outbox is
+  flag-independent, and the flag would render the home inbox card — the account's
+  inbox holds the probe — pushing `button-import-workout` below the fold). It
+  imports + completes a workout (the proven `workout-flow` steps), then
+  **relaunches** to fire `flushIfAuthenticated` (the completed session + queue
+  persist across the non-`--reset-data` relaunch). The server-side round-trip is
+  asserted by a workflow step querying the outbox, because the app has no in-app
+  outbox list view.
+
+All rely on the runner's `waitFor*` polling for async settling (CloudFront/Lambda
+latency).
 
 ## CI workflow — `[iOS] E2E (beta)`
 


### PR DESCRIPTION
Re-approaches the flaky beta e2e (per the chosen direction): the inbox/outbox scenarios now **start signed in via `--seed-session`** instead of driving the iOS-26-flaky login sheet. `beta-login` remains the one scenario exercising the real login UI.

- **App**: `--seed-session=<accessJWT>:<refreshToken>` writes tokens to the Keychain at launch; `--live-backend` rehydrates them.
- **beta-inbox**: seeded + `workoutInbox`; launch-time poll surfaces the pushed "Beta Inbox Probe".
- **beta-outbox**: seeded, no `workoutInbox` (keeps `button-import-workout` at the top); import+complete a workout, then **relaunch** to flush. CI asserts the server outbox.
- **Workflow**: mints a real session (login → access+refresh) → `LMWF_E2E_SESSION`.

Verified: build compiles; `testBetaOutbox` UI flow passes locally. Seeded-auth round-trips verified by CI (real session). 🤖 Generated with [Claude Code](https://claude.com/claude-code)