### PR TITLE
ci(ios): TestFlight "What to Test" notes + advance Pushover promote preview

### DIFF
--- a/.github/scripts/asc-client.mjs
+++ b/.github/scripts/asc-client.mjs
@@ -144,6 +144,35 @@ export async function attachBuildToGroup(buildId, groupId) {
   });
 }
 
+// TestFlight "What to Test" lives on betaBuildLocalizations (one row per locale
+// per build). Create the locale row if it doesn't exist yet, otherwise patch
+// whatsNew on the existing one.
+export async function setBetaBuildNotes(buildId, whatsNew, locale = 'en-US') {
+  const existing = await ascFetch(
+    `/builds/${buildId}/betaBuildLocalizations?fields[betaBuildLocalizations]=locale,whatsNew&limit=50`,
+  );
+  const row = (existing.data || []).find((l) => l.attributes?.locale === locale);
+  if (row) {
+    await ascFetch(`/betaBuildLocalizations/${row.id}`, {
+      method: 'PATCH',
+      body: JSON.stringify({
+        data: { type: 'betaBuildLocalizations', id: row.id, attributes: { whatsNew } },
+      }),
+    });
+  } else {
+    await ascFetch('/betaBuildLocalizations', {
+      method: 'POST',
+      body: JSON.stringify({
+        data: {
+          type: 'betaBuildLocalizations',
+          attributes: { locale, whatsNew },
+          relationships: { build: { data: { type: 'builds', id: buildId } } },
+        },
+      }),
+    });
+  }
+}
+
 export async function submitForBetaReview(buildId) {
   await ascFetch('/betaAppReviewSubmissions', {
     method: 'POST',

--- a/.github/scripts/changelog.mjs
+++ b/.github/scripts/changelog.mjs
@@ -1,0 +1,97 @@
+// Shared changelog generation for TestFlight "What to Test" notes.
+//
+// Builds notes deterministically from conventional-commit subjects — no LLM, no
+// extra secret. `feat:` commits become a "New" list, `fix:` commits a "Fixed"
+// list; trailing PR refs like "(#486)" are stripped for tester-facing prose.
+//
+// Two classes of commit are dropped as non-tester-facing: those whose scope is
+// in EXCLUDE_SCOPES (default "ci"), and those whose subject matches
+// EXCLUDE_PATTERN (default: test-infrastructure churn).
+//
+// Used by:
+//   set-beta-notes.mjs      — upload-time notes for a single build (range: prev release..HEAD)
+//   promote-preflight.mjs   — rollup notes at promotion (range: last Pre-flight..promoted build)
+//
+// Env (read once at import):
+//   EXCLUDE_SCOPES    — optional; comma-separated scopes to drop (default "ci")
+//   EXCLUDE_PATTERN   — optional; JS regex (case-insensitive) dropping matching subjects
+
+import { execSync } from 'node:child_process';
+
+export const CHAR_LIMIT = 4000; // App Store Connect whatsNew max length
+
+// Subjects that are real commits but not tester-facing: test scaffolding,
+// flaky-test stabilization, snapshot/UI/unit test repair, CI plumbing wording.
+const DEFAULT_EXCLUDE_PATTERN =
+  '\\b(ui|unit|snapshot)\\s+tests?\\b|\\bnightly\\b|\\bflaky\\b|waitfor\\w+|\\btest\\s+(suite|harness|plan)\\b';
+
+const excludeScopes = new Set(
+  (process.env.EXCLUDE_SCOPES ?? 'ci')
+    .split(',')
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean),
+);
+const excludePattern = new RegExp(process.env.EXCLUDE_PATTERN || DEFAULT_EXCLUDE_PATTERN, 'i');
+
+function capitalize(s) {
+  // Leave camelCase / brand tokens like iCloud, iPad, iOS untouched.
+  if (/^[a-z][A-Z]/.test(s)) return s;
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+// Resolve a marketing version to an existing tag ref. The pipeline tags new
+// releases deploy/<version>; the pre-existing scheme used alpha-v<version>. Try
+// both. Returns the ref string, or null if neither tag exists.
+export function resolveVersionRef(version) {
+  if (!version) return null;
+  for (const ref of [`deploy/${version}`, `alpha-v${version}`]) {
+    try {
+      execSync(`git rev-parse --verify --quiet "${ref}^{commit}"`, { stdio: 'pipe' });
+      return ref;
+    } catch {
+      // try next candidate
+    }
+  }
+  return null;
+}
+
+// Generate "What to Test" notes from feat/fix commits in (lowerRef, upperRef].
+// lowerRef null → from the start of history. Returns the notes string, or null
+// when the range contains no tester-facing feat/fix commits.
+export function generateNotes(lowerRef, upperRef = 'HEAD') {
+  const range = lowerRef ? `${lowerRef}..${upperRef}` : upperRef;
+  const raw = execSync(`git log --no-merges --format=%s ${range}`, { encoding: 'utf8' });
+  const subjects = raw.split('\n').map((s) => s.trim()).filter(Boolean);
+
+  const features = [];
+  const fixes = [];
+  for (const s of subjects) {
+    const m = s.match(/^(feat|fix)(?:\(([^)]*)\))?!?:\s*(.+)$/i);
+    if (!m) continue;
+    const type = m[1].toLowerCase();
+    const scope = (m[2] || '').toLowerCase();
+    // Strip trailing PR refs like " (#486)" or " (#486) (#500)".
+    const text = m[3].replace(/\s*\(#\d+\)/g, '').trim();
+    if (!text) continue;
+    // Drop non-tester-facing noise: excluded scopes (e.g. ci) and test churn.
+    if (excludeScopes.has(scope)) continue;
+    if (excludePattern.test(text)) continue;
+    (type === 'feat' ? features : fixes).push(capitalize(text));
+  }
+
+  if (features.length === 0 && fixes.length === 0) return null;
+
+  const lines = [];
+  if (features.length) {
+    lines.push('New:');
+    for (const f of features) lines.push(`• ${f}`);
+  }
+  if (fixes.length) {
+    if (lines.length) lines.push('');
+    lines.push('Fixed:');
+    for (const f of fixes) lines.push(`• ${f}`);
+  }
+  let notes = lines.join('\n');
+  if (notes.length > CHAR_LIMIT) notes = `${notes.slice(0, CHAR_LIMIT - 1)}…`;
+  return notes;
+}

--- a/.github/scripts/promote-preflight.mjs
+++ b/.github/scripts/promote-preflight.mjs
@@ -8,10 +8,7 @@
 //   1. In the Beta group, not yet in the Pre-flight group
 //   2. Build number > newest already in the Pre-flight group (downgrade guard)
 //   3. Build age ≥ SOAK_HOURS
-//   4. Build number not in BLOCKED_BUILDS (from block-promotion/build-N git tags).
-//      These tags can be created manually, or automatically by the nightly UI
-//      suite (swift-nightly.yml) when it fails on the code that produced the build;
-//      a subsequent green nightly on the same commit removes the tag.
+//   4. Build number not in BLOCKED_BUILDS (from block-promotion/build-N git tags)
 //   5. Sentry session count for the build's release ≥ MIN_SESSIONS
 //   6. Sentry crash-free session rate ≥ MIN_CRASH_FREE_RATE
 //   7. Sentry unresolved error/fatal issues for the release ≤ MAX_UNRESOLVED_ISSUES
@@ -28,6 +25,7 @@
 //   DRY_RUN ('true' evaluates without promoting)
 //   ASC_* (via asc-client)
 
+import { writeFileSync } from 'node:fs';
 import {
   required,
   getAppId,
@@ -35,7 +33,34 @@ import {
   listBuildsInGroup,
   attachBuildToGroup,
   submitForBetaReview,
+  setBetaBuildNotes,
 } from './asc-client.mjs';
+import { resolveVersionRef, generateNotes } from './changelog.mjs';
+
+// Roll up "What to Test" across every build accumulated since the last build in
+// Pre-flight. The promoted build's upload-time notes only cover its own one-build
+// delta; testers promoting weekly want the whole span. Range is bounded by deploy
+// tags (deploy/<version>) so it works from the promotion job's checkout, which is
+// not necessarily at the promoted build's commit. Returns notes, or null when the
+// span can't be resolved or has no tester-facing commits (caller keeps existing).
+function rollupNotes(prevPreflightVersion, promotedVersion) {
+  if (!prevPreflightVersion) {
+    console.log('No prior Pre-flight build; keeping the build\'s upload-time notes.');
+    return null;
+  }
+  const lowerRef = resolveVersionRef(prevPreflightVersion);
+  const upperRef = resolveVersionRef(promotedVersion);
+  if (!lowerRef) {
+    console.log(`No deploy tag for previous Pre-flight version ${prevPreflightVersion}; keeping upload-time notes.`);
+    return null;
+  }
+  if (!upperRef) {
+    console.log(`No deploy tag for promoted version ${promotedVersion}; keeping upload-time notes.`);
+    return null;
+  }
+  console.log(`Rollup "What to Test" range: ${lowerRef}..${upperRef}`);
+  return generateNotes(lowerRef, upperRef);
+}
 
 let _sentryProjectId;
 async function sentryProjectId(org, projectSlug, token) {
@@ -105,6 +130,19 @@ function parseBlocked(csv) {
   return new Set((csv || '').split(',').map((s) => s.trim()).filter(Boolean));
 }
 
+// Additive: when SUMMARY_FILE is set, write a machine-readable JSON summary of the
+// evaluation so callers (e.g. the preview-notification workflow) can build a clean
+// message without scraping logs. No-op when unset, so the real promotion is unchanged.
+function writeSummary(obj) {
+  const path = process.env.SUMMARY_FILE;
+  if (!path) return;
+  try {
+    writeFileSync(path, JSON.stringify(obj, null, 2));
+  } catch (err) {
+    console.warn(`::warning::Failed to write SUMMARY_FILE: ${err.message}`);
+  }
+}
+
 async function main() {
   const bundleId = required('APP_BUNDLE_ID');
   const sourceName = required('SOURCE_GROUP_NAME');
@@ -124,10 +162,11 @@ async function main() {
   const sourceBuilds = await listBuildsInGroup(appId, sourceName);
   const targetBuilds = await listBuildsInGroup(appId, targetName);
   const targetBuildIds = new Set(targetBuilds.map((b) => b.id));
-  const maxTargetBuildNumber = targetBuilds.reduce(
-    (max, b) => Math.max(max, Number(b.buildNumber) || 0),
-    0,
+  const latestTarget = targetBuilds.reduce(
+    (best, b) => (!best || (Number(b.buildNumber) || 0) > (Number(best.buildNumber) || 0) ? b : best),
+    null,
   );
+  const maxTargetBuildNumber = latestTarget ? Number(latestTarget.buildNumber) || 0 : 0;
 
   sourceBuilds.sort((a, b) => new Date(b.uploadedAt) - new Date(a.uploadedAt));
 
@@ -162,6 +201,13 @@ async function main() {
   }
 
   console.log('## Evaluation');
+  const evaluation = results.map((r) => ({
+    build: r.build.buildNumber,
+    version: r.build.version,
+    ageHours: Number(r.ageHours.toFixed(1)),
+    eligible: r.reasons.length === 0,
+    reasons: r.reasons,
+  }));
   for (const r of results) {
     const tag = r.reasons.length === 0 ? 'ELIGIBLE' : 'skip';
     console.log(`- [${tag}] build ${r.build.buildNumber} (${r.build.version}), age ${r.ageHours.toFixed(1)}h${r.reasons.length ? ' — ' + r.reasons.join('; ') : ''}`);
@@ -170,15 +216,49 @@ async function main() {
   const eligible = results.find((r) => r.reasons.length === 0);
   if (!eligible) {
     console.log('No eligible build to promote.');
+    writeSummary({
+      eligible: false,
+      soakHours,
+      targetGroup: targetName,
+      currentTargetBuild: maxTargetBuildNumber || null,
+      evaluation,
+    });
     return;
   }
 
+  const notes = rollupNotes(latestTarget?.version, eligible.build.version);
+
+  writeSummary({
+    eligible: true,
+    soakHours,
+    targetGroup: targetName,
+    currentTargetBuild: maxTargetBuildNumber || null,
+    build: eligible.build.buildNumber,
+    version: eligible.build.version,
+    notes: notes || null,
+    evaluation,
+  });
+
   if (dryRun) {
     console.log(`DRY RUN: would promote build ${eligible.build.buildNumber} to ${targetName}`);
+    if (notes) console.log(`DRY RUN: would set rollup "What to Test":\n${notes}`);
+    else console.log('DRY RUN: no rollup notes; build would keep its upload-time "What to Test".');
     return;
   }
 
   await attachBuildToGroup(eligible.build.id, targetGroupId);
+  // Cosmetic and best-effort: a notes failure must not strand a promoted build
+  // un-submitted, so swallow it and proceed to Beta App Review.
+  if (notes) {
+    try {
+      await setBetaBuildNotes(eligible.build.id, notes);
+      console.log(`Set rollup "What to Test" on build ${eligible.build.buildNumber}.`);
+    } catch (err) {
+      console.warn(`::warning::Failed to set rollup "What to Test": ${err.message}`);
+    }
+  } else {
+    console.log('No rollup notes; keeping the build\'s upload-time "What to Test".');
+  }
   await submitForBetaReview(eligible.build.id);
   console.log(`Promoted build ${eligible.build.buildNumber} to ${targetName} and submitted for Beta App Review`);
 }

--- a/.github/scripts/pushover-preflight-preview.mjs
+++ b/.github/scripts/pushover-preflight-preview.mjs
@@ -1,0 +1,99 @@
+// Sends a Pushover notification previewing the next Beta → Pre-flight promotion.
+//
+// Reads the JSON written by promote-preflight.mjs (via SUMMARY_FILE) and posts a
+// concise message: which build is likely to promote, the rolled-up "What to Test"
+// changes, and any build whose only blocker is soak that will clear it before the
+// real promotion (LEAD_HOURS later). Best-effort — a Pushover failure exits non-zero
+// so the workflow surfaces it, but nothing here touches the promotion itself.
+//
+// Env:
+//   SUMMARY_FILE   — path to the evaluation JSON (required)
+//   PUSHOVER_TOKEN — Pushover application/API token (required)
+//   PUSHOVER_USER  — Pushover user/group key (required)
+//   LEAD_HOURS     — hours between this preview and the actual promote (default 9)
+//   PROMOTE_WHEN   — human label for the promote time (default 'Tue 12:00 UTC')
+
+import { readFileSync } from 'node:fs';
+
+const MESSAGE_LIMIT = 1024; // Pushover message hard cap
+
+function required(name) {
+  const v = process.env[name];
+  if (!v) throw new Error(`Missing required env: ${name}`);
+  return v;
+}
+
+function clamp(s) {
+  return s.length > MESSAGE_LIMIT ? `${s.slice(0, MESSAGE_LIMIT - 1)}…` : s;
+}
+
+function buildMessage(summary, leadHours, promoteWhen) {
+  const lines = [];
+  const target = summary.targetGroup || 'Pre-flight';
+  const current = summary.currentTargetBuild ? ` (current ${target}: ${summary.currentTargetBuild})` : '';
+
+  if (summary.eligible) {
+    lines.push(`<b>Build ${summary.build} (v${summary.version})</b> likely promotes to ${target} ${promoteWhen}${current}.`);
+    lines.push('');
+    if (summary.notes) {
+      lines.push('<b>What to Test</b>');
+      lines.push(summary.notes);
+    } else {
+      lines.push('No rolled-up "What to Test"; build keeps its upload-time notes.');
+    }
+  } else {
+    lines.push(`<b>No build currently eligible</b> for ${target}${current}. Nothing would promote ${promoteWhen}.`);
+  }
+
+  // Heads-up: builds blocked ONLY by soak that will pass the soak gate by promote
+  // time. Their reason reads "soak X.Xh < Yh"; project age forward by leadHours.
+  const soak = Number(summary.soakHours) || 0;
+  const nearMiss = (summary.evaluation || [])
+    .filter((e) => !e.eligible
+      && e.reasons.length === 1
+      && /^soak /.test(e.reasons[0])
+      && e.ageHours + leadHours >= soak)
+    .map((e) => `• build ${e.build} (v${e.version}): ${e.ageHours.toFixed(1)}h now → ~${(e.ageHours + leadHours).toFixed(1)}h at promote (soak ${soak}h)`);
+
+  if (nearMiss.length) {
+    lines.push('');
+    lines.push('<b>May also qualify by promote time</b> (soak clears):');
+    lines.push(...nearMiss);
+  }
+
+  return clamp(lines.join('\n'));
+}
+
+async function main() {
+  const summary = JSON.parse(readFileSync(required('SUMMARY_FILE'), 'utf8'));
+  const token = required('PUSHOVER_TOKEN');
+  const user = required('PUSHOVER_USER');
+  const leadHours = Number(process.env.LEAD_HOURS || '9');
+  const promoteWhen = process.env.PROMOTE_WHEN || 'Tue 12:00 UTC';
+
+  const title = summary.eligible
+    ? `Pre-flight preview: build ${summary.build} → promote ${promoteWhen}`
+    : `Pre-flight preview: none eligible for ${promoteWhen}`;
+
+  const params = new URLSearchParams({
+    token,
+    user,
+    title,
+    message: buildMessage(summary, leadHours, promoteWhen),
+    html: '1',
+  });
+
+  const res = await fetch('https://api.pushover.net/1/messages.json', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: params,
+  });
+  const body = await res.text();
+  if (!res.ok) throw new Error(`Pushover → ${res.status}: ${body}`);
+  console.log(`Pushover notification sent: ${title}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/.github/scripts/set-beta-notes.mjs
+++ b/.github/scripts/set-beta-notes.mjs
@@ -1,0 +1,74 @@
+// Generates TestFlight "What to Test" notes from the commits since the previous
+// release and writes them to the just-uploaded build's betaBuildLocalizations.
+//
+// Note formatting (conventional-commit parsing, scope/pattern filtering, char
+// limit) lives in changelog.mjs and is shared with the Pre-flight promotion
+// rollup so both surfaces read identically.
+//
+// Non-fatal by design: "What to Test" is cosmetic, so any failure (ASC hiccup,
+// build slow to process) logs a warning and exits 0 — it never blocks a deploy.
+//
+// Env:
+//   APP_BUNDLE_ID     — bundle id of the app (e.g. com.eff3.liftmark.native-ios)
+//   APP_VERSION       — marketing version of the build just uploaded (e.g. 1.1.200)
+//   APP_BUILD         — build number (CFBundleVersion) of that build
+//   PREVIOUS_VERSION  — marketing version of the previous release; lower bound for
+//                       the changelog range. Empty on the very first release.
+//   MAX_WAIT_SECONDS  — optional; how long to poll for the build to appear (default 1200)
+//   EXCLUDE_SCOPES    — optional; see changelog.mjs
+//   EXCLUDE_PATTERN   — optional; see changelog.mjs
+//   ASC_*             — via asc-client
+
+import { required, getAppId, getBuild, setBetaBuildNotes } from './asc-client.mjs';
+import { resolveVersionRef, generateNotes } from './changelog.mjs';
+
+function sleep(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function pollForBuild(appId, version, buildNumber, maxWaitSeconds) {
+  const deadline = Date.now() + maxWaitSeconds * 1000;
+  let attempt = 0;
+  for (;;) {
+    const build = await getBuild(appId, { version, buildNumber });
+    if (build) return build;
+    if (Date.now() >= deadline) return null;
+    attempt += 1;
+    console.log(`Build ${version} (${buildNumber}) not yet visible in App Store Connect; retry ${attempt} in 30s…`);
+    await sleep(30_000);
+  }
+}
+
+async function main() {
+  const bundleId = required('APP_BUNDLE_ID');
+  const version = required('APP_VERSION');
+  const buildNumber = required('APP_BUILD');
+  const previous = process.env.PREVIOUS_VERSION || '';
+  const maxWait = Number(process.env.MAX_WAIT_SECONDS || '1200');
+
+  const lowerRef = resolveVersionRef(previous);
+  console.log(`Changelog range: ${lowerRef ? `${lowerRef}..HEAD` : 'entire history (no previous release tag found)'}`);
+
+  const notes = generateNotes(lowerRef);
+  if (!notes) {
+    console.log('No feat/fix commits in range; leaving "What to Test" unset.');
+    return;
+  }
+  console.log(`Generated "What to Test":\n${notes}`);
+
+  const appId = await getAppId(bundleId);
+  const build = await pollForBuild(appId, version, buildNumber, maxWait);
+  if (!build) {
+    console.warn(`::warning::Build ${version} (${buildNumber}) never appeared in App Store Connect within ${maxWait}s; skipping notes.`);
+    return;
+  }
+
+  await setBetaBuildNotes(build.id, notes);
+  console.log(`Set "What to Test" on build ${version} (${buildNumber}).`);
+}
+
+main().catch((err) => {
+  // Non-fatal: never fail a deploy over cosmetic release notes.
+  console.warn(`::warning::Failed to set "What to Test" notes: ${err.message}`);
+  process.exit(0);
+});

--- a/.github/workflows/promote-preflight-preview.yml
+++ b/.github/workflows/promote-preflight-preview.yml
@@ -1,31 +1,33 @@
-name: '[iOS] Promote Beta → Pre-flight'
+name: '[iOS] Pre-flight promote preview (notify)'
+
+# Runs the Beta → Pre-flight eligibility gate in DRY-RUN ~9h before the real
+# promotion (promote-preflight.yml, Tue 12:00 UTC) and sends a Pushover preview of
+# which build is likely to promote and what changed — so there is time to push a
+# block-promotion/build-<N> tag before it ships.
+#
+# Scheduled Tue 03:00 UTC = Mon 8:00 PM PDT (7:00 PM PST). Keep the gate inputs
+# (SOAK_HOURS / MIN_* / MAX_*) identical to promote-preflight.yml so the preview
+# reflects the real decision; if you change them there, change them here too.
 
 on:
   schedule:
-    - cron: '0 12 * * 2'
+    - cron: '0 3 * * 2'
   workflow_dispatch:
-    inputs:
-      dry_run:
-        description: 'Evaluate eligibility but do not promote'
-        required: false
-        default: 'false'
-        type: choice
-        options: ['true', 'false']
 
 concurrency:
-  group: promote-preflight
+  group: promote-preflight-preview
   cancel-in-progress: false
 
 permissions:
   contents: read
 
 jobs:
-  evaluate-and-promote:
-    name: Evaluate Beta builds and promote latest eligible to Pre-flight
+  preview:
+    name: Preview the next Pre-flight promotion and notify via Pushover
     runs-on: ubuntu-latest
     steps:
       # Full history + tags: the rollup "What to Test" walks git log between the
-      # deploy/<version> tags of the last Pre-flight build and the promoted build.
+      # deploy/<version> tags, same as the real promotion job.
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
@@ -52,7 +54,7 @@ jobs:
           echo "blocked=${BLOCKED}" >> "$GITHUB_OUTPUT"
           echo "Blocked builds: ${BLOCKED:-(none)}"
 
-      - name: Evaluate and promote
+      - name: Evaluate eligibility (dry run) and write summary
         env:
           ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
           ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
@@ -68,8 +70,18 @@ jobs:
           MIN_CRASH_FREE_RATE: '0.99'
           MAX_UNRESOLVED_ISSUES: '0'
           BLOCKED_BUILDS: ${{ steps.blocks.outputs.blocked }}
-          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+          DRY_RUN: 'true'
+          SUMMARY_FILE: ${{ runner.temp }}/preflight-preview.json
         run: node .github/scripts/promote-preflight.mjs
+
+      - name: Send Pushover preview
+        env:
+          SUMMARY_FILE: ${{ runner.temp }}/preflight-preview.json
+          PUSHOVER_TOKEN: ${{ secrets.PUSHOVER_TOKEN }}
+          PUSHOVER_USER: ${{ secrets.PUSHOVER_USER }}
+          LEAD_HOURS: '9'
+          PROMOTE_WHEN: 'Tue 12:00 UTC'
+        run: node .github/scripts/pushover-preflight-preview.mjs
 
       - name: Cleanup
         if: always()

--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -113,7 +113,11 @@ jobs:
       build_number: ${{ steps.version.outputs.build_number }}
       marketing_version: ${{ steps.version.outputs.marketing_version }}
     steps:
+      # fetch-depth: 0 so the "What to Test" changelog step can read the full
+      # commit range between the previous release tag and HEAD.
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - name: Select Xcode 26
         run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
@@ -222,6 +226,7 @@ jobs:
           echo "Previous deploy: $LATEST → next: $MARKETING (build $BUILD)"
           echo "marketing_version=$MARKETING" >> "$GITHUB_OUTPUT"
           echo "build_number=$BUILD" >> "$GITHUB_OUTPUT"
+          echo "previous_version=$LATEST" >> "$GITHUB_OUTPUT"
           echo "APP_VERSION=$MARKETING" >> $GITHUB_ENV
           echo "APP_BUILD=$BUILD" >> $GITHUB_ENV
 
@@ -274,6 +279,30 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag "deploy/${MARKETING_VERSION}" "${{ github.sha }}"
           git push origin "deploy/${MARKETING_VERSION}"
+
+      - name: Setup Node
+        if: success()
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      # Generate a TestFlight "What to Test" from the feat/fix commits since the
+      # previous release and attach it to the build we just uploaded. Runs after
+      # the tag push (so the deploy is already recorded) but before Cleanup wipes
+      # the ASC key. Non-fatal: the script swallows its own errors.
+      - name: Set TestFlight "What to Test" notes
+        if: success()
+        working-directory: ${{ github.workspace }}
+        env:
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_KEY_PATH: ~/.private_keys/AuthKey_${{ secrets.ASC_KEY_ID }}.p8
+          APP_BUNDLE_ID: com.eff3.liftmark.native-ios
+          APP_VERSION: ${{ steps.version.outputs.marketing_version }}
+          APP_BUILD: ${{ steps.version.outputs.build_number }}
+          PREVIOUS_VERSION: ${{ steps.version.outputs.previous_version }}
+          MAX_WAIT_SECONDS: '1200'
+        run: node .github/scripts/set-beta-notes.mjs
 
       - name: Cleanup
         if: always()


### PR DESCRIPTION
Brings the lift.md release pipeline to parity with the build-notes and pre-flight notification mechanisms recently added to migralog.

## What lift.md was missing
- No TestFlight **"What to Test"** notes were ever written — builds reached Pre-flight with blank testing notes.
- No **advance notification** of what build would be promoted.

## What this adds
1. **Upload-time "What to Test"** (`set-beta-notes.mjs` + `changelog.mjs`): every push to main sets the Beta build's notes from `feat:`/`fix:` commits since the last release. Deterministic, no LLM; ci-scope and test-churn commits are filtered out. Non-fatal — never blocks a deploy.
2. **Rollup notes at promotion** (`promote-preflight.mjs`): when a build promotes Beta→Pre-flight, its notes are rolled up across every build accumulated since the last Pre-flight build (testers promote weekly and want the whole span).
3. **Advance Pushover preview** (`promote-preflight-preview.yml` + `pushover-preflight-preview.mjs`): Tue 03:00 UTC (~9h before the real Tue 12:00 UTC promotion) the eligibility gate runs in **dry-run** and Pushover-notifies which build will promote, its rolled-up "What to Test", and any build whose only blocker is soak that will clear by promote time — leaving time to push a `block-promotion/build-<N>` tag to stop it.
4. Supporting: `asc-client.setBetaBuildNotes`, `SUMMARY_FILE` JSON emit from the gate, full-history/tags fetch, `previous_version` output.

## Config
- Repo secrets `PUSHOVER_TOKEN` and `PUSHOVER_USER` are **set**.
- Gate inputs (SOAK_HOURS / MIN_* / MAX_*) in the preview workflow are kept identical to `promote-preflight.yml` so the preview reflects the real decision.

## Verification
- `node --check` passes on all scripts.
- All three workflow YAMLs parse.
- Ran `changelog.generateNotes` against real recent history: correctly produced a `Fixed:` note from the `fix:` commit and dropped the `test(ios):` / `chore(deps):` commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)