### PR TITLE
docs: add GitHub CI status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # LiftMark
 
+[![iOS Release Pipeline](https://github.com/vfilby/lift.md/actions/workflows/release-pipeline.yml/badge.svg?branch=main)](https://github.com/vfilby/lift.md/actions/workflows/release-pipeline.yml)
+[![iOS Nightly UI Suite](https://github.com/vfilby/lift.md/actions/workflows/swift-nightly.yml/badge.svg?branch=main)](https://github.com/vfilby/lift.md/actions/workflows/swift-nightly.yml)
+[![Validator](https://github.com/vfilby/lift.md/actions/workflows/validator-ci.yml/badge.svg?branch=main)](https://github.com/vfilby/lift.md/actions/workflows/validator-ci.yml)
+
 Public beta: https://testflight.apple.com/join/u8EJFzYu
 
 I have tried many different fitness apps and programs to help me create and track workouts but they tend to be limited in what they allow you to do and they make it difficult to import of export workouts.  I have spent nearly as much time "creating" or "tweaking" workouts as I have actually working out in some cases. I want something that gives me all the benefits of tracking without the tedium.


### PR DESCRIPTION
## What

Adds GitHub Actions status badges to the top of the README for the three workflows that run against `main`:

- **iOS Release Pipeline** (`release-pipeline.yml`)
- **iOS Nightly UI Suite** (`swift-nightly.yml`)
- **Validator** (`validator-ci.yml`)

All pinned to `?branch=main` so they reflect main-branch health rather than an arbitrary PR run. All three currently render **passing**.

## Not included

Dynamic **beta / pre-flight version** badges were scoped out for now. Beta build numbers are derivable from `deploy/*` git tags, but pre-flight lives only in App Store Connect (the `promote-preflight` workflow promotes inside ASC with no git footprint), so a truly dynamic pre-flight badge needs a JSON endpoint fed by the ASC API. Deferred pending that decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)