### PR TITLE
test(e2e): harden workout-detail nav against dropped-tap flake

### DIFF
--- a/e2e-spec/scenarios/active-workout-focused.yaml
+++ b/e2e-spec/scenarios/active-workout-focused.yaml
@@ -40,11 +40,29 @@ tests:
   # Issue 7: Workout detail must display weight values from imported plan
   - name: "workout detail shows exercise weights after import"
     steps:
-      - action: tapText
-        text: "Active Workout Test"
+      # The workout-row → detail nav is a dropped-tap flake point (nightly
+      # timeout 2026-06-26): the tap on the plan name silently fails to
+      # register, so the detail screen never pushes and the wait times out on
+      # nothing. Mirror the Start- and Finish-step mitigations below — probe
+      # non-asserting, re-tap on a miss, then assert for real so a genuine nav
+      # regression still surfaces.
+      - action: tryCatch
+        try:
+          - action: tapText
+            text: "Active Workout Test"
+          # Non-asserting probe; if absent, fall to the retry.
+          - action: waitFor
+            target: "workout-detail-view"
+            timeout: 12000
+        catch:
+          # Retry: a dropped tap left us on the workout list. Re-tap the plan
+          # name; the asserting waitFor below then confirms navigation.
+          - action: tapText
+            text: "Active Workout Test"
+      # Asserting waitFor — if nav genuinely regressed, this still fails.
       - action: waitFor
         target: "workout-detail-view"
-        timeout: 5000
+        timeout: 10000
       # Verify exercise name is shown
       - action: waitForText
         text: "Bench Press"


### PR DESCRIPTION
## Why

The nightly Full UI suite went red two nights running (2026-06-25, 2026-06-26) with **no app source changes** between the last green and the failures — only dependency bumps. The two runs failed on *different* tests at *different* points, and the failing tests **swapped** pass/fail between runs:

| Test | Run 1 (06-25) | Run 2 (06-26 re-run) |
|---|---|---|
| `testHistoryFlow` | ✗ ("OK" timeout) | ✓ (82.8s) |
| `testActiveWorkout` | ✓ | ✗ (workout-detail-view timeout) |

That signature is a flake, not a regression — same code/fixtures, the failure just lands on whichever test loses the slow-shared-runner lottery.

## What

Run 2's failure point — `tapText "Active Workout Test"` → `waitFor workout-detail-view` in `active-workout-focused.yaml` — is a **dropped-tap** nav: the tap silently fails to register, the detail screen never pushes, and the wait times out on nothing.

This is the exact flake class already mitigated for the **Start-nav** (issue #296) and **Finish** steps in the *same scenario file*. The detail-nav tap was the one unprotected sibling. This PR applies the identical probe-and-retry pattern:

- `tap` + non-asserting probe inside a `tryCatch`
- re-tap on a miss (dropped tap leaves us on the workout list)
- trailing **asserting** `waitFor` so a genuine navigation regression still fails the test

## Verification

- `testActiveWorkout` passes locally with the hardened scenario (72.9s).
- No app code touched — test-harness robustness only.
- Scope kept tight to the one observed unprotected nav point, matching the repo's incremental-hardening practice (run 1's import→"OK" flake is rarer and shares setupOnce across ~6 scenarios; left for a targeted fix if it recurs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)