### PR TITLE
test(ios): restore beta-login e2e + exclude beta tests from nightly Full (#277, #272)

### DIFF
--- a/e2e-spec/scenarios/beta-login.yaml
+++ b/e2e-spec/scenarios/beta-login.yaml
@@ -1,0 +1,65 @@
+name: "Beta — login round-trip"
+
+# Layer-3 e2e (GH #137): exercises the real auth contract against the deployed
+# beta backend. Runs ONLY under the BetaE2E test plan — credentials are injected
+# per CI run via ${LMWF_E2E_*} env interpolation, and the backend host via
+# ${LMWF_E2E_BASE_URL}. See spec/services/ios-e2e-beta.md.
+#
+# --reset-data wipes the DB + UserDefaults + Keychain tokens (see
+# LiftMarkApp.swift), so this scenario starts from a clean *signed-out* state
+# regardless of test order — a seeded session from an earlier beta scenario
+# can't bleed in. The login UI is driven for real here; the app-side sheet-drop
+# bug (GH #279) is fixed (sheet presents from a stable host), so a single tap on
+# account-sign-in presents LoginView reliably — no settle delay / re-tap dance.
+
+setupOnce:
+  - action: launchApp
+    newInstance: true
+    launchArgs:
+      - "--reset-data"
+      - "--live-backend"
+      - "--api-base-url=${LMWF_E2E_BASE_URL}"
+      - "--enable-flag=workoutInbox"
+
+tests:
+  - name: "should sign in against beta and persist the session"
+    steps:
+      - action: tap
+        target: "tab-settings"
+      - action: waitFor
+        target: "account-sign-in"
+        timeout: 15000
+      # Single tap presents the LoginView sheet (GH #279 stable-host fix) and it
+      # stays — no second tap.
+      - action: tap
+        target: "account-sign-in"
+      - action: waitFor
+        target: "login-email"
+        timeout: 15000
+      - action: replaceText
+        target: "login-email"
+        value: "${LMWF_E2E_EMAIL}"
+      - action: replaceText
+        target: "login-password"
+        value: "${LMWF_E2E_PASSWORD}"
+      - action: tap
+        target: "login-submit"
+      # Real network login → the account section flips to signed-in.
+      - action: waitFor
+        target: "account-identity"
+        timeout: 30000
+      - action: expect
+        target: "account-sign-out"
+        assertion: "toExist"
+
+  - name: "should sign out and revoke the session"
+    steps:
+      - action: waitFor
+        target: "account-sign-out"
+        timeout: 10000
+      - action: tap
+        target: "account-sign-out"
+      # logout() revokes server-side then clears local tokens → signed-out copy.
+      - action: waitFor
+        target: "account-sign-in"
+        timeout: 20000

--- a/mobile-apps/ios/LiftMarkUITests/LiftMarkUITests.swift
+++ b/mobile-apps/ios/LiftMarkUITests/LiftMarkUITests.swift
@@ -129,11 +129,15 @@ final class LiftMarkUITests: XCTestCase {
     // CI workflow). Run locally with those set + the beta host reachable.
     // See spec/services/ios-e2e-beta.md.
 
-    // testBetaLogin (real login-UI sheet) is temporarily removed: the
-    // SettingsAccountSection sign-in sheet is too flaky to drive reliably under
-    // XCUITest on iOS 26 (it drops on the first-tap re-render). The data
-    // round-trips below seed the session instead. Tracked for restoration in a
-    // follow-up issue (see spec/services/ios-e2e-beta.md).
+    /// Real login-UI round-trip against beta (GH #137 / restored per GH #277).
+    /// Starts from a clean signed-out state via `--reset-data` (order-
+    /// independent) and drives Settings → Sign in → account-identity →
+    /// sign-out/revoke. The first-tap sheet-drop bug it used to work around is
+    /// fixed app-side (GH #279, stable-host sheet presentation), so the scenario
+    /// taps sign-in once with no settle/re-tap workaround.
+    func testBetaLogin() throws {
+        runner.runScenario(named: "beta-login")
+    }
 
     func testBetaInbox() throws {
         runner.runScenario(named: "beta-inbox")

--- a/mobile-apps/ios/TestPlans/BetaE2E.xctestplan
+++ b/mobile-apps/ios/TestPlans/BetaE2E.xctestplan
@@ -40,6 +40,7 @@
   "testTargets" : [
     {
       "selectedTests" : [
+        "LiftMarkUITests\/testBetaLogin()",
         "LiftMarkUITests\/testBetaInbox()",
         "LiftMarkUITests\/testBetaOutbox()"
       ],

--- a/mobile-apps/ios/TestPlans/Full.xctestplan
+++ b/mobile-apps/ios/TestPlans/Full.xctestplan
@@ -31,6 +31,9 @@
     },
     {
       "skippedTests" : [
+        "LiftMarkUITests\/testBetaInbox()",
+        "LiftMarkUITests\/testBetaLogin()",
+        "LiftMarkUITests\/testBetaOutbox()",
         "LiftMarkUITests\/testScreenshots()"
       ],
       "target" : {

--- a/spec/services/ios-e2e-beta.md
+++ b/spec/services/ios-e2e-beta.md
@@ -63,13 +63,12 @@ run with the existing `--enable-flag=workoutInbox` plumbing
 
 Writes a token pair straight to the Keychain at launch (after the `--reset-data`
 wipe), so a scenario starts **already signed in** — combined with
-`--live-backend`, `restoreSession()` rehydrates it. This bypasses the login
-sheet, which is genuinely flaky to drive under XCUITest on iOS 26: the
-`SettingsAccountSection` sheet drops on the re-render that the first "Sign in"
-tap triggers (the documented `AuthSyncBannerView` instability), so it can take a
-second tap to stick. The data-round-trip scenarios (`beta-inbox`, `beta-outbox`)
-therefore seed the session and never touch the login UI; `beta-login` is the one
-scenario that exercises the real sheet (with a settle + re-tap). The access JWT
+`--live-backend`, `restoreSession()` rehydrates it. This lets the data-round-trip
+scenarios (`beta-inbox`, `beta-outbox`) start signed in without re-driving the
+login UI — that contract is covered once by `beta-login`, which taps the real
+sheet a single time (the first-tap sheet-drop bug is fixed app-side, GH #279:
+`LoginView` is presented from a stable host so it no longer needs a settle +
+re-tap). The access JWT
 is dot-delimited and the refresh token opaque — neither contains a colon — so the
 first colon is the separator. `--reset-data` also now clears the Keychain, so
 each scenario starts from a known auth state.
@@ -88,22 +87,27 @@ Example: `replaceText target: login-email, value: "${LMWF_E2E_EMAIL}"`.
 ## Scenarios
 
 New scenarios live alongside the existing ones in `e2e-spec/scenarios/` and run
-**only** under the `BetaE2E` test plan (they are excluded from `Smoke` and
-`Full`, which have no backend).
+**only** under the `BetaE2E` test plan. They are excluded from `Smoke` and
+`Full` (which have no backend and no `LMWF_E2E_*` credentials): `Full` lists the
+three `testBeta*` methods in its `skippedTests`, so the nightly Full UI suite
+never drives them. (Before that exclusion existed they ran credential-less in the
+nightly and failed on `login-email` / empty `--seed-session` every run — GH #272.)
 
 | Scenario | Auth | Exercises | Assertion surface |
 | --- | --- | --- | --- |
+| `beta-login` | real login UI | login → token persist → logout/revoke | `account-identity`, `account-sign-out`, `account-sign-in` (in-app) |
 | `beta-inbox` | `--seed-session` | launch-time poll surfaces an API-pushed workout | `inbox-section` + the pushed workout name (in-app) |
 | `beta-outbox` | `--seed-session` | complete workout → relaunch flush → outbox push | server-side `GET /v1/workouts/outbox` asserts in the workflow |
 
-> **`beta-login` (real login-UI) is temporarily removed** — the
-> `SettingsAccountSection` sign-in sheet is too flaky to drive under XCUITest on
-> iOS 26 (it drops on the first-tap re-render). Both remaining scenarios seed the
-> session instead. Restoring `beta-login` after fixing the sheet is tracked in
-> GH #277.
-
-Both scenarios start signed in via `--seed-session` so they test the
-inbox/outbox contract without depending on the flaky login UI:
+`beta-login` drives the **real** Settings → Sign in sheet. It launches with
+`--reset-data`, which wipes the DB + UserDefaults + Keychain tokens, so it starts
+from a clean *signed-out* state independent of test order (a seeded session from
+another scenario can't bleed in). A single tap on `account-sign-in` presents
+`LoginView` reliably — the first-tap sheet-drop instability is fixed app-side
+(GH #279: the sheet is hosted from a stable parent, `SettingsView`), so the
+scenario needs no settle delay or re-tap workaround. `beta-inbox` / `beta-outbox`
+start signed in via `--seed-session` so they test the inbox/outbox contract
+without re-driving the login UI:
 
 - `beta-inbox` launches with `--enable-flag=workoutInbox`; `--live-backend`
   polls the inbox at launch, and the pushed "Beta Inbox Probe" must surface in


### PR DESCRIPTION
## Summary

Two related fixes stemming from the Settings sign-in sheet work just delivered (GH #279 / #280).

### GH #277 — restore the real login-UI beta e2e
The Layer-3 `testBetaLogin` scenario was dropped in #278 because the Settings sign-in sheet dropped on the first tap under XCUITest. #280 fixed the app (LoginView now presents from a stable host), so this re-adds:
- `e2e-spec/scenarios/beta-login.yaml` — rewritten **clean**: launches with `--reset-data` for an order-independent signed-out start (the Keychain wipe stops a seeded session from another scenario bleeding in), and taps `account-sign-in` **once** — no settle delay / re-tap workaround. Drives the real beta `login → account-identity → sign-out/revoke` contract.
- `testBetaLogin()` in `LiftMarkUITests.swift`
- `BetaE2E.xctestplan` entry, listed **first**

### GH #272 — nightly Full UI suite failing
Root cause: the **Full** test plan ran *all* UITests with no selection, sweeping in `testBetaInbox/Login/Outbox`. Those require a live backend + `LMWF_E2E_*` creds the nightly job doesn't provide, so they failed **deterministically every night** (`login-email` not found / empty `--seed-session`). The spec already *claimed* these were "excluded from Smoke and Full" — this enforces it by adding the three `testBeta*` methods to `Full.xctestplan` `skippedTests`. They run only under `BetaE2E` (with creds) via the `[iOS] E2E (beta)` workflow.

> Note: the same nightly run also showed a `testWorkoutFlow` timeout — a separate, intermittent flake unrelated to the sign-in sheet. Not addressed here; will watch the next nightly.

### Spec
`spec/services/ios-e2e-beta.md`: `beta-login` row restored, "temporarily removed" note dropped, clean-start + Full-exclusion behavior documented.

## Verification
- `xcodebuild build-for-testing -testPlan BetaE2E` (iPhone 17 Pro / iOS 26.5) → **TEST BUILD SUCCEEDED**. `testBetaLogin()` compiles and the plan resolves.
- The `beta-login` scenario executes against the live beta backend only via the `[iOS] E2E (beta)` workflow (CI-gated creds) — same local-proof bar as #278. Will trigger it post-merge to confirm green.

Closes #277. Addresses #272.

🤖 Generated with [Claude Code](https://claude.com/claude-code)