### PR TITLE
feat(ios): show current + next exercise on Apple Watch Smart Stack

### DIFF
--- a/mobile-apps/ios/LiveWorkouts/LiveWorkoutsLiveActivity.swift
+++ b/mobile-apps/ios/LiveWorkouts/LiveWorkoutsLiveActivity.swift
@@ -5,8 +5,8 @@ import SwiftUI
 struct LiveWorkoutsLiveActivity: Widget {
     var body: some WidgetConfiguration {
         ActivityConfiguration(for: WorkoutActivityAttributes.self) { context in
-            // Lock screen / banner UI
-            lockScreenView(context: context)
+            // Lock screen / banner / watch Smart Stack UI
+            LiveWorkoutContentView(context: context)
                 .activityBackgroundTint(.black.opacity(0.8))
                 .activitySystemActionForegroundColor(.white)
 
@@ -39,12 +39,164 @@ struct LiveWorkoutsLiveActivity: Widget {
             }
             .widgetURL(URL(string: "liftmark://workout"))
         }
+        .supplementalActivityFamilies([.small])
     }
 
-    // MARK: - Lock Screen View
+    // MARK: - Dynamic Island Expanded
 
     @ViewBuilder
-    private func lockScreenView(context: ActivityViewContext<WorkoutActivityAttributes>) -> some View {
+    private func expandedLeading(context: ActivityViewContext<WorkoutActivityAttributes>) -> some View {
+        let state = context.state
+
+        if state.isRestTimer {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Rest")
+                    .font(.lmHeadline)
+                if let nextName = state.nextExerciseName {
+                    Text("Next: \(nextName)")
+                        .font(.lmCaption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+        } else {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(state.exerciseName)
+                    .font(.lmHeadline)
+                    .lineLimit(1)
+                if !state.weightReps.isEmpty {
+                    Text(state.setInfo.isEmpty ? state.weightReps : "\(state.setInfo) \u{2022} \(state.weightReps)")
+                        .font(.lmCaption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func expandedTrailing(context: ActivityViewContext<WorkoutActivityAttributes>) -> some View {
+        let state = context.state
+
+        if let timerEnd = state.timerEndDate {
+            Text(timerEnd, style: .timer)
+                .font(.lmTitle3.monospacedDigit().bold())
+                .foregroundStyle(timerEnd > Date() ? .green : .red)
+        } else {
+            Text("\(Int(state.progress * 100))%")
+                .font(.lmTitle3.bold())
+        }
+    }
+
+    @ViewBuilder
+    private func expandedBottom(context: ActivityViewContext<WorkoutActivityAttributes>) -> some View {
+        let state = context.state
+
+        if state.isRestTimer, let detail = state.nextSetDetail {
+            Text(detail)
+                .font(.lmCaption2.monospacedDigit())
+                .foregroundStyle(.secondary)
+        } else if !state.isRestTimer, let nextName = state.nextExerciseName {
+            Text("Next: \(nextName)")
+                .font(.lmCaption2)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+        }
+    }
+}
+
+// MARK: - Lock Screen / Smart Stack Content
+
+struct LiveWorkoutContentView: View {
+    @Environment(\.activityFamily) private var activityFamily
+
+    let context: ActivityViewContext<WorkoutActivityAttributes>
+
+    var body: some View {
+        switch activityFamily {
+        case .small:
+            smartStackView
+        case .medium:
+            lockScreenView
+        @unknown default:
+            lockScreenView
+        }
+    }
+
+    // MARK: Apple Watch Smart Stack (small family)
+
+    // System fonts only: the watch renders this view on-device and the custom
+    // fonts bundled in the widget extension are not available there.
+    @ViewBuilder
+    private var smartStackView: some View {
+        let state = context.state
+
+        if state.isRestTimer {
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(alignment: .firstTextBaseline) {
+                    Text("Rest")
+                        .font(.headline)
+                    Spacer()
+                    if let timerEnd = state.timerEndDate {
+                        Text(timerEnd, style: .timer)
+                            .font(.headline.monospacedDigit())
+                            .foregroundStyle(timerEnd > Date() ? .green : .red)
+                            .multilineTextAlignment(.trailing)
+                    }
+                }
+
+                if let nextName = state.nextExerciseName {
+                    Text("Next: \(nextName)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                    if let detail = state.nextSetDetail {
+                        Text(detail)
+                            .font(.caption.monospacedDigit())
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                }
+            }
+        } else {
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(alignment: .firstTextBaseline) {
+                    Text(state.exerciseName)
+                        .font(.headline)
+                        .lineLimit(1)
+                    Spacer()
+                    if !state.setInfo.isEmpty {
+                        Text(state.setInfo)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                if !state.weightReps.isEmpty {
+                    Text(state.weightReps)
+                        .font(.title3.monospacedDigit().bold())
+                }
+
+                HStack(alignment: .firstTextBaseline) {
+                    if let nextName = state.nextExerciseName {
+                        Text("Next: \(nextName)")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                    Spacer()
+                    Text("\(Int(state.progress * 100))%")
+                        .font(.caption.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+    }
+
+    // MARK: Lock screen / banner (medium family)
+
+    @ViewBuilder
+    private var lockScreenView: some View {
         let state = context.state
 
         if state.isRestTimer {
@@ -117,68 +269,6 @@ struct LiveWorkoutsLiveActivity: Widget {
                     .tint(.blue)
             }
             .padding()
-        }
-    }
-
-    // MARK: - Dynamic Island Expanded
-
-    @ViewBuilder
-    private func expandedLeading(context: ActivityViewContext<WorkoutActivityAttributes>) -> some View {
-        let state = context.state
-
-        if state.isRestTimer {
-            VStack(alignment: .leading, spacing: 2) {
-                Text("Rest")
-                    .font(.lmHeadline)
-                if let nextName = state.nextExerciseName {
-                    Text("Next: \(nextName)")
-                        .font(.lmCaption2)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                }
-            }
-        } else {
-            VStack(alignment: .leading, spacing: 2) {
-                Text(state.exerciseName)
-                    .font(.lmHeadline)
-                    .lineLimit(1)
-                if !state.weightReps.isEmpty {
-                    Text(state.setInfo.isEmpty ? state.weightReps : "\(state.setInfo) \u{2022} \(state.weightReps)")
-                        .font(.lmCaption2)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                }
-            }
-        }
-    }
-
-    @ViewBuilder
-    private func expandedTrailing(context: ActivityViewContext<WorkoutActivityAttributes>) -> some View {
-        let state = context.state
-
-        if let timerEnd = state.timerEndDate {
-            Text(timerEnd, style: .timer)
-                .font(.lmTitle3.monospacedDigit().bold())
-                .foregroundStyle(timerEnd > Date() ? .green : .red)
-        } else {
-            Text("\(Int(state.progress * 100))%")
-                .font(.lmTitle3.bold())
-        }
-    }
-
-    @ViewBuilder
-    private func expandedBottom(context: ActivityViewContext<WorkoutActivityAttributes>) -> some View {
-        let state = context.state
-
-        if state.isRestTimer, let detail = state.nextSetDetail {
-            Text(detail)
-                .font(.lmCaption2.monospacedDigit())
-                .foregroundStyle(.secondary)
-        } else if !state.isRestTimer, let nextName = state.nextExerciseName {
-            Text("Next: \(nextName)")
-                .font(.lmCaption2)
-                .foregroundStyle(.secondary)
-                .lineLimit(1)
         }
     }
 }

--- a/spec/services/live-activities.md
+++ b/spec/services/live-activities.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Display workout progress on the iOS Lock Screen and Dynamic Island via Live Activities. This gives users at-a-glance workout status without unlocking their device or navigating back to the app.
+Display workout progress on the iOS Lock Screen, Dynamic Island, and Apple Watch Smart Stack via Live Activities. This gives users at-a-glance workout status without unlocking their device or navigating back to the app.
 
 ## Public API
 
@@ -123,6 +123,25 @@ The rest timer uses `timerEndDate` with SwiftUI's `Text(date, style: .timer)`. C
 
 Note: The system `.timer` style automatically counts down to the target date, then counts up past it.
 
+#### Apple Watch Smart Stack (Small Activity Family)
+
+The widget must opt into Apple Watch rendering via `.supplementalActivityFamilies([.small])` on the `ActivityConfiguration`. Without this opt-in, watchOS shows only a default card built from the Dynamic Island compact views (dumbbell icon + percentage), which conveys no workout information.
+
+The content view reads the `\.activityFamily` environment value and renders a dedicated compact layout for `.small` (Apple Watch Smart Stack); `.medium` and unknown families render the standard lock-screen layout.
+
+The small-family layout must show "what's up next" so the watch card is useful mid-workout without pulling out the phone:
+
+- **Active set state**:
+  - Top row: Exercise name (left), "Set X/Y" (right)
+  - Middle row: Weight × reps (e.g., "185 lbs × 5")
+  - Bottom row: "Next: [exercise name]" (left, omitted when nil), percentage complete (right)
+- **Rest timer state**:
+  - Top row: "Rest" label (left), countdown timer (right, green when time remains / red when expired — same color logic as other surfaces)
+  - Middle row: "Next: [exercise name]" (omitted when nil)
+  - Bottom row: Next set detail (weight × reps, omitted when nil)
+- No progress bar in either state — vertical space is limited; the percentage in the active-set layout is sufficient.
+- The small-family layout uses system fonts, not the app's custom fonts: the watch renders the view on-device and the custom fonts bundled in the widget extension are not available there.
+
 ### Update Throttling
 
 `updateWorkoutLiveActivity()` throttles ordinary content refreshes to at most one per second to avoid excessive Live Activity churn during rapid set logging. However, two transitions are considered significant and must bypass the throttle so they are never dropped:
@@ -163,6 +182,7 @@ The service is called from the session store during these actions:
 - WidgetKit framework (widget extension).
 - The `LiveWorkouts` widget extension must be configured in `project.yml` and embedded in the main app.
 - The widget extension must use the same `WorkoutActivityAttributes` type as the main app (shared source file included in both targets).
+- Apple Watch Smart Stack rendering requires iOS 18 / watchOS 11 or later (`supplementalActivityFamilies`); the paired iPhone drives the activity — no watchOS target is required.
 
 ## Dependencies
 
@@ -205,6 +225,12 @@ All operations silently catch and discard errors. Live Activities are an optiona
 - Rest timer state must include: "Rest" as exercise name, timer end date, next exercise name with its set details, and progress.
 - When there is no next exercise (last exercise in workout), `nextExerciseName` and `nextSetDetail` must be nil.
 - Widget UI must show green timer color when time remains and red when timer has expired.
+
+### Apple Watch Smart Stack
+- The `ActivityConfiguration` must declare `.supplementalActivityFamilies([.small])` so watchOS renders the app-provided layout instead of the default icon + percentage card.
+- The small-family active-set layout must include the current exercise name, set info, weight × reps, next exercise name (when present), and progress percentage.
+- The small-family rest layout must include the countdown timer and the next exercise name with its set detail (when present).
+- The small-family views must use only system fonts (custom widget fonts are unavailable on the watch).
 
 ### Cursor Advance on Skip
 - Skipping the last pending set of an exercise resolves the current exercise to the next exercise with pending sets; the resolved active-set state must name that next exercise, not the skipped one.


### PR DESCRIPTION
## Problem

The Live Activity's Apple Watch Smart Stack card was useless mid-workout — just the app name, a dumbbell icon, and a progress percent:

The widget never opted into `supplementalActivityFamilies`, so watchOS fell back to a default card synthesized from the Dynamic Island compact views (icon + `9%`).

## Fix

- Opt into `.supplementalActivityFamilies([.small])` on the `ActivityConfiguration`.
- Refactor the lock-screen content closure into `LiveWorkoutContentView`, which reads `\.activityFamily` and branches: `.small` renders a new watch-sized layout, `.medium`/unknown keeps the existing lock-screen layout (unchanged).
- Watch layout, active set: exercise name + "Set X/Y", weight × reps, "Next: …" + percent. Rest mode: "Rest" + green/red countdown, next exercise, next set detail. No progress bar (vertical space).
- Watch layout uses system fonts — the extension's bundled custom fonts aren't available when watchOS renders the view.

No service/data changes: `nextExerciseName` / `nextSetDetail` were already computed and shipped in every ContentState update; this is view-layer only.

## Spec

`spec/services/live-activities.md` updated first per ground rules: new *Apple Watch Smart Stack (Small Activity Family)* display-state section, test requirements, and platform notes (iOS 18 / watchOS 11+, no watchOS target needed).

## Verification

- `xcodebuild build` (LiftMark scheme, iPhone 17 Pro sim, iOS 26.5): **BUILD SUCCEEDED**, 0 errors.
- `LiveActivityServiceTests`: 29/29 passed (state-derivation logic the watch view consumes is untouched).
- Widget views have no snapshot-test infra; the watch card needs a quick on-wrist check after the next TestFlight build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)