### PR TITLE
test(ios): harden replaceText against dropped ⌘A modifier flake

### DIFF
--- a/e2e-spec/runners/xcuitest/ActionAdapter.swift
+++ b/e2e-spec/runners/xcuitest/ActionAdapter.swift
@@ -476,13 +476,43 @@ class ActionAdapter {
             throw ActionError.missingParam("value or fixture", "replaceText")
         }
 
+        robustReplaceText(el, with: textValue)
+    }
+
+    /// Replace a field's contents via hardware-keyboard select-all + type,
+    /// defending against the XCUITest flake that drops the modifier on the
+    /// first synthesized keystroke after focus.
+    ///
+    /// We use hardware-keyboard shortcuts rather than the UIKit edit menu: on
+    /// iOS 26 the "Select All" / "Paste" menu items don't reliably appear on
+    /// SwiftUI TextEditors via long-press, and the repeated menu probes cascade
+    /// into the accessibility-snapshot SIGKILL.
+    ///
+    /// The hazard: if the keyboard isn't fully up when `typeKey("a", .command)`
+    /// fires, XCUITest occasionally loses the ⌘ modifier and types a literal
+    /// "a". `typeText` then appends the real content, leaving `a# Push Day…` —
+    /// which fails LMWF header validation, disables the Import button, and
+    /// strands the import (observed in nightly testHistoryExport/testPlanExport
+    /// as "Timed out waiting for text 'OK'"). We wait for the keyboard to
+    /// settle, then verify the field holds exactly the intended text and retry
+    /// once on mismatch.
+    func robustReplaceText(_ el: XCUIElement, with text: String) {
         el.tap()
-        // Use hardware-keyboard shortcuts rather than the UIKit edit menu.
-        // On iOS 26 the "Select All" / "Paste" menu items don't reliably
-        // appear on SwiftUI TextEditors via long-press, and the repeated
-        // menu probes cascade into the accessibility-snapshot SIGKILL.
-        el.typeKey("a", modifierFlags: .command)
-        el.typeText(textValue)
+        // Let the keyboard come up so the first keystroke keeps its modifier.
+        _ = app.keyboards.firstMatch.waitForExistence(timeout: UITestTiming.scaled(5))
+
+        for attempt in 0..<2 {
+            el.typeKey("a", modifierFlags: .command)
+            el.typeText(text)
+            if (el.value as? String) == text { return }
+
+            // Mismatch — typically a dropped ⌘ left a stray leading char.
+            // Clear the field and try once more before giving up.
+            NSLog("[robustReplaceText] field value mismatch on attempt \(attempt + 1); clearing and retrying")
+            el.tap()
+            el.typeKey("a", modifierFlags: .command)
+            el.typeText(XCUIKeyboardKey.delete.rawValue)
+        }
     }
 
     private func executeTypeText(_ action: TestAction) throws {
@@ -909,10 +939,8 @@ class ActionAdapter {
             return
         }
 
-        // Hardware-keyboard select-all + typeText. See executeReplaceText for why.
-        inputMarkdown.tap()
-        inputMarkdown.typeKey("a", modifierFlags: .command)
-        inputMarkdown.typeText(content)
+        // Select-all + type with the dropped-modifier guard. See robustReplaceText.
+        robustReplaceText(inputMarkdown, with: content)
 
         guard let importBtn = waitForAnyElement(byId: "button-import", timeout: 5) else {
             XCTFail("button-import not found for runFixture")


### PR DESCRIPTION
## Summary

Fixes the nightly UI flake where `testHistoryExport` and `testPlanExport` intermittently fail with **`Timed out waiting for text 'OK'`** (observed in nightly run [28285844542](https://github.com/vfilby/lift.md/actions/runs/28285844542)).

### Root cause

The failure is in each test's `setupOnce` **import** step, not the export step. The shared YAML runner's `replaceText` did:

```swift
el.tap()
el.typeKey("a", modifierFlags: .command)  // ⌘A select-all, first keystroke after focus
el.typeText(textValue)
```

XCUITest occasionally **drops the ⌘ modifier on the first synthesized keystroke after focus**, so `⌘A` is typed as a literal `a`. `typeText` then appends the real markdown, leaving the field as `a# Test Workout…`. The corrupted `a#` first line fails LMWF header validation → the **Import button stays `Disabled`** → the tap is a no-op → no success alert → timeout waiting for "OK".

Confirmed from the failing run's xcresult UI hierarchy: `input-markdown` value = `a# Test Workout`, `button-import` = `Disabled`, import modal still open. Both export tests share the `replaceText` helper, which is why they failed together while sibling import tests (`import-simple`, `import-flow-robust`) passed the same step in the same run.

### Fix

Extract `robustReplaceText(_:with:)`:
- wait for `app.keyboards.firstMatch` before sending ⌘A so the first keystroke keeps its modifier,
- verify the field holds exactly the intended text and retry once on mismatch (clearing the stray char).

Both `executeReplaceText` and the `runFixture` twin now route through it.

### Verification

`testHistoryExport` + `testPlanExport` pass on iPhone 17 Pro / iOS 26.5:

```
Test Case '-[LiftMarkUITests testHistoryExport]' passed (66.925 seconds).
Test Case '-[LiftMarkUITests testPlanExport]' passed (51.305 seconds).
** TEST SUCCEEDED **
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)