### PR TITLE
ci(validator): run the Vitest integration tier in CI so it gates prod (#137)

### DIFF
--- a/.github/workflows/validator-ci.yml
+++ b/.github/workflows/validator-ci.yml
@@ -83,6 +83,84 @@ jobs:
         if: needs.changes.outputs.validator == 'true'
         run: npm run ${{ matrix.check }}
 
+  # ── Stage 1.5: integration ─────────────────────────────────────────────
+  # Vitest integration tier (tests/{repositories,middleware,routes}/** +
+  # flow.test.ts) against a live DynamoDB Local + Mailpit stack. These tests
+  # gate on DDB_ENDPOINT/SMTP_HOST and self-skip under the plain
+  # `validate (test)` job (which exports neither) — so WITHOUT this job the
+  # ~219 integration tests (every IDOR / scope / token-rotation / dedup /
+  # tier-gate contract, plus the Layer 1 full-flow suite) run NOWHERE in CI
+  # and gate nothing. This job is what makes "Vitest hard-gates prod" true.
+  # It is lighter than e2e-local: the suite drives the Hono app in-process
+  # via app.request(), so it needs neither the website bundle nor a running
+  # server nor Playwright — only DDB Local + Mailpit. Runs on PR + push.
+  # See spec/services/validator-e2e.md (Layer 1 + Pipeline integration).
+  integration:
+    name: integration
+    needs: changes
+    if: ${{ needs.changes.outputs.validator == 'true' }}
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: validator
+    # NOTE: do NOT use GHA `services:` for DynamoDB Local — the default image
+    # command runs WITHOUT `-sharedDb`, so the bootstrap writes tables into
+    # one credential-scoped namespace and the test client reads from another
+    # (ResourceNotFoundException). The repo docker-compose.yml passes
+    # `-sharedDb`; reuse it, exactly as e2e-local does.
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: validator/package-lock.json
+      - name: Install validator deps
+        run: npm ci --no-audit --no-fund
+      - name: Bring up DDB Local + Mailpit
+        run: |
+          set -euo pipefail
+          docker compose up -d
+          echo "==> waiting for DynamoDB Local"
+          for i in $(seq 1 60); do
+            if docker compose ps dynamodb-local --format json 2>/dev/null | grep -q '"Health":"healthy"'; then break; fi
+            sleep 0.5
+          done
+          echo "==> waiting for Mailpit"
+          for i in $(seq 1 60); do
+            if docker compose ps mailpit --format json 2>/dev/null | grep -q '"Health":"healthy"'; then break; fi
+            sleep 0.5
+          done
+      - name: Bootstrap DynamoDB tables
+        run: npx tsx scripts/ddb-local-bootstrap.ts
+        env:
+          DDB_ENDPOINT: http://localhost:8000
+          AWS_REGION: us-west-2
+          AWS_ACCESS_KEY_ID: local
+          AWS_SECRET_ACCESS_KEY: local
+      - name: Run Vitest integration suite (full, against live stack)
+        run: npx vitest run
+        env:
+          DDB_ENDPOINT: http://localhost:8000
+          AWS_REGION: us-west-2
+          AWS_ACCESS_KEY_ID: local
+          AWS_SECRET_ACCESS_KEY: local
+          DDB_TABLE_USERS: lmwf-local-users
+          DDB_TABLE_IDENTITIES: lmwf-local-identities
+          DDB_TABLE_PAT_TOKENS: lmwf-local-pat_tokens
+          DDB_TABLE_ENTITLEMENTS: lmwf-local-entitlements
+          DDB_TABLE_REFRESH_TOKENS: lmwf-local-refresh_tokens
+          DDB_TABLE_WORKOUT_INBOX: lmwf-local-workout_inbox
+          DDB_TABLE_WORKOUT_OUTBOX: lmwf-local-workout_outbox
+          SMTP_HOST: localhost
+          SMTP_PORT: '1025'
+          SMTP_FROM: noreply@local.test
+          JWT_SECRET: ci-integration-jwt-secret-do-not-use-in-prod
+          MAILPIT_API: http://localhost:8025
+      - name: Dump container logs on failure
+        if: failure()
+        run: docker compose logs --no-color || true
+
   # ── Stage 2: build ─────────────────────────────────────────────────────
   # Produces validator/dist/ and website/dist/ and uploads both as artifacts
   # so deploy jobs deploy exactly what was tested. CDK's BucketDeployment
@@ -266,8 +344,8 @@ jobs:
   # (AWS_ACCESS_KEY_ID/SECRET) per environment.
   deploy-beta:
     name: deploy-beta
-    needs: [changes, build, e2e-local]
-    if: ${{ github.event_name == 'push' && needs.changes.outputs.validator == 'true' && needs.build.result == 'success' && needs['e2e-local'].result == 'success' }}
+    needs: [changes, build, e2e-local, integration]
+    if: ${{ github.event_name == 'push' && needs.changes.outputs.validator == 'true' && needs.build.result == 'success' && needs['e2e-local'].result == 'success' && needs.integration.result == 'success' }}
     runs-on: ubuntu-latest
     environment:
       name: beta

--- a/spec/services/validator-e2e.md
+++ b/spec/services/validator-e2e.md
@@ -75,14 +75,27 @@ DDB_ENDPOINT=http://localhost:8000 \
 ```
 
 The suite is gated on `DDB_ENDPOINT` + `SMTP_HOST` (the same `describe.skip`
-pattern as every other live-integration test). Under plain `npm test` —
-including the CI `validate (test)` job, which exports neither var — the
-suite self-skips. It therefore adds **no** new CI job and **no** new
-service dependency: it runs under the existing `npm test` whenever a
-developer has the local stack up, and is a no-op everywhere else. It uses
-a unique email per run and cleans up the outbox row + PAT it creates, so
-it is robust against the sequential / shared-state Vitest config
-(`fileParallelism: false`).
+pattern as every other live-integration test). This gate is shared by the
+**entire** integration tier — every test under `tests/repositories/`,
+`tests/middleware/`, `tests/routes/`, plus `flow.test.ts` itself — so the
+gate decides whether the whole tier runs, not just Layer 1.
+
+That gate is satisfied in CI by a dedicated **`integration`** job (see
+*Pipeline integration* below) that brings up DDB Local + Mailpit and exports
+`DDB_ENDPOINT` + `SMTP_HOST` before `npx vitest run`. This is **load-bearing**:
+the plain `validate (test)` job exports neither var, so under it the
+integration tier self-skips — `validate (test)` alone runs only the ~190
+pure-unit tests and silently skips the ~219 integration tests (54% of the
+suite), including every IDOR / scope / token-rotation / dedup / tier-gate
+contract the *Division of labour* section below names as Vitest-owned.
+Without the `integration` job those contracts would gate **nothing**,
+contradicting the "Vitest hard-gates prod" guarantee. The `integration` job
+is what makes that guarantee true.
+
+Locally a developer gets the same coverage by running the suite with the
+stack up (`make dev-up` first). The suite uses a unique email per run and
+cleans up the outbox row + PAT it creates, so it is robust against the
+sequential / shared-state Vitest config (`fileParallelism: false`).
 
 ## Purpose
 
@@ -106,20 +119,30 @@ The validator deploy pipeline (`.github/workflows/validator-ci.yml`) is a
 linear chain, each stage a required predecessor of the next:
 
 ```
-validate (Vitest: typecheck + npm test)
+validate     (typecheck + unit-only `npm test`, no stack)
+integration  (Vitest FULL suite vs local DDB+Mailpit stack)  ← gates prod
   → build
-  → e2e-local   (Playwright vs local DDB+Mailpit stack)   ← gates prod
+  → e2e-local   (Playwright vs local DDB+Mailpit stack)      ← gates prod
   → deploy-beta
   → smoke-beta
-  → e2e-beta    (Playwright vs https://beta.getlift.md)    ← gates prod
+  → e2e-beta    (Playwright vs https://beta.getlift.md)       ← gates prod
   → deploy-prod
 ```
 
 `deploy-prod` needs `smoke-beta` AND `e2e-beta`; `deploy-beta` needs
-`e2e-local`; `e2e-local`/`e2e-beta` both need `build`, which needs
-`validate`. **Therefore Vitest, e2e-local, AND e2e-beta all hard-gate
-prod.** A contract pinned by any one of them cannot regress into a prod
-deploy. This is the load-bearing fact behind the division of labour below.
+`e2e-local` AND `integration`; `e2e-local`/`e2e-beta` both need `build`,
+which needs `validate`; `integration` needs only `changes` and runs in
+parallel with `build`. **Therefore Vitest (the full suite, via
+`integration`), e2e-local, AND e2e-beta all hard-gate prod.** A contract
+pinned by any one of them cannot regress into a prod deploy.
+
+This is load-bearing and easy to get wrong: the Vitest contracts hard-gate
+prod **only because** the `integration` job runs them against a live
+DDB+Mailpit stack. The `validate (test)` job runs the same `npx vitest run`
+without the stack, so it exercises only the ~190 pure-unit tests and skips
+the ~219 integration tests — it is a fast smoke, **not** the gate. The gate
+is `integration`. This is the load-bearing fact behind the division of
+labour below.
 
 ### Division of labour: Vitest owns logic, e2e owns topology
 
@@ -399,6 +422,17 @@ with redirect-following disabled so the redirect itself is observable:
 
 `validator-ci.yml`:
 
+- `integration` — runs on `pull_request` AND `push`. Needs: `changes`
+  (runs in parallel with `build`; does not need the website/lambda
+  bundles — the suite drives the Hono app in-process via `app.request()`).
+  Stands up DynamoDB Local + Mailpit from the repo `docker-compose.yml`
+  (the same `-sharedDb` reuse as `e2e-local`, NOT GHA `services:`),
+  bootstraps tables, then runs `npx vitest run` with `DDB_ENDPOINT` +
+  `SMTP_HOST` + the `DDB_TABLE_*` env exported so the full integration
+  tier executes (~409 tests, 0 skipped). Required check on the PR and a
+  predecessor of `deploy-beta`, so the Vitest contracts (Layer 1 +
+  every route/repository/middleware test) hard-gate prod. Without this
+  job those tests self-skip and gate nothing — see *Layer 1* above.
 - `e2e-local` — runs on `pull_request` AND `push`. Needs: `build`.
   Stands up DynamoDB Local + Mailpit as GHA service containers,
   bootstraps tables, starts the validator with `WEBSITE_DIST` pointing


### PR DESCRIPTION
## Problem

The validator's route / repository / middleware tests — and the Layer 1 `flow.test.ts` full-journey suite — all gate on `DDB_ENDPOINT`/`SMTP_HOST` via `describe.skip`. No CI job set those vars or brought up DDB Local + Mailpit, so `npx vitest run` in the `validate (test)` job **silently skipped 219 of 409 tests (54%, 18 of 25 files)** — every IDOR / scope / token-rotation / dedup / tier-gate contract, plus the entire Layer 1 flow.

Proven by running vitest exactly as CI does (no env, no stack):

```
Tests  190 passed | 219 skipped (409)
```

This contradicted `spec/services/validator-e2e.md`, which claims *"Vitest … hard-gate[s] prod"* and names those very tests as the authoritative owners of those contracts. They gated **nothing** on the path to prod.

## Change

- **`.github/workflows/validator-ci.yml`** — new `integration` job: brings up DDB Local + Mailpit (reusing `e2e-local`'s proven `-sharedDb` docker pattern, **not** GHA `services:`), bootstraps tables, runs the full vitest suite with the stack env exported. Lighter than `e2e-local` (the suite drives the Hono app in-process via `app.request()`, so no website bundle / server boot / Playwright). Runs on PR + push, needs only `changes`. `deploy-beta` now requires it, so the Vitest contracts hard-gate prod.
- **`spec/services/validator-e2e.md`** — corrected the false "self-skips in CI / no new job" framing; documented the new job as what makes the Vitest-gates-prod guarantee true; updated the pipeline diagram + reasoning.

Addresses the "Validator integration on PR" item of #137. (Stripe webhook coverage is intentionally out of scope — no billing route exists yet; the spec defers it.)

## Verification

- Full suite with the stack up + env set: **409 passed, 0 skipped (~21s)**.
- `actionlint`: no structural errors (the one `SC2034` on the health-poll loop matches the existing `e2e-local` loops).

## Follow-up (needs repo admin)

After this job's first run on a PR, add the **`integration`** check to branch-protection required status checks so it actually blocks merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)