### PR TITLE
test(e2e): guard import-button tap against dropped-tap flake in active-workout scenario

### DIFF
--- a/e2e-spec/scenarios/active-workout-focused.yaml
+++ b/e2e-spec/scenarios/active-workout-focused.yaml
@@ -17,8 +17,27 @@ setupOnce:
   - action: waitFor
     target: "button-import-workout"
     timeout: 5000
-  - action: tap
-    target: "button-import-workout"
+  # The import-button tap is a dropped-tap flake point (nightly timeout
+  # 2026-08-09): the tap silently fails to register, so the import sheet
+  # never presents and the input-markdown wait times out on nothing. This
+  # test runs first in the suite, so it also absorbs cold-start slowness.
+  # Same mitigation as the plan-name tap below — probe non-asserting,
+  # re-tap on a miss, then assert for real so a genuine import regression
+  # still surfaces.
+  - action: tryCatch
+    try:
+      - action: tap
+        target: "button-import-workout"
+      # Non-asserting probe; if the sheet never presents, fall to the retry.
+      - action: waitFor
+        target: "input-markdown"
+        timeout: 10000
+    catch:
+      # Retry: a dropped tap left us on the home screen. Re-tap the import
+      # button; the asserting waitFor below then confirms the sheet.
+      - action: tap
+        target: "button-import-workout"
+  # Asserting waitFor — if import genuinely regressed, this still fails.
   - action: waitFor
     target: "input-markdown"
     timeout: 10000


### PR DESCRIPTION
## Summary

Nightly UI suite [run 31307072093](https://github.com/vfilby/lift.md/actions/runs/31307072093) (2026-08-09) failed `testActiveWorkout` with *"Timed out waiting for 'input-markdown' to exist"*. The failing run was on the **same SHA** (`9b78624`) that passed the previous four nights, so this is the known dropped-tap flake, not a regression: the tap on `button-import-workout` silently fails to register, the import sheet never presents, and the wait times out. This test also runs first in the suite, so it absorbs cold-start slowness.

## Fix

Apply the same mitigation this scenario already uses for the plan-name tap (added after the 2026-06-26 nightly timeout): wrap the tap in `tryCatch` with a non-asserting `waitFor` probe, re-tap on a miss, then follow with an asserting `waitFor` so a genuine import regression still fails the test.

## Verification

Ran the affected test locally against the updated scenario:

```
Test Case '-[LiftMarkUITests.LiftMarkUITests testActiveWorkout]' passed (72.867 seconds).
** TEST SUCCEEDED **
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)