### PR TITLE
feat(248): repoint beta client code onto beta.getlift.md

### DIFF
--- a/mobile-apps/ios/LiftMark/Services/APIClient.swift
+++ b/mobile-apps/ios/LiftMark/Services/APIClient.swift
@@ -179,9 +179,10 @@ final class APIClient: APIClientProtocol, @unchecked Sendable {
             useBeta = false
         }
         return useBeta
-            // Beta env. Migration to beta.getlift.md is a follow-up (GH #248);
-            // beta.liftmark.app still serves directly until then.
-            ? URL(string: "https://beta.liftmark.app")!
+            // Canonical beta host (GH #248 beta cutover is live). beta.liftmark.app
+            // now 308-redirects /v1/* here, but we target beta.getlift.md directly
+            // to skip the hop.
+            ? URL(string: "https://beta.getlift.md")!
             // Canonical prod host (GH #248). liftmark.app now 308-redirects
             // /v1/* here, but we target getlift.md directly to skip the hop.
             : URL(string: "https://getlift.md")!

--- a/mobile-apps/ios/LiftMark/Views/Auth/LoginView.swift
+++ b/mobile-apps/ios/LiftMark/Views/Auth/LoginView.swift
@@ -32,12 +32,12 @@ struct LoginView: View {
 
     /// Web host for the account pages, mirroring the API host the app talks
     /// to (so a session created on the web is on the same origin the API
-    /// uses). Prod is canonical `getlift.md` (GH #248); beta mode keeps the
-    /// beta env until its `beta.getlift.md` cutover lands.
+    /// uses). Prod is canonical `getlift.md`; beta is canonical `beta.getlift.md`
+    /// (both GH #248 — beta cutover is live, `beta.liftmark.app` redirects here).
     private static var accountWebBase: String {
         let useBeta = UserDefaults.standard.object(forKey: "feature_flag.useBetaApi") != nil
             && UserDefaults.standard.bool(forKey: "feature_flag.useBetaApi")
-        return useBeta ? "https://beta.liftmark.app" : "https://getlift.md"
+        return useBeta ? "https://beta.getlift.md" : "https://getlift.md"
     }
     private static var forgotPasswordURL: URL { URL(string: "\(accountWebBase)/account/forgot")! }
     private static var signupURL: URL { URL(string: "\(accountWebBase)/account/signup")! }

--- a/spec/services/lmwf-validator.md
+++ b/spec/services/lmwf-validator.md
@@ -153,14 +153,13 @@ solely so old links and shipped-app deep-links don't break. Beta mirrors this:
 **`beta.getlift.md`** is the all-in-one beta environment, and `beta.liftmark.app`
 redirects to it.
 
-> **Migration status (GH #248):** the **prod** cutover (table below) is
-> implemented — `getlift.md` serves everything; `liftmark.app` / `liftmd.app` /
-> `workoutformat.liftmark.app` are redirect-only. The **beta** half
-> (`beta.getlift.md`) is a tracked follow-up: it needs a cross-account DNS
-> delegation deploy (create the beta-account zone, read its NS, delegate from
-> the `getlift.md` zone, issue the cert), so until that lands beta still serves
-> from `beta.liftmark.app` and the e2e pipeline runs against it. The table and
-> the `beta.getlift.md` rows describe the target end state.
+> **Migration status (GH #248):** complete for both environments. The **prod**
+> cutover (table below) is implemented — `getlift.md` serves everything;
+> `liftmark.app` / `liftmd.app` / `workoutformat.liftmark.app` are redirect-only.
+> The **beta** cutover is also live (`betaCutoverPhase: 'live'`): `beta.getlift.md`
+> serves everything and `beta.liftmark.app` is 301/308 redirect-only (AASA
+> excepted), with the e2e pipeline running against `beta.getlift.md`. The table
+> rows describe the deployed end state.
 
 The **one** exception to "liftmark.app redirects everything" is the AASA path:
 Apple does NOT follow redirects when fetching `apple-app-site-association`, and

--- a/spec/services/validator-e2e.md
+++ b/spec/services/validator-e2e.md
@@ -10,7 +10,7 @@ next layer exists.
 | Layer | What it exercises | Transport | Where it lives | Status |
 |-------|-------------------|-----------|----------------|--------|
 | **1 — HTTP flow integration** | The full client journey through the real Hono app + DynamoDB Local + Mailpit, asserting the *protocol contract* composes end-to-end (each step consumes the exact token/id the previous step emitted). | In-process `app.request()` against DDB Local + Mailpit. | `validator/tests/flow.test.ts` | **Implemented** |
-| **2 — Live smoke flow** | The same journey against a deployed beta stack over real HTTP (`smoke-flow-live.sh`), proving the deploy topology (Lambda + API GW + DDB + SES) wires up. | Real HTTPS against `beta.liftmark.app`. | `validator/scripts/smoke-flow-live.sh` (planned) | Deferred |
+| **2 — Live smoke flow** | The same journey against a deployed beta stack over real HTTP (`smoke-flow-live.sh`), proving the deploy topology (Lambda + API GW + DDB + SES) wires up. | Real HTTPS against `beta.getlift.md`. | `validator/scripts/smoke-flow-live.sh` (planned) | Deferred |
 | **3 — iOS vs. beta** | The iOS client driving the live beta backend, proving the Swift client and the server agree on the wire format. | iOS UI/integration test against beta. | iOS test target (planned) | Deferred |
 
 ### Layer 1 — HTTP flow integration (`flow.test.ts`)
@@ -111,7 +111,7 @@ validate (Vitest: typecheck + npm test)
   → e2e-local   (Playwright vs local DDB+Mailpit stack)   ← gates prod
   → deploy-beta
   → smoke-beta
-  → e2e-beta    (Playwright vs https://beta.liftmark.app)  ← gates prod
+  → e2e-beta    (Playwright vs https://beta.getlift.md)    ← gates prod
   → deploy-prod
 ```
 
@@ -161,7 +161,7 @@ those are visible to an in-process `app.request()`.
 | # | Topology delta it guards | Why Vitest can't see it | Where it lives | Mode |
 |---|--------------------------|-------------------------|----------------|------|
 | a | `lmwf_refresh` Set-Cookie carries `HttpOnly`, `Secure`, `SameSite=Strict`, `Path=/v1/auth` **over the wire** | In-process pins the `setCookie()` *call*; APIGW (multiValueHeaders) / CloudFront can strip/fold/rewrite the actual header bytes | `e2e/tests/auth-session.spec.ts` | both (esp. e2e-beta) |
-| b | Verify/reset **email link host** == env `appBaseUrl` (beta→`beta.liftmark.app`) | The host comes from the Lambda's `LMWF_ENV`; a misconfigured env builds wrong-host links. Only readable where the email body is — Mailpit = local mode | `auth-signup-verify.spec.ts` (verify) + `auth-forgot-reset.spec.ts` (reset) | **local only** (guarded on `getMode()`) |
+| b | Verify/reset **email link host** == env `appBaseUrl` (beta→`beta.getlift.md`) | The host comes from the Lambda's `LMWF_ENV`; a misconfigured env builds wrong-host links. Only readable where the email body is — Mailpit = local mode | `auth-signup-verify.spec.ts` (verify) + `auth-forgot-reset.spec.ts` (reset) | **local only** (guarded on `getMode()`) |
 | c | A minted PAT authenticates a live `GET /v1/workouts`, then 401s after revoke | Proves the deployed APIGW authorizer + scope middleware are actually wired in front of the route and honour revocation over the wire — not just the in-process middleware logic | `e2e/tests/pat-live-auth.spec.ts` | both (esp. e2e-beta) |
 | d | Real-SES signup → 201 (SES credentials resolve on the deployed stack) | The signup handler's email send is the last step before 201 and rolls back to 503 if it throws (`password.ts:282-325`); a 201 for the SES-verified address therefore proves SES creds resolve — invisible in-process where SMTP is Mailpit | `auth-signup-verify.spec.ts` (the existing signup POST, now explicitly asserted) | real send only in remote/beta |
 
@@ -178,7 +178,7 @@ test that gates prod:
 
 #### Beta-vs-prod SES caveat (honest scope of (d))
 
-e2e-beta runs against `beta.liftmark.app`, so test (d) proves **beta** SES
+e2e-beta runs against `beta.getlift.md`, so test (d) proves **beta** SES
 credentials resolve — NOT prod. The prod stack uses a separate SES identity
 and IAM role; a prod-only SES-credential regression (the original #137
 shape, if it recurred on the prod stack) would NOT be caught by (d). Closing
@@ -282,7 +282,7 @@ The suite runs in three modes, selected by env var `LMWF_E2E_MODE`:
   Verification + reset tokens are extracted from Mailpit's REST API at
   `http://localhost:8025/api/v1/messages`.
 - `remote` — used post-Beta-deploy. The suite runs against the public
-  beta hostname (`https://beta.liftmark.app`). Email is real SES — the
+  beta hostname (`https://beta.getlift.md`). Email is real SES — the
   suite calls the test-only `/v1/__test__/mint-token` endpoint
   (see below) to obtain verification + reset tokens without inspecting
   email.
@@ -376,8 +376,9 @@ spec, schemas, AASA). The entire `liftmark.app` family (`liftmark.app`, its lega
 follow AASA redirects, old installs pinned there). See "Domains & Hosting
 Topology" in `lmwf-validator.md`. This topology is a prod-only deploy concern, so
 it is verified only in `remote:prod` mode and is **not** wired into the pipeline
-(beta still serves from `beta.liftmark.app` — its `beta.getlift.md` cutover is a
-tracked GH #248 follow-up). These checks are also enforced post-deploy by the
+(beta's equivalent redirect topology — `beta.liftmark.app` → `beta.getlift.md`,
+live since the GH #248 beta cutover — is exercised separately). These checks are
+also enforced post-deploy by the
 `Verify canonical redirect topology` step in `validator-ci.yml`.
 
 These are HTTP-level checks (status / `Location` / `Content-Type`), run
@@ -404,7 +405,7 @@ with redirect-following disabled so the redirect itself is observable:
   at the downloaded website bundle, runs Playwright. Required check on
   the PR. No deploy happens without this green.
 - `e2e-beta` — runs on `push` only. Needs: `smoke-beta`. Executes the
-  same Playwright spec set against `https://beta.liftmark.app` with
+  same Playwright spec set against `https://beta.getlift.md` with
   `LMWF_E2E_MODE=remote` and the shared secret from GHA secrets. Blocks
   `deploy-prod`.
 

--- a/validator/e2e/helpers/env.ts
+++ b/validator/e2e/helpers/env.ts
@@ -20,7 +20,7 @@ export function getBaseUrl(): string {
   const explicit = process.env.LMWF_E2E_BASE_URL;
   if (explicit) return explicit.replace(/\/$/, '');
   return getMode() === 'remote'
-    ? 'https://beta.liftmark.app'
+    ? 'https://beta.getlift.md'
     : 'http://localhost:3001';
 }
 
@@ -48,13 +48,13 @@ export function getMailpitUrl(): string {
  * The e2e process doesn't share the server's LMWF_ENV directly, so this is
  * configurable via LMWF_E2E_EXPECTED_EMAIL_HOST. The default matches the
  * local stack, which `scripts/e2e-local.sh` boots with LMWF_ENV=beta →
- * links resolve to beta.liftmark.app.
+ * links resolve to beta.getlift.md (appBaseUrl's beta fallback, GH #248).
  */
 export function expectedEmailLinkHost(): string {
   const explicit = process.env.LMWF_E2E_EXPECTED_EMAIL_HOST;
   if (explicit) return explicit;
   // The local stack runs with LMWF_ENV=beta (see scripts/e2e-local.sh).
-  return 'beta.liftmark.app';
+  return 'beta.getlift.md';
 }
 
 /**

--- a/validator/e2e/playwright.config.ts
+++ b/validator/e2e/playwright.config.ts
@@ -6,7 +6,7 @@ import { defineConfig, devices } from '@playwright/test';
  * Modes (env LMWF_E2E_MODE):
  *   - local  → baseURL http://localhost:3001 (validator with WEBSITE_DIST,
  *              DDB Local, Mailpit). Pre-merge in CI + local dev.
- *   - remote → baseURL https://beta.liftmark.app, uses /v1/__test__
+ *   - remote → baseURL https://beta.getlift.md, uses /v1/__test__
  *              endpoint for token mint. Post-Beta-deploy gate.
  *
  * Override baseURL via LMWF_E2E_BASE_URL if needed (e.g. for ad-hoc
@@ -16,7 +16,7 @@ import { defineConfig, devices } from '@playwright/test';
  */
 const mode = (process.env.LMWF_E2E_MODE ?? 'local') as 'local' | 'remote';
 const defaultBaseUrl =
-  mode === 'remote' ? 'https://beta.liftmark.app' : 'http://localhost:3001';
+  mode === 'remote' ? 'https://beta.getlift.md' : 'http://localhost:3001';
 const baseURL = process.env.LMWF_E2E_BASE_URL ?? defaultBaseUrl;
 
 const isCI = Boolean(process.env.CI);

--- a/validator/scripts/smoke-test-live.sh
+++ b/validator/scripts/smoke-test-live.sh
@@ -7,8 +7,8 @@
 #   scripts/smoke-test-live.sh <base_url> [expected_commit]
 #
 # Examples:
-#   scripts/smoke-test-live.sh https://beta.liftmark.app
-#   scripts/smoke-test-live.sh https://beta.liftmark.app $(git rev-parse HEAD)
+#   scripts/smoke-test-live.sh https://beta.getlift.md
+#   scripts/smoke-test-live.sh https://beta.getlift.md $(git rev-parse HEAD)
 #
 # Exits non-zero if:
 #   - expected_commit was supplied and /version reports a different commit

--- a/validator/src/routes/auth/password.ts
+++ b/validator/src/routes/auth/password.ts
@@ -151,18 +151,17 @@ function classifyEmailError(err: unknown): string {
 
 function appBaseUrl(): string {
   // The deploy sets APP_BASE_URL to the env's serving origin (CDK
-  // servingWebOrigin), so the host tracks the beta.getlift.md cutover phase
-  // automatically — beta.liftmark.app until 'live', beta.getlift.md after — and
-  // prod stays canonical getlift.md. Both serve the API (/v1/*) and account
-  // pages (/account/*) directly, no redirect hop (GH #248).
+  // servingWebOrigin) — beta.getlift.md in beta, getlift.md in prod. Both serve
+  // the API (/v1/*) and account pages (/account/*) directly, no redirect hop
+  // (GH #248; the beta cutover to beta.getlift.md is live).
   //
-  // Fallback (env var unset — older deploy / local dev): the previous
-  // LMWF_ENV-keyed hardcode. In local dev the link still points at the public
-  // host, fine for Mailpit inspection.
+  // Fallback (env var unset — older deploy / local dev): the canonical host per
+  // LMWF_ENV. In local dev the link still points at the public host, fine for
+  // Mailpit inspection.
   const fromEnv = process.env.APP_BASE_URL;
   if (fromEnv && fromEnv.length > 0) return fromEnv;
   const env = process.env.LMWF_ENV;
-  return env === 'beta' ? 'https://beta.liftmark.app' : 'https://getlift.md';
+  return env === 'beta' ? 'https://beta.getlift.md' : 'https://getlift.md';
 }
 
 async function sendVerificationEmail(


### PR DESCRIPTION
## What

The GH #248 **beta cutover is live** — `beta.getlift.md` serves everything and `beta.liftmark.app` is now 301/308 redirect-only (verified against live DNS + HTTPS). The CDK/backend already compute the serving origin from `betaCutoverPhase: 'live'`, but several **client-side surfaces still hardcoded the legacy `beta.liftmark.app`** and worked only by leaning on the redirect hop. This points them at the canonical host directly.

## Changes

- **iOS** — `APIClient` beta API base + `LoginView` beta account-web base → `beta.getlift.md`
- **validator** — `appBaseUrl()` beta fallback → `beta.getlift.md` (email links); e2e remote baseURL + expected-email-host defaults (`env.ts`, `playwright.config.ts`) and `smoke-test-live.sh` usage examples → `beta.getlift.md`
- **spec** — mark the #248 beta cutover complete in `lmwf-validator.md`; refresh the stale "runs against `beta.liftmark.app`" references in `validator-e2e.md`

## Deliberately NOT changed

- **CDK `config.ts` / infra** — the beta env's `domainName` intentionally stays the legacy apex (`beta.liftmark.app`); the canonical host is derived from `betaCutoverPhase: 'live'`. This matches the already-deployed model.
- **Redirect-topology descriptions** in the specs (e.g. "`beta.liftmark.app` redirects to it") — still accurate, left as-is.

## Verification

- validator: `typecheck` clean + `npm test` → **190 passed / 219 skipped** (skips are live-integration, gated on `DDB_ENDPOINT`)
- iOS: `xcodebuild -scheme LiftMark ... build` → **BUILD SUCCEEDED**
- The local e2e email-host assertion stays internally consistent: `appBaseUrl()`'s beta fallback and `expectedEmailLinkHost()`'s default both move to `beta.getlift.md` together (Mailpit doesn't care about the host).

Progresses #248 (client-side leftover of the beta cutover).

🤖 Generated with [Claude Code](https://claude.com/claude-code)