### PR TITLE
test(e2e): fix robustReplaceText clearing SecureTextFields — verify by length

### DIFF
--- a/e2e-spec/runners/xcuitest/ActionAdapter.swift
+++ b/e2e-spec/runners/xcuitest/ActionAdapter.swift
@@ -494,25 +494,39 @@ class ActionAdapter {
     /// which fails LMWF header validation, disables the Import button, and
     /// strands the import (observed in nightly testHistoryExport/testPlanExport
     /// as "Timed out waiting for text 'OK'"). We wait for the keyboard to
-    /// settle, then verify the field holds exactly the intended text and retry
-    /// once on mismatch.
+    /// settle, then verify the field holds the intended text and retry once on
+    /// mismatch. On a final mismatch the best-effort text is left in place —
+    /// never a cleared field.
     func robustReplaceText(_ el: XCUIElement, with text: String) {
         el.tap()
         // Let the keyboard come up so the first keystroke keeps its modifier.
         _ = app.keyboards.firstMatch.waitForExistence(timeout: UITestTiming.scaled(5))
 
-        for attempt in 0..<2 {
+        for attempt in 1...2 {
             el.typeKey("a", modifierFlags: .command)
             el.typeText(text)
-            if (el.value as? String) == text { return }
+            if fieldHoldsIntendedText(el, text) { return }
 
             // Mismatch — typically a dropped ⌘ left a stray leading char.
-            // Clear the field and try once more before giving up.
-            NSLog("[robustReplaceText] field value mismatch on attempt \(attempt + 1); clearing and retrying")
+            NSLog("[robustReplaceText] field value mismatch on attempt \(attempt)")
+            guard attempt < 2 else { break }
+            // Clear and try once more. Only between attempts — clearing after
+            // the last one would guarantee an empty field.
             el.tap()
             el.typeKey("a", modifierFlags: .command)
             el.typeText(XCUIKeyboardKey.delete.rawValue)
         }
+    }
+
+    /// Secure fields (password inputs) read back one bullet per character, so
+    /// plaintext comparison can never succeed there — compare length instead,
+    /// which still catches the dropped-⌘ flake (the stray "a" adds a char).
+    private func fieldHoldsIntendedText(_ el: XCUIElement, _ text: String) -> Bool {
+        guard let value = el.value as? String else { return false }
+        if el.elementType == .secureTextField {
+            return value.count == text.count
+        }
+        return value == text
     }
 
     private func executeTypeText(_ action: TestAction) throws {

--- a/e2e-spec/schema.md
+++ b/e2e-spec/schema.md
@@ -114,6 +114,13 @@ Replace all text in a text input.
 | `target` | yes      | Accessibility ID of the input   |
 | `value`  | yes      | Text to set                     |
 
+Runners must verify the field holds the intended text after typing and retry
+once on mismatch (guards against dropped-keystroke flakes). Secure text fields
+(password inputs) cannot be read back as plaintext — their value renders as one
+bullet per character — so runners verify by character count instead of
+equality. On a final mismatch the typed best-effort text must be left in
+place, never a cleared field.
+
 ### typeText
 
 Type text into an input (simulates keyboard).


### PR DESCRIPTION
## Problem

The weekly `[iOS] E2E (beta)` run has failed 4 consecutive weeks (Jun 29 → Jul 20) on `testBetaLogin` with `Timed out waiting for 'account-identity' to exist` — starting immediately after the dropped-⌘ hardening (e0d7d5e, #315) merged.

Root cause: `robustReplaceText` verifies the field with `(el.value as? String) == text`. A **SecureTextField reads its value back as one bullet per character**, so the comparison can never succeed. After two attempts the helper clears the field and gives up → the beta login submits an empty password → `account-identity` never appears.

## Fix

- Verify secure fields by **character count** instead of plaintext equality — a stray literal `a` from a dropped modifier still shifts the length, so the guard keeps working.
- On a final mismatch, leave the best-effort text in place instead of clearing (the old code guaranteed an empty field on give-up).
- Documented these runner semantics in `e2e-spec/schema.md` (spec-first).

## Verification

- `xcodebuild build-for-testing` (Full test plan, iPhone 17 Pro / iOS 26.5) succeeds.
- `[iOS] E2E (beta)` dispatched on this branch (Beta env temporarily allowlisted) — link in comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)