### PR TITLE
ci(nightly): auto-close the tracking issue on a green run

### DIFF
--- a/.github/workflows/swift-nightly.yml
+++ b/.github/workflows/swift-nightly.yml
@@ -4,7 +4,7 @@ name: '[iOS] Nightly UI suite'
 # order-dependent flake (issue #106), so it is kept OUT of the PR gate. The PR
 # gate runs the Smoke test plan (unit + render checks); this workflow runs the
 # Full test plan nightly against main. Failures open/append a tracking issue so
-# a red nightly is never silently ignored.
+# a red nightly is never silently ignored; a later green run auto-closes it.
 #
 # It also feeds the Pre-flight promotion gate. The nightly is time-triggered, not
 # build-triggered, so it can't certify a build as "passed" — but it CAN flag code
@@ -199,5 +199,41 @@ jobs:
                 title: 'Nightly UI suite failing',
                 labels: [label],
                 body,
+              });
+            }
+
+      # Mirror of the step above, and of the promotion-tag unblock. The suite
+      # runs without auto-retry on purpose (issue #106), so one flaky test opens
+      # a ticket even though a manual re-run — or the next night — usually goes
+      # green. Without an auto-close, those tickets pile up and a green run never
+      # clears them. Gated on the test step's own outcome (not success()) so an
+      # infra failure on a night the tests passed doesn't leave a ticket open.
+      - name: Close stale failure issue
+        if: always() && steps.run_suite.outcome == 'success'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const label = 'nightly-failure';
+            const sha = context.sha.substring(0, 7);
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: label,
+            });
+            for (const issue of existing.data) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: `Nightly Full UI suite green on \`${sha}\` — auto-closing.\n\n[View run](${runUrl})`,
+              });
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+                state_reason: 'completed',
               });
             }


### PR DESCRIPTION
## Problem

The nightly UI suite runs **without auto-retry on purpose** (issue #106 — flakes should surface, not be masked). The consequence: a single flaky test opens a `nightly-failure` tracking issue even though a manual re-run, or the next night, usually goes green.

The workflow opened that issue on `failure()` but had **no step to close it**. So stale flake tickets accumulate and a passing run never clears them.

Concrete example: **#298** was auto-filed on `27821455781` attempt 1, which failed on two known flakes (`testActiveWorkout`, `testImportSimple` — both timeouts). Attempt 2 (manual re-run) passed, and the last three nightlies (06-19/06-20/06-21) are all green — yet #298 is still open.

Note: there is no in-workflow auto-rerun; the green attempt-2 was a manual "re-run failed jobs". So the fix is auto-close-on-green (covers both a re-run and the next nightly) rather than reintroducing the deliberately-omitted `-retry-tests-on-failure`.

## Change

Add a **"Close stale failure issue"** step that mirrors the existing promotion-tag *unblock* step: on a green test run, comment on and close any open `nightly-failure` issue.

- Gated on `steps.run_suite.outcome == 'success'` (not `success()`), consistent with the block/unblock-promotion steps — so an infra failure on a night the tests actually passed doesn't spuriously leave a ticket open.
- Preserves the no-auto-retry behavior; only the issue lifecycle changes.

## Verification

- YAML validated (parses clean).
- Logic mirrors the already-proven block/unblock-promotion-tag pattern in the same job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)