### PR TITLE
fix(e2e): retry focusing tap in replaceText when keyboard focus is missed

### DIFF
--- a/e2e-spec/runners/xcuitest/ActionAdapter.swift
+++ b/e2e-spec/runners/xcuitest/ActionAdapter.swift
@@ -497,10 +497,27 @@ class ActionAdapter {
     /// settle, then verify the field holds the intended text and retry once on
     /// mismatch. On a final mismatch the best-effort text is left in place —
     /// never a cleared field.
+    ///
+    /// A second hazard sits before the first keystroke: the focusing tap
+    /// itself is occasionally dropped on a loaded CI runner (same family as
+    /// the scenario-level dropped-tap retries), so the field never gains
+    /// keyboard focus and the first synthesized keystroke aborts the test with
+    /// "Neither element nor any descendant has keyboard focus" (nightly
+    /// testActiveWorkout, 2026-08-14). The keyboard wait doubles as the focus
+    /// probe — re-tap on a miss, with `hasKeyboardFocus` covering
+    /// hardware-keyboard setups where the software keyboard never appears.
     func robustReplaceText(_ el: XCUIElement, with text: String) {
-        el.tap()
-        // Let the keyboard come up so the first keystroke keeps its modifier.
-        _ = app.keyboards.firstMatch.waitForExistence(timeout: UITestTiming.scaled(5))
+        for attempt in 1...3 {
+            el.tap()
+            // Let the keyboard come up so the first keystroke keeps its
+            // modifier — and so a dropped tap is caught here instead of as a
+            // failed-to-synthesize-event abort on the first keystroke.
+            if app.keyboards.firstMatch.waitForExistence(timeout: UITestTiming.scaled(5))
+                || hasKeyboardFocus(el) {
+                break
+            }
+            NSLog("[robustReplaceText] no keyboard focus after tap (attempt \(attempt)); re-tapping")
+        }
 
         for attempt in 1...2 {
             el.typeKey("a", modifierFlags: .command)
@@ -516,6 +533,14 @@ class ActionAdapter {
             el.typeKey("a", modifierFlags: .command)
             el.typeText(XCUIKeyboardKey.delete.rawValue)
         }
+    }
+
+    /// Whether the element currently owns keyboard focus. XCUIElement exposes
+    /// this only via the private-but-stable `hasKeyboardFocus` attribute (no
+    /// public API). Used as a fallback focus signal for hardware-keyboard
+    /// setups where the software keyboard never appears on screen.
+    private func hasKeyboardFocus(_ el: XCUIElement) -> Bool {
+        (el.value(forKey: "hasKeyboardFocus") as? Bool) ?? false
     }
 
     /// Secure fields (password inputs) read back one bullet per character, so

--- a/e2e-spec/schema.md
+++ b/e2e-spec/schema.md
@@ -114,8 +114,12 @@ Replace all text in a text input.
 | `target` | yes      | Accessibility ID of the input   |
 | `value`  | yes      | Text to set                     |
 
-Runners must verify the field holds the intended text after typing and retry
-once on mismatch (guards against dropped-keystroke flakes). Secure text fields
+Runners must confirm the input actually gained keyboard focus before
+synthesizing keystrokes, retrying the focusing tap on a miss — on a loaded CI
+host the tap is occasionally dropped, and typing into an unfocused field
+aborts the test (XCUITest: "Neither element nor any descendant has keyboard
+focus"). Runners must also verify the field holds the intended text after
+typing and retry once on mismatch (guards against dropped-keystroke flakes). Secure text fields
 (password inputs) cannot be read back as plaintext — their value renders as one
 bullet per character — so runners verify by character count instead of
 equality. On a final mismatch the typed best-effort text must be left in


### PR DESCRIPTION
## Summary

Last night's Full UI suite failed ([run 31791468649](https://github.com/vfilby/lift.md/actions/runs/31791468649)) in `testActiveWorkout`'s `setupOnce`:

> Failed to synthesize event: Neither element nor any descendant has keyboard focus. Event dispatch snapshot: TextView … identifier: 'input-markdown'

`robustReplaceText` tapped the field and waited for the keyboard, but **discarded the wait result** and typed anyway. When the focusing tap gets dropped on a loaded CI runner (the same dropped-tap flake family already mitigated at the scenario level for Start/Finish/nav taps), the field never gains keyboard focus and the first synthesized keystroke aborts the test.

## Fix

- `robustReplaceText` now re-taps up to 3× until the software keyboard appears **or** the field reports `hasKeyboardFocus` (fallback for hardware-keyboard setups where the software keyboard never shows). No extra wall-clock on the happy path.
- Documented the focus requirement for `replaceText` in `e2e-spec/schema.md` (spec-first).

The `LiftMarkUITests` copies are symlinks to `e2e-spec/runners/xcuitest/`, so the single canonical edit covers the test target.

## Verification

- `testActiveWorkout` run locally against the updated runner: **passed** (73s, 0 failures) — exercises the exact `replaceText` → import path that failed.

Fixes #390

🤖 Generated with [Claude Code](https://claude.com/claude-code)