### PR TITLE
test(e2e): skip app.terminate() when the app isn't running

### DIFF
--- a/e2e-spec/runners/xcuitest/ActionAdapter.swift
+++ b/e2e-spec/runners/xcuitest/ActionAdapter.swift
@@ -51,6 +51,21 @@ class ActionAdapter {
         self.fixturesPath = fixturesPath
     }
 
+    /// Terminate the app only when there is a live process to terminate.
+    ///
+    /// Under iOS 26 memory pressure the app host can be SIGKILL'd before a
+    /// `newInstance` relaunch runs. Calling `XCUIApplication.terminate()` on an
+    /// already-dead process makes XCTest record a "Failed to terminate …:0"
+    /// failure (pid resolves to 0). `terminate()` is non-throwing, so a tryCatch
+    /// can't swallow it — gating on `app.state` is the only way to avoid the
+    /// spurious failure. Skipping the call when not running is harmless: the goal
+    /// of terminate here is purely to guarantee a fresh process before relaunch.
+    private func terminateIfRunning() {
+        if app.state != .notRunning {
+            app.terminate()
+        }
+    }
+
     // MARK: - Public
 
     func execute(_ action: TestAction) throws {
@@ -644,7 +659,7 @@ class ActionAdapter {
 
     private func executeLaunchApp(_ action: TestAction) throws {
         if action.newInstance == true {
-            app.terminate()
+            terminateIfRunning()
         }
         // Build launch arguments from scratch each time
         var args: [String] = []
@@ -698,7 +713,7 @@ class ActionAdapter {
         // path issues where the test runner's temp directory differs from the
         // app's sandboxed container (which causes validateDeepLinkPath to reject
         // the path).
-        app.terminate()
+        terminateIfRunning()
         if let content = sharedFileContent,
            url.contains("liftmark://") {
             let base64 = Data(content.utf8).base64EncodedString()


### PR DESCRIPTION
## Why

Nightly Full ([run 27948527011](https://github.com/vfilby/lift.md/actions/runs/27948527011)) failed on `testActiveWorkout`:

```
✗ testActiveWorkout, Failed to terminate com.eff3.liftmark.native-ios.dev:20620: Failed to terminate com.eff3.liftmark.native-ios.dev:0
  ActionAdapter.swift  (newInstance == true { app.terminate() })
```

The pid resolving to `:0` means the app process was **already gone** when `terminate()` ran. Under iOS 26 memory pressure the test host can be SIGKILL'd before a `newInstance` relaunch's terminate runs (the file already documents this SIGKILL pressure for the onboarding probe). `XCUIApplication.terminate()` is non-throwing, so XCTest records the failure directly on the test — a `tryCatch` action can't swallow it.

This is a simulator-teardown flake, not a product regression: all 19 other UI tests passed, and `testActiveWorkout` is a [known recurring flake](#).

## Fix

Add a `terminateIfRunning()` helper that gates `terminate()` on `app.state != .notRunning`, and use it at both call sites (`executeLaunchApp` newInstance + `executeOpenURL`). Skipping the call when the app isn't running is harmless — terminate here only exists to guarantee a fresh process before relaunch.

## Verification

- `xcodebuild build-for-testing` succeeds
- `testActiveWorkout` passes locally (iPhone 17, iOS 26.5): `Executed 1 test, with 0 failures`

🤖 Generated with [Claude Code](https://claude.com/claude-code)