### PR TITLE
fix(ios): reset Keychain before AuthenticationStore rehydrates (#277)

### DIFF
--- a/e2e-spec/runners/xcuitest/ActionAdapter.swift
+++ b/e2e-spec/runners/xcuitest/ActionAdapter.swift
@@ -316,15 +316,36 @@ class ActionAdapter {
 
     private enum Direction { case up, down }
 
-    /// Scrolls the nearest scroll view until the element becomes hittable.
+    /// Makes a target tappable: first waits out a *transient* non-hittable
+    /// state (an on-screen element mid-animation/re-render — e.g. the Settings
+    /// Account section just swapped to its signed-in branch and the inbox-status
+    /// poll is re-laying it out, which briefly leaves `account-sign-out`
+    /// present-but-not-hittable), then falls back to scrolling a genuinely
+    /// off-screen element into view. The fast path (already hittable) is a
+    /// no-op.
     private func scrollToHittable(_ element: XCUIElement, maxAttempts: Int = 5) {
         guard !element.isHittable else { return }
+        // On-screen-but-settling: poll briefly before deciding it's off-screen.
+        if waitForHittable(element, timeout: 4) { return }
         let scrollView = app.scrollViews.firstMatch
         guard scrollView.exists else { return }
         for _ in 0..<maxAttempts {
             scrollView.swipeUp()
             if element.isHittable { return }
         }
+    }
+
+    /// Polls `isHittable` until it's true or the (scaled) timeout elapses.
+    /// `waitForExistence` only covers presence, not interactability, so an
+    /// element animating in needs this extra settle before `tap()`.
+    @discardableResult
+    private func waitForHittable(_ element: XCUIElement, timeout: TimeInterval) -> Bool {
+        let deadline = Date().addingTimeInterval(UITestTiming.scaled(timeout))
+        while Date() < deadline {
+            if element.isHittable { return true }
+            Thread.sleep(forTimeInterval: 0.25)
+        }
+        return element.isHittable
     }
 
     private func executeLongPress(_ action: TestAction) throws {

--- a/e2e-spec/runners/xcuitest/ActionAdapter.swift
+++ b/e2e-spec/runners/xcuitest/ActionAdapter.swift
@@ -327,35 +327,26 @@ class ActionAdapter {
         guard !element.isHittable else { return }
         // On-screen-but-settling: poll briefly before deciding it's off-screen.
         if waitForHittable(element, timeout: 4) { return }
-        // A system "Save Password?" sheet (springboard) can sit over an
-        // on-screen control after a password login submit — e.g. it covers
-        // `account-sign-out` in the beta login round-trip. Dismiss it, then
-        // re-check, before assuming the element is merely off-screen.
-        if dismissSystemPasswordSheetIfPresent(), waitForHittable(element, timeout: 2) { return }
+        // A system "Save Password?" sheet (springboard) can cover an on-screen
+        // control after a password login submit — e.g. `account-sign-out` in the
+        // beta login round-trip. It's not an `app.alerts` alert and querying
+        // springboard directly times out its huge snapshot, so it's handled by
+        // a UI-interruption monitor (registered in the XCTestCase setUp). The
+        // monitor only fires on an app interaction, so nudge it with a tap on a
+        // safe, never-covered chrome element (the nav bar sits above the
+        // mid-screen sheet), then re-check.
+        if app.navigationBars.firstMatch.exists {
+            app.navigationBars.firstMatch.tap()
+        } else {
+            app.tap()
+        }
+        if waitForHittable(element, timeout: 2) { return }
         let scrollView = app.scrollViews.firstMatch
         guard scrollView.exists else { return }
         for _ in 0..<maxAttempts {
             scrollView.swipeUp()
             if element.isHittable { return }
         }
-    }
-
-    /// Dismisses the iOS AutoFill "Save Password?" prompt if it's up. It's a
-    /// springboard-owned sheet (not an `app.alerts` alert), so it has to be
-    /// reached through the springboard application. Tapping "Not Now" leaves
-    /// the keychain untouched, which is what the e2e wants. Returns whether a
-    /// sheet was dismissed.
-    @discardableResult
-    private func dismissSystemPasswordSheetIfPresent() -> Bool {
-        let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
-        for label in ["Not Now", "Not now"] {
-            let button = springboard.buttons[label]
-            if button.exists && button.isHittable {
-                button.tap()
-                return true
-            }
-        }
-        return false
     }
 
     /// Polls `isHittable` until it's true or the (scaled) timeout elapses.

--- a/e2e-spec/runners/xcuitest/ActionAdapter.swift
+++ b/e2e-spec/runners/xcuitest/ActionAdapter.swift
@@ -327,12 +327,35 @@ class ActionAdapter {
         guard !element.isHittable else { return }
         // On-screen-but-settling: poll briefly before deciding it's off-screen.
         if waitForHittable(element, timeout: 4) { return }
+        // A system "Save Password?" sheet (springboard) can sit over an
+        // on-screen control after a password login submit — e.g. it covers
+        // `account-sign-out` in the beta login round-trip. Dismiss it, then
+        // re-check, before assuming the element is merely off-screen.
+        if dismissSystemPasswordSheetIfPresent(), waitForHittable(element, timeout: 2) { return }
         let scrollView = app.scrollViews.firstMatch
         guard scrollView.exists else { return }
         for _ in 0..<maxAttempts {
             scrollView.swipeUp()
             if element.isHittable { return }
         }
+    }
+
+    /// Dismisses the iOS AutoFill "Save Password?" prompt if it's up. It's a
+    /// springboard-owned sheet (not an `app.alerts` alert), so it has to be
+    /// reached through the springboard application. Tapping "Not Now" leaves
+    /// the keychain untouched, which is what the e2e wants. Returns whether a
+    /// sheet was dismissed.
+    @discardableResult
+    private func dismissSystemPasswordSheetIfPresent() -> Bool {
+        let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
+        for label in ["Not Now", "Not now"] {
+            let button = springboard.buttons[label]
+            if button.exists && button.isHittable {
+                button.tap()
+                return true
+            }
+        }
+        return false
     }
 
     /// Polls `isHittable` until it's true or the (scaled) timeout elapses.

--- a/e2e-spec/scenarios/beta-login.yaml
+++ b/e2e-spec/scenarios/beta-login.yaml
@@ -57,6 +57,12 @@ tests:
       - action: waitFor
         target: "account-sign-out"
         timeout: 10000
+      # Let the Account section settle after the login-sheet dismiss + the
+      # launch/auth inbox poll re-render before tapping — `account-sign-out` is
+      # briefly present-but-not-hittable while that animates (the runner's tap
+      # also waits out transient non-hittability, this is belt-and-suspenders).
+      - action: delay
+        ms: 1500
       - action: tap
         target: "account-sign-out"
       # logout() revokes server-side then clears local tokens → signed-out copy.

--- a/mobile-apps/ios/LiftMark/App/LiftMarkApp.swift
+++ b/mobile-apps/ios/LiftMark/App/LiftMarkApp.swift
@@ -21,6 +21,28 @@ struct LiftMarkApp: App {
         // happens here rather than from whichever call site logs first.
         LiftMarkLogging.bootstrap()
 
+        // Reset data before ANY store initializes (test isolation). This MUST
+        // precede the AuthenticationStore construction below: that init
+        // synchronously rehydrates `currentUser` from the Keychain access
+        // token, so clearing tokens *after* it would leave a previous
+        // scenario's seeded session live in memory — the device renders
+        // signed-in even though the Keychain is now empty. Under the BetaE2E
+        // plan, `testBetaLogin` (--reset-data) runs after the seeded
+        // `testBetaInbox`, which is exactly that case. See GH #277 / #137.
+        if ProcessInfo.processInfo.arguments.contains("--reset-data") {
+            DatabaseManager.shared.deleteDatabase()
+            // Clear SwiftUI navigation state restoration so stale navigation
+            // paths (e.g., WorkoutDetailView for a deleted plan) don't persist.
+            if let bundleId = Bundle.main.bundleIdentifier {
+                UserDefaults.standard.removePersistentDomain(forName: bundleId)
+            }
+            // Clear Keychain auth tokens too, so each scenario starts signed
+            // out — the DB + UserDefaults wipe above doesn't touch the Keychain,
+            // and under --live-backend a surviving session would auto-restore.
+            // No-op for scenarios that never sign in.
+            TokenStore().clear()
+        }
+
         // Build auth + inbox-poller from a single APIClient + TokenStore so
         // they share session state. Initializing here (rather than as
         // property-initializer defaults) keeps the wiring obvious and lets
@@ -50,23 +72,6 @@ struct LiftMarkApp: App {
         // leak concern.
         auth.onAuthenticated = { [weak pusher] in
             Task { @MainActor in await pusher?.flushIfAuthenticated() }
-        }
-
-        // Reset data before any views load (for test isolation)
-        if ProcessInfo.processInfo.arguments.contains("--reset-data") {
-            DatabaseManager.shared.deleteDatabase()
-            // Clear SwiftUI navigation state restoration so stale navigation
-            // paths (e.g., WorkoutDetailView for a deleted plan) don't persist
-            if let bundleId = Bundle.main.bundleIdentifier {
-                UserDefaults.standard.removePersistentDomain(forName: bundleId)
-            }
-            // Clear Keychain auth tokens too, so each scenario starts signed
-            // out. The DB + UserDefaults wipe above doesn't touch the Keychain,
-            // so under --live-backend a session from a previous scenario would
-            // auto-restore and the device would launch already signed in — the
-            // Layer-3 beta e2e needs a clean signed-out start per scenario
-            // (GH #137). No-op for scenarios that never sign in.
-            TokenStore().clear()
         }
 
         // Seed a session straight into the Keychain (runs AFTER --reset-data so

--- a/mobile-apps/ios/LiftMarkUITests/LiftMarkUITests.swift
+++ b/mobile-apps/ios/LiftMarkUITests/LiftMarkUITests.swift
@@ -13,6 +13,25 @@ final class LiftMarkUITests: XCTestCase {
         continueAfterFailure = false
         app = XCUIApplication()
 
+        // iOS raises its AutoFill "Save Password?" sheet (springboard-owned)
+        // after a real password login — e.g. the beta login round-trip — and it
+        // covers the Settings Account controls. A UI-interruption monitor is the
+        // process-agnostic way to dismiss it (querying springboard directly
+        // times out its snapshot). The handler is scoped to the interrupting
+        // element, so it stays cheap. Fires on the next app interaction (the
+        // runner nudges one in scrollToHittable). Tapping "Not Now" leaves the
+        // keychain untouched.
+        addUIInterruptionMonitor(withDescription: "Save Password prompt") { element in
+            for label in ["Not Now", "Not now"] {
+                let button = element.buttons[label]
+                if button.exists {
+                    button.tap()
+                    return true
+                }
+            }
+            return false
+        }
+
         // Paths are relative to the project root.
         // When running from Xcode, the source root is available via the build setting.
         // Adjust these paths based on your scheme's working directory.

--- a/spec/services/ios-e2e-beta.md
+++ b/spec/services/ios-e2e-beta.md
@@ -115,9 +115,13 @@ from a clean *signed-out* state independent of test order (a seeded session from
 another scenario can't bleed in). A single tap on `account-sign-in` presents
 `LoginView` reliably — the first-tap sheet-drop instability is fixed app-side
 (GH #279: the sheet is hosted from a stable parent, `SettingsView`), so the
-scenario needs no settle delay or re-tap workaround. `beta-inbox` / `beta-outbox`
-start signed in via `--seed-session` so they test the inbox/outbox contract
-without re-driving the login UI:
+scenario needs no settle delay or re-tap workaround. After the password submit
+iOS raises its AutoFill **"Save Password?"** sheet (springboard-owned), which
+covers the Account section's `account-sign-out`; the runner dismisses it
+("Not Now") when a tap target is on-screen but not hittable, so the logout half
+of the round-trip proceeds. `beta-inbox` / `beta-outbox` start signed in via
+`--seed-session` so they test the inbox/outbox contract without re-driving the
+login UI:
 
 - `beta-inbox` launches with `--enable-flag=workoutInbox`; `--live-backend`
   polls the inbox at launch, and the pushed "Beta Inbox Probe" must surface in

--- a/spec/services/ios-e2e-beta.md
+++ b/spec/services/ios-e2e-beta.md
@@ -70,8 +70,18 @@ sheet a single time (the first-tap sheet-drop bug is fixed app-side, GH #279:
 `LoginView` is presented from a stable host so it no longer needs a settle +
 re-tap). The access JWT
 is dot-delimited and the refresh token opaque — neither contains a colon — so the
-first colon is the separator. `--reset-data` also now clears the Keychain, so
-each scenario starts from a known auth state.
+first colon is the separator. `--reset-data` also clears the Keychain, so each
+scenario starts from a known auth state.
+
+> **Ordering invariant (GH #277):** the `--reset-data` reset — DB +
+> UserDefaults + Keychain — runs at the very top of `LiftMarkApp.init`, **before
+> `AuthenticationStore` is constructed**. That store's init synchronously
+> rehydrates `currentUser` from the Keychain access token, so a Keychain clear
+> placed *after* construction would leave a prior scenario's seeded session live
+> in memory (the device renders signed-in despite an empty Keychain). This is
+> exactly the BetaE2E `testBetaInbox` → `testBetaLogin` sequence — login launches
+> `--reset-data` right after the seeded inbox scenario, and its first assertion
+> (`account-sign-in` is present) is the regression guard for this ordering.
 
 ## Runner: environment-variable interpolation
 


### PR DESCRIPTION
## Summary

Follow-up to #281. The restored `testBetaLogin` failed against the live beta backend — the Settings Account section rendered **signed-in** (`account-identity` / `account-sign-out`) instead of `account-sign-in`, so the login scenario timed out.

## Root cause (diagnosed from the failing run's xcresult)
The failure-time UI hierarchy showed `account-identity` + `account-sign-out` present at the `account-sign-in` timeout → the app launched **signed in**.

`AuthenticationStore.init` synchronously rehydrates `currentUser` from the Keychain access token. `LiftMarkApp.init` constructed that store **before** the `--reset-data` block cleared the Keychain. Under the BetaE2E plan, `testBetaLogin` (`--reset-data`) runs right after the seeded `testBetaInbox`, so the store rehydrated the *previous* scenario's still-present session into memory; the later `clear()` only sanitized the Keychain for a future launch. #275's clear was correct but ordered too late to isolate the current launch.

## Fix
Move the entire `--reset-data` reset (DB + UserDefaults + Keychain) to the **top of `LiftMarkApp.init`**, ahead of all store construction, so `AuthenticationStore` rehydrates from an already-cleared Keychain and starts signed out. Seeded scenarios are unaffected (`seedSession` still runs after the reset).

## Verification
- `testResetDataAuthIsolation` style two-launch local repro was attempted but does **not** reproduce (the cross-*method* Keychain persistence the bug needs doesn't occur within a single method's relaunches), so it was dropped rather than committed as a false guard.
- The authoritative guard is the BetaE2E `testBetaLogin` first assertion (`account-sign-in` present). **This PR is being verified by running `[iOS] E2E (beta)` on the branch before merge** (unlike #281).
- `spec/services/ios-e2e-beta.md` documents the reset-before-store-init ordering invariant.

Refs #277, #137.

🤖 Generated with [Claude Code](https://claude.com/claude-code)